### PR TITLE
feat(sysadvisor): choose effective headroom and provison policy by co…

### DIFF
--- a/cmd/katalyst-agent/app/options/sysadvisor/qosaware/resource/cpu/cpu_advisor.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/qosaware/resource/cpu/cpu_advisor.go
@@ -50,7 +50,7 @@ func (o *CPUAdvisorOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringToStringVar(&o.CPUProvisionPolicyPriority, "cpu-provision-policy-priority", o.CPUProvisionPolicyPriority,
 		"policies of each region type for cpu advisor to update resource provision, sorted by priority descending order, "+
 			"should be formatted as 'share=rama/canonical,dedicated-numa-exclusive=rama/canonical'")
-	fs.StringToStringVar(&o.CPUHeadroomPolicyPriority, "cpu-provision-effective-policy", o.CPUHeadroomPolicyPriority,
+	fs.StringToStringVar(&o.CPUHeadroomPolicyPriority, "cpu-headroom-policy-priority", o.CPUHeadroomPolicyPriority,
 		"policies of each region type for cpu advisor to estimate resource headroom, sorted by priority descending order, "+
 			"should be formatted as 'share=rama/canonical,dedicated-numa-exclusive=rama/canonical'")
 }

--- a/cmd/katalyst-agent/app/options/sysadvisor/qosaware/resource/memory/memory_advisor.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/qosaware/resource/memory/memory_advisor.go
@@ -25,24 +25,26 @@ import (
 
 // MemoryAdvisorOptions holds the configurations for memory advisor in qos aware plugin
 type MemoryAdvisorOptions struct {
-	MemoryHeadroomPolicy string
+	MemoryHeadroomPolicyPriority []string
 }
 
 // NewMemoryAdvisorOptions creates a new Options with a default config
 func NewMemoryAdvisorOptions() *MemoryAdvisorOptions {
 	return &MemoryAdvisorOptions{
-		MemoryHeadroomPolicy: string(types.MemoryHeadroomPolicyCanonical),
+		MemoryHeadroomPolicyPriority: []string{string(types.MemoryHeadroomPolicyCanonical)},
 	}
 }
 
 // AddFlags adds flags to the specified FlagSet.
 func (o *MemoryAdvisorOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.MemoryHeadroomPolicy, "memory-headroom-policy", o.MemoryHeadroomPolicy,
-		"policy memory advisor to estimate resource headroom")
+	fs.StringSliceVar(&o.MemoryHeadroomPolicyPriority, "memory-headroom-policy-priority", o.MemoryHeadroomPolicyPriority,
+		"policy memory advisor to estimate resource headroom, sorted by priority descending order, should be formatted as 'policy1,policy2'")
 }
 
 // ApplyTo fills up config with options
 func (o *MemoryAdvisorOptions) ApplyTo(c *memory.MemoryAdvisorConfiguration) error {
-	c.MemoryHeadroomPolicy = o.MemoryHeadroomPolicy
+	for _, policy := range o.MemoryHeadroomPolicyPriority {
+		c.MemoryHeadroomPolicies = append(c.MemoryHeadroomPolicies, types.MemoryHeadroomPolicyName(policy))
+	}
 	return nil
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_test.go
@@ -53,6 +53,14 @@ func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string)
 	conf.GenericSysAdvisorConfiguration.StateFileDirectory = stateFileDir
 	conf.MetaServerConfiguration.CheckpointManagerDir = checkpointDir
 	conf.ReclaimedResourceConfiguration.ReservedResourceForAllocate[v1.ResourceCPU] = resource.MustParse("4")
+	conf.ProvisionPolicies = map[types.QoSRegionType][]types.CPUProvisionPolicyName{
+		types.QoSRegionTypeShare:                  {types.CPUProvisionPolicyCanonical},
+		types.QoSRegionTypeDedicatedNumaExclusive: {types.CPUProvisionPolicyCanonical},
+	}
+	conf.HeadroomPolicies = map[types.QoSRegionType][]types.CPUHeadroomPolicyName{
+		types.QoSRegionTypeShare:                  {types.CPUHeadroomPolicyCanonical},
+		types.QoSRegionTypeDedicatedNumaExclusive: {types.CPUHeadroomPolicyCanonical},
+	}
 
 	return conf
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
@@ -84,6 +84,7 @@ func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string)
 	conf.MetaServerConfiguration.CheckpointManagerDir = checkpointDir
 	conf.ReclaimedResourceConfiguration.ReservedResourceForAllocate[v1.ResourceMemory] = resource.MustParse(fmt.Sprintf("%d", 4<<30))
 	conf.EnableReclaim = true
+	conf.MemoryHeadroomPolicies = []types.MemoryHeadroomPolicyName{types.MemoryHeadroomPolicyCanonical}
 
 	return conf
 }
@@ -251,7 +252,8 @@ func TestUpdate(t *testing.T) {
 			}
 
 			advisor.enableReclaim = tt.reclaimedEnable
-			advisor.headroomPolicy.SetEssentials(types.ResourceEssentials{
+			headroomPolicy := advisor.headroomPolices[0]
+			headroomPolicy.SetEssentials(types.ResourceEssentials{
 				Total:               int(advisor.metaServer.MemoryCapacity),
 				ReservedForAllocate: int(advisor.reservedForAllocate),
 				EnableReclaim:       tt.reclaimedEnable,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_base.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_base.go
@@ -26,7 +26,7 @@ type PolicyBase struct {
 	PodSet types.PodSet
 	types.ResourceEssentials
 
-	metaReader metacache.MetaReader
+	MetaReader metacache.MetaReader
 	MetaServer *metaserver.MetaServer
 }
 
@@ -34,7 +34,7 @@ func NewPolicyBase(metaReader metacache.MetaReader, metaServer *metaserver.MetaS
 	cp := &PolicyBase{
 		PodSet: make(types.PodSet),
 
-		metaReader: metaReader,
+		MetaReader: metaReader,
 		MetaServer: metaServer,
 	}
 	return cp

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_canonical.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_canonical.go
@@ -72,7 +72,7 @@ func (p *PolicyCanonical) Update() (err error) {
 		if !p.EnableReclaim {
 			containerEstimation = ci.MemoryRequest
 		} else {
-			containerEstimation, err = helper.EstimateContainerResourceUsage(ci, v1.ResourceMemory, p.metaReader)
+			containerEstimation, err = helper.EstimateContainerResourceUsage(ci, v1.ResourceMemory, p.MetaReader)
 			if err != nil {
 				errList = append(errList, err)
 				return true
@@ -83,7 +83,7 @@ func (p *PolicyCanonical) Update() (err error) {
 		containerCnt += 1
 		return true
 	}
-	p.metaReader.RangeContainer(f)
+	p.MetaReader.RangeContainer(f)
 	klog.Infof("[qosaware-memory-headroom] memory requirement estimation: %.2e, #container %v", memoryEstimation, containerCnt)
 
 	p.memoryHeadroom = math.Max(float64(p.Total-p.ReservedForAllocate)-memoryEstimation, 0)

--- a/pkg/config/agent/sysadvisor/qosaware/resource/cpu/cpu_advisor.go
+++ b/pkg/config/agent/sysadvisor/qosaware/resource/cpu/cpu_advisor.go
@@ -23,15 +23,15 @@ import (
 
 // CPUAdvisorConfiguration stores configurations of cpu advisors in qos aware plugin
 type CPUAdvisorConfiguration struct {
-	ProvisionAdditionalPolicy map[types.QoSRegionType]types.CPUProvisionPolicyName
-	HeadroomAdditionalPolicy  map[types.QoSRegionType]types.CPUHeadroomPolicyName
+	ProvisionPolicies map[types.QoSRegionType][]types.CPUProvisionPolicyName
+	HeadroomPolicies  map[types.QoSRegionType][]types.CPUHeadroomPolicyName
 }
 
 // NewCPUAdvisorConfiguration creates new cpu advisor configurations
 func NewCPUAdvisorConfiguration() *CPUAdvisorConfiguration {
 	return &CPUAdvisorConfiguration{
-		ProvisionAdditionalPolicy: make(map[types.QoSRegionType]types.CPUProvisionPolicyName),
-		HeadroomAdditionalPolicy:  make(map[types.QoSRegionType]types.CPUHeadroomPolicyName),
+		ProvisionPolicies: map[types.QoSRegionType][]types.CPUProvisionPolicyName{},
+		HeadroomPolicies:  map[types.QoSRegionType][]types.CPUHeadroomPolicyName{},
 	}
 }
 

--- a/pkg/config/agent/sysadvisor/qosaware/resource/memory/memory_advisor.go
+++ b/pkg/config/agent/sysadvisor/qosaware/resource/memory/memory_advisor.go
@@ -16,16 +16,21 @@ limitations under the License.
 
 package memory
 
-import "github.com/kubewharf/katalyst-core/pkg/config/dynamic"
+import (
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
+	"github.com/kubewharf/katalyst-core/pkg/config/dynamic"
+)
 
 // MemoryAdvisorConfiguration stores configurations of memory advisors in qos aware plugin
 type MemoryAdvisorConfiguration struct {
-	MemoryHeadroomPolicy string
+	MemoryHeadroomPolicies []types.MemoryHeadroomPolicyName
 }
 
 // NewMemoryAdvisorConfiguration creates new memory advisor configurations
 func NewMemoryAdvisorConfiguration() *MemoryAdvisorConfiguration {
-	return &MemoryAdvisorConfiguration{}
+	return &MemoryAdvisorConfiguration{
+		MemoryHeadroomPolicies: make([]types.MemoryHeadroomPolicyName, 0),
+	}
 }
 
 // ApplyConfiguration is used to set configuration based on conf.


### PR DESCRIPTION
According to the design of resource advisor, the specified policies will be performed during the updating phase of resource advisor. and we only select one effective policy to GetHeadroom and GetProvision by priority order. For now, the policied with priority should be configured by cmdline, and dynamic configuration for policy will be supported in the near future.