### PR TITLE
feat(qrm): introduce network QRM plugin and support packet tagging

### DIFF
--- a/cmd/katalyst-agent/app/agent/qrm/network_plugin.go
+++ b/cmd/katalyst-agent/app/agent/qrm/network_plugin.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qrm
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+)
+
+const (
+	QRMPluginNameNetwork = "qrm_network_plugin"
+)
+
+// networkPolicyInitializers is used to store the initializing function for network resource plugin policies
+var networkPolicyInitializers sync.Map
+
+// RegisterNetworkPolicyInitializer is used to register user-defined resource plugin init functions
+func RegisterNetworkPolicyInitializer(name string, initFunc agent.InitFunc) {
+	networkPolicyInitializers.Store(name, initFunc)
+}
+
+// getNetworkPolicyInitializers returns those policies with initialized functions
+func getNetworkPolicyInitializers() map[string]agent.InitFunc {
+	agents := make(map[string]agent.InitFunc)
+	networkPolicyInitializers.Range(func(key, value interface{}) bool {
+		agents[key.(string)] = value.(agent.InitFunc)
+		return true
+	})
+	return agents
+}
+
+// InitQRMNetworkPlugins initializes the network QRM plugins
+func InitQRMNetworkPlugins(agentCtx *agent.GenericContext, conf *config.Configuration, extraConf interface{}, agentName string) (bool, agent.Component, error) {
+	initializers := getNetworkPolicyInitializers()
+	policyName := conf.NetworkQRMPluginConfig.PolicyName
+
+	initFunc, ok := initializers[policyName]
+	if !ok {
+		return false, agent.ComponentStub{}, fmt.Errorf("invalid policy name %v for network resource plugin", policyName)
+	}
+
+	return initFunc(agentCtx, conf, extraConf, agentName)
+}

--- a/cmd/katalyst-agent/app/enableagents.go
+++ b/cmd/katalyst-agent/app/enableagents.go
@@ -47,6 +47,7 @@ func init() {
 	// qrm plugins are registered at top level of agent
 	agentInitializers.Store(qrm.QRMPluginNameCPU, AgentStarter{Init: qrm.InitQRMCPUPlugins})
 	agentInitializers.Store(qrm.QRMPluginNameMemory, AgentStarter{Init: qrm.InitQRMMemoryPlugins})
+	agentInitializers.Store(qrm.QRMPluginNameNetwork, AgentStarter{Init: qrm.InitQRMNetworkPlugins})
 }
 
 // RegisterAgentInitializer is used to register user-defined agents

--- a/cmd/katalyst-agent/app/options/qrm/network_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/network_plugin.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qrm
+
+import (
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	qrmconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/qrm"
+)
+
+type NetworkOptions struct {
+	PolicyName                    string
+	NetClass                      NetClassOptions
+	PodLevelNetClassAnnoKey       string
+	PodLevelNetAttributesAnnoKeys string
+}
+
+type NetClassOptions struct {
+	// ReclaimedCores is the network class id for reclaimed_cores
+	ReclaimedCores uint32
+	// SharedCores is the network class id for shared_cores
+	SharedCores uint32
+	// DedicatedCores is the network class id for dedicated_cores
+	DedicatedCores uint32
+	// SystemCores is the network class id for system_cores
+	SystemCores uint32
+}
+
+func NewNetworkOptions() *NetworkOptions {
+	return &NetworkOptions{
+		PolicyName:                    "dynamic",
+		PodLevelNetClassAnnoKey:       consts.PodAnnotationNetClassKey,
+		PodLevelNetAttributesAnnoKeys: "",
+	}
+}
+
+func (o *NetworkOptions) AddFlags(fss *cliflag.NamedFlagSets) {
+	fs := fss.FlagSet("network_resource_plugin")
+
+	fs.StringVar(&o.PolicyName, "network-resource-plugin-policy",
+		o.PolicyName, "The policy network resource plugin should use")
+	fs.Uint32Var(&o.NetClass.ReclaimedCores, "network-resource-plugin-class-id-reclaimed-cores",
+		o.NetClass.ReclaimedCores, "net class id for reclaimed_cores")
+	fs.Uint32Var(&o.NetClass.SharedCores, "network-resource-plugin-class-id-shared-cores",
+		o.NetClass.SharedCores, "net class id for shared_cores")
+	fs.Uint32Var(&o.NetClass.DedicatedCores, "network-resource-plugin-class-id-dedicated-cores",
+		o.NetClass.DedicatedCores, "net class id for dedicated_cores")
+	fs.Uint32Var(&o.NetClass.SystemCores, "network-resource-plugin-class-id-system-cores",
+		o.NetClass.SystemCores, "net class id for system_cores")
+	fs.StringVar(&o.PodLevelNetClassAnnoKey, "network-resource-plugin-net-class-annotation-key",
+		o.PodLevelNetClassAnnoKey, "The annotation key of pod-level net class")
+	fs.StringVar(&o.PodLevelNetAttributesAnnoKeys, "network-resource-plugin-net-attributes-keys",
+		o.PodLevelNetAttributesAnnoKeys, "The annotation keys of pod-level network attributes, separated by commas")
+}
+
+func (o *NetworkOptions) ApplyTo(conf *qrmconfig.NetworkQRMPluginConfig) error {
+	conf.PolicyName = o.PolicyName
+	conf.NetClass.ReclaimedCores = o.NetClass.ReclaimedCores
+	conf.NetClass.SharedCores = o.NetClass.SharedCores
+	conf.NetClass.DedicatedCores = o.NetClass.DedicatedCores
+	conf.NetClass.SystemCores = o.NetClass.SystemCores
+	conf.PodLevelNetClassAnnoKey = o.PodLevelNetClassAnnoKey
+	conf.PodLevelNetAttributesAnnoKeys = o.PodLevelNetAttributesAnnoKeys
+
+	return nil
+}

--- a/cmd/katalyst-agent/app/options/qrm/qrm_base.go
+++ b/cmd/katalyst-agent/app/options/qrm/qrm_base.go
@@ -58,20 +58,23 @@ func (o *GenericQRMPluginOptions) ApplyTo(conf *qrmconfig.GenericQRMPluginConfig
 }
 
 type QRMPluginsOptions struct {
-	CPUOptions    *CPUOptions
-	MemoryOptions *MemoryOptions
+	CPUOptions     *CPUOptions
+	MemoryOptions  *MemoryOptions
+	NetworkOptions *NetworkOptions
 }
 
 func NewQRMPluginsOptions() *QRMPluginsOptions {
 	return &QRMPluginsOptions{
-		CPUOptions:    NewCPUOptions(),
-		MemoryOptions: NewMemoryOptions(),
+		CPUOptions:     NewCPUOptions(),
+		MemoryOptions:  NewMemoryOptions(),
+		NetworkOptions: NewNetworkOptions(),
 	}
 }
 
 func (o *QRMPluginsOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	o.CPUOptions.AddFlags(fss)
 	o.MemoryOptions.AddFlags(fss)
+	o.NetworkOptions.AddFlags(fss)
 }
 
 func (o *QRMPluginsOptions) ApplyTo(conf *qrmconfig.QRMPluginsConfiguration) error {
@@ -79,6 +82,9 @@ func (o *QRMPluginsOptions) ApplyTo(conf *qrmconfig.QRMPluginsConfiguration) err
 		return err
 	}
 	if err := o.MemoryOptions.ApplyTo(conf.MemoryQRMPluginConfig); err != nil {
+		return err
+	}
+	if err := o.NetworkOptions.ApplyTo(conf.NetworkQRMPluginConfig); err != nil {
 		return err
 	}
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 )
 
 replace (
-	github.com/kubewharf/katalyst-api => github.com/kubewharf/katalyst-api v0.0.4
+	github.com/kubewharf/katalyst-api => github.com/caohe/katalyst-api v0.0.0-20230423073908-4e492bfdaf40
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 )
 
 replace (
-	github.com/kubewharf/katalyst-api => github.com/caohe/katalyst-api v0.0.0-20230423073908-4e492bfdaf40
+	github.com/kubewharf/katalyst-api => github.com/kubewharf/katalyst-api v0.1.1
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/caohe/katalyst-api v0.0.0-20230423073908-4e492bfdaf40 h1:85nIuJ3Xa88SW1ufcITUMcwEj4WapTSc5YfYo0CbC2g=
+github.com/caohe/katalyst-api v0.0.0-20230423073908-4e492bfdaf40/go.mod h1:N477ZHDwzROGwkee/sPGs2mo5lWqtS10hZxYfTcxB88=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -550,8 +552,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.0.4 h1:P4ezSfAN65+fPIpoQiAcGy03EQ2gbL/R+WRZRwG7QeM=
-github.com/kubewharf/katalyst-api v0.0.4/go.mod h1:N477ZHDwzROGwkee/sPGs2mo5lWqtS10hZxYfTcxB88=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.4 h1:3lg/wqi0jqZZr60JcjDHeOpLcXMKsq3MrEq/4bmfzR8=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.4/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,6 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/caohe/katalyst-api v0.0.0-20230423073908-4e492bfdaf40 h1:85nIuJ3Xa88SW1ufcITUMcwEj4WapTSc5YfYo0CbC2g=
-github.com/caohe/katalyst-api v0.0.0-20230423073908-4e492bfdaf40/go.mod h1:N477ZHDwzROGwkee/sPGs2mo5lWqtS10hZxYfTcxB88=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -552,6 +550,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kubewharf/katalyst-api v0.1.1 h1:Nik2aN3nmsOVKew60Wa/hLnJcc5JkGjSbgeBmEKxI1Y=
+github.com/kubewharf/katalyst-api v0.1.1/go.mod h1:N477ZHDwzROGwkee/sPGs2mo5lWqtS10hZxYfTcxB88=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.4 h1:3lg/wqi0jqZZr60JcjDHeOpLcXMKsq3MrEq/4bmfzR8=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.4/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=

--- a/pkg/agent/qrm-plugins/network/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/network/dynamicpolicy/policy.go
@@ -1,0 +1,270 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamicpolicy
+
+import (
+	"context"
+	"fmt"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+	"github.com/kubewharf/katalyst-core/pkg/util/qos"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-api/pkg/plugins/skeleton"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	cgroupcmutils "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+const (
+	// NetworkResourcePluginPolicyNameDynamic is the policy name of dynamic network resource plugin
+	NetworkResourcePluginPolicyNameDynamic = "dynamic"
+	// ResourceNameNetwork is the resource name of network
+	ResourceNameNetwork = "network"
+)
+
+// DynamicPolicy is the dynamic network policy
+type DynamicPolicy struct {
+	sync.RWMutex
+
+	name       string
+	stopCh     chan struct{}
+	started    bool
+	qosConfig  *generic.QoSConfiguration
+	emitter    metrics.MetricEmitter
+	metaServer *metaserver.MetaServer
+
+	netClassMap                   map[string]uint32
+	isCgV2Env                     bool
+	applyNetClassFunc             func(podUID, containerId string, data *common.NetClsData) error
+	podLevelNetClassAnnoKey       string
+	podLevelNetAttributesAnnoKeys []string
+}
+
+// NewDynamicPolicy returns a dynamic network policy
+func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration, _ interface{}, agentName string) (bool, agent.Component, error) {
+	wrappedEmitter := agentCtx.EmitterPool.GetDefaultMetricsEmitter().WithTags(agentName, metrics.MetricTag{
+		Key: util.QRMPluginPolicyTagName,
+		Val: NetworkResourcePluginPolicyNameDynamic,
+	})
+
+	policyImplement := &DynamicPolicy{
+		qosConfig:   conf.QoSConfiguration,
+		emitter:     wrappedEmitter,
+		metaServer:  agentCtx.MetaServer,
+		stopCh:      make(chan struct{}),
+		name:        fmt.Sprintf("%s_%s", agentName, NetworkResourcePluginPolicyNameDynamic),
+		netClassMap: make(map[string]uint32),
+	}
+
+	if common.IsCgroup2UnifiedMode() {
+		policyImplement.isCgV2Env = true
+		policyImplement.applyNetClassFunc = agentCtx.MetaServer.ExternalManager.ApplyNetClass
+	} else {
+		policyImplement.isCgV2Env = false
+		policyImplement.applyNetClassFunc = cgroupcmutils.ApplyNetClsForContainer
+	}
+
+	policyImplement.ApplyConfig(conf.DynamicConfiguration)
+
+	pluginWrapper, err := skeleton.NewRegistrationPluginWrapper(
+		policyImplement,
+		conf.QRMPluginSocketDirs, nil)
+	if err != nil {
+		return false, agent.ComponentStub{}, fmt.Errorf("dynamic policy new plugin wrapper failed with error: %v", err)
+	}
+
+	return true, &agent.PluginWrapper{GenericPlugin: pluginWrapper}, nil
+}
+
+// ApplyConfig applies config to DynamicPolicy
+func (p *DynamicPolicy) ApplyConfig(conf *config.DynamicConfiguration) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.netClassMap[apiconsts.PodAnnotationQoSLevelReclaimedCores] = conf.NetClass.ReclaimedCores
+	p.netClassMap[apiconsts.PodAnnotationQoSLevelSharedCores] = conf.NetClass.SharedCores
+	p.netClassMap[apiconsts.PodAnnotationQoSLevelDedicatedCores] = conf.NetClass.DedicatedCores
+	p.netClassMap[apiconsts.PodAnnotationQoSLevelSystemCores] = conf.NetClass.SystemCores
+
+	p.podLevelNetClassAnnoKey = conf.PodLevelNetClassAnnoKey
+	p.podLevelNetAttributesAnnoKeys = strings.Split(conf.PodLevelNetAttributesAnnoKeys, ",")
+
+	klog.Infof("[network-resource-plugin] apply configs, "+
+		"netClassMap: %+v, "+
+		"podLevelNetClassAnnoKey: %s, "+
+		"podLevelNetAttributesAnnoKeys: %+v",
+		p.netClassMap,
+		p.podLevelNetClassAnnoKey,
+		p.podLevelNetAttributesAnnoKeys)
+}
+
+// Start starts this plugin
+func (p *DynamicPolicy) Start() (err error) {
+	klog.Infof("MemoryDynamicPolicy start called")
+
+	p.Lock()
+
+	defer func() {
+		if err == nil {
+			p.started = true
+		}
+
+		p.Unlock()
+	}()
+
+	if p.started {
+		klog.Infof("[NetworkDynamicPolicy.Start] DynamicPolicy is already started")
+		return nil
+	}
+
+	p.stopCh = make(chan struct{})
+
+	go wait.Until(func() {
+		_ = p.emitter.StoreInt64(util.MetricNameHeartBeat, 1, metrics.MetricTypeNameRaw)
+	}, time.Second*30, p.stopCh)
+
+	go wait.Until(p.applyNetClass, 5*time.Second, p.stopCh)
+
+	return nil
+}
+
+// Stop stops this plugin
+func (p *DynamicPolicy) Stop() error {
+	p.Lock()
+	defer func() {
+		p.started = false
+		p.Unlock()
+
+		klog.Infof("[NetworkDynamicPolicy.Stop] DynamicPolicy stopped")
+	}()
+
+	if !p.started {
+		klog.Warningf("[NetworkDynamicPolicy.Stop] DynamicPolicy already stopped")
+		return nil
+	}
+	close(p.stopCh)
+	return nil
+}
+
+// Name returns the name of this plugin
+func (p *DynamicPolicy) Name() string {
+	return p.name
+}
+
+// ResourceName returns resource names managed by this plugin
+func (p *DynamicPolicy) ResourceName() string {
+	return ResourceNameNetwork
+}
+
+// GetTopologyHints returns hints of corresponding resources
+func (p *DynamicPolicy) GetTopologyHints(ctx context.Context, req *pluginapi.ResourceRequest) (*pluginapi.ResourceHintsResponse, error) {
+	return nil, nil
+}
+
+func (p *DynamicPolicy) RemovePod(ctx context.Context, req *pluginapi.RemovePodRequest) (*pluginapi.RemovePodResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("RemovePod got nil req")
+	}
+
+	if p.isCgV2Env {
+		err := p.removePod(req.PodUid)
+		if err != nil {
+			klog.ErrorS(err, "[NetworkDynamicPolicy.RemovePod] remove pod failed with error", "podUID", req.PodUid)
+			return nil, err
+		}
+	}
+
+	return &pluginapi.RemovePodResponse{}, nil
+}
+
+// GetResourcesAllocation returns allocation results of corresponding resources
+func (p *DynamicPolicy) GetResourcesAllocation(ctx context.Context, req *pluginapi.GetResourcesAllocationRequest) (*pluginapi.GetResourcesAllocationResponse, error) {
+	return nil, nil
+}
+
+// GetTopologyAwareResources returns allocation results of corresponding resources as topology aware format
+func (p *DynamicPolicy) GetTopologyAwareResources(ctx context.Context, req *pluginapi.GetTopologyAwareResourcesRequest) (*pluginapi.GetTopologyAwareResourcesResponse, error) {
+	return nil, nil
+}
+
+// GetTopologyAwareAllocatableResources returns corresponding allocatable resources as topology aware format
+func (p *DynamicPolicy) GetTopologyAwareAllocatableResources(ctx context.Context, req *pluginapi.GetTopologyAwareAllocatableResourcesRequest) (*pluginapi.GetTopologyAwareAllocatableResourcesResponse, error) {
+	return nil, nil
+}
+
+// GetResourcePluginOptions returns options to be communicated with Resource Manager
+func (p *DynamicPolicy) GetResourcePluginOptions(context.Context, *pluginapi.Empty) (*pluginapi.ResourcePluginOptions, error) {
+	return &pluginapi.ResourcePluginOptions{
+		PreStartRequired:      false,
+		WithTopologyAlignment: false,
+		NeedReconcile:         false,
+	}, nil
+}
+
+// Allocate is called during pod admit so that the resource
+// plugin can allocate corresponding resource for the container
+// according to resource request
+func (p *DynamicPolicy) Allocate(ctx context.Context, req *pluginapi.ResourceRequest) (resp *pluginapi.ResourceAllocationResponse, respErr error) {
+	return &pluginapi.ResourceAllocationResponse{
+		PodUid:         req.PodUid,
+		PodNamespace:   req.PodNamespace,
+		PodName:        req.PodName,
+		ContainerName:  req.ContainerName,
+		ContainerType:  req.ContainerType,
+		ContainerIndex: req.ContainerIndex,
+		PodRole:        req.PodRole,
+		PodType:        req.PodType,
+		ResourceName:   ResourceNameNetwork,
+		AllocationResult: &pluginapi.ResourceAllocation{
+			ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+				ResourceNameNetwork: {},
+			},
+		},
+		Labels:      general.DeepCopyMap(req.Labels),
+		Annotations: general.DeepCopyMap(req.Annotations),
+	}, nil
+}
+
+// PreStartContainer is called, if indicated by resource plugin during registeration phase,
+// before each container start. Resource plugin can run resource specific operations
+// such as resetting the resource before making resources available to the container
+func (p *DynamicPolicy) PreStartContainer(context.Context, *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+	return nil, nil
+}
+
+func (p *DynamicPolicy) applyNetClass() {
+
+}
+
+func (p *DynamicPolicy) removePod(podUID string) error {
+
+
+	return nil
+}
+
+

--- a/pkg/agent/qrm-plugins/network/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/network/dynamicpolicy/policy_test.go
@@ -1,0 +1,477 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dynamicpolicy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	katalyst_base "github.com/kubewharf/katalyst-core/cmd/base"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	metaserveragent "github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+func generateTestConfiguration(t *testing.T) *config.Configuration {
+	testConfiguration, err := options.NewOptions().Config()
+	require.NoError(t, err)
+	require.NotNil(t, testConfiguration)
+	return testConfiguration
+}
+
+func makeMetaServer() *metaserver.MetaServer {
+	return &metaserver.MetaServer{
+		MetaAgent: &metaserveragent.MetaAgent{},
+	}
+}
+
+func makeTestGenericContext(t *testing.T) *agent.GenericContext {
+	genericCtx, err := katalyst_base.GenerateFakeGenericContext([]runtime.Object{})
+	assert.NoError(t, err)
+
+	return &agent.GenericContext{
+		GenericContext: genericCtx,
+		MetaServer:     makeMetaServer(),
+		PluginManager:  nil,
+	}
+}
+
+func makeDynamicPolicy(t *testing.T) *DynamicPolicy {
+	agentCtx := makeTestGenericContext(t)
+	wrappedEmitter := agentCtx.EmitterPool.GetDefaultMetricsEmitter().WithTags(NetworkResourcePluginPolicyNameDynamic, metrics.MetricTag{
+		Key: util.QRMPluginPolicyTagName,
+		Val: NetworkResourcePluginPolicyNameDynamic,
+	})
+
+	return &DynamicPolicy{
+		qosConfig:   generateTestConfiguration(t).QoSConfiguration,
+		emitter:     wrappedEmitter,
+		metaServer:  agentCtx.MetaServer,
+		stopCh:      make(chan struct{}),
+		name:        fmt.Sprintf("%s_%s", "qrm_network_plugin", NetworkResourcePluginPolicyNameDynamic),
+		netClassMap: make(map[string]uint32),
+	}
+}
+
+func TestNewDynamicPolicy(t *testing.T) {
+	neetToRun, policy, err := NewDynamicPolicy(makeTestGenericContext(t), generateTestConfiguration(t), nil, NetworkResourcePluginPolicyNameDynamic)
+	assert.NoError(t, err)
+	assert.NotNil(t, policy)
+	assert.True(t, neetToRun)
+
+	return
+}
+
+func TestRemovePod(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	req := &pluginapi.RemovePodRequest{
+		PodUid: string(uuid.NewUUID()),
+	}
+
+	_, err := policy.RemovePod(context.TODO(), req)
+	assert.NoError(t, err)
+
+	return
+}
+
+func TestAllocate(t *testing.T) {
+	testName := "test"
+
+	testCases := []struct {
+		description  string
+		req          *pluginapi.ResourceRequest
+		expectedResp *pluginapi.ResourceAllocationResponse
+	}{
+		{
+			description: "req for init container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:           string(uuid.NewUUID()),
+				PodNamespace:     testName,
+				PodName:          testName,
+				ContainerName:    testName,
+				ContainerType:    pluginapi.ContainerType_INIT,
+				ContainerIndex:   0,
+				ResourceName:     ResourceNameNetwork,
+				ResourceRequests: make(map[string]float64),
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+			},
+			expectedResp: &pluginapi.ResourceAllocationResponse{
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_INIT,
+				ContainerIndex: 0,
+				ResourceName:   ResourceNameNetwork,
+				AllocationResult: &pluginapi.ResourceAllocation{
+					ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+						ResourceNameNetwork: {},
+					},
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+			},
+		},
+		{
+			description: "req for shared_cores main container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:           string(uuid.NewUUID()),
+				PodNamespace:     testName,
+				PodName:          testName,
+				ContainerName:    testName,
+				ContainerType:    pluginapi.ContainerType_MAIN,
+				ContainerIndex:   0,
+				ResourceName:     ResourceNameNetwork,
+				ResourceRequests: make(map[string]float64),
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+			},
+			expectedResp: &pluginapi.ResourceAllocationResponse{
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   ResourceNameNetwork,
+				AllocationResult: &pluginapi.ResourceAllocation{
+					ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+						ResourceNameNetwork: {},
+					},
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+			},
+		},
+		{
+			description: "req for reclaimed_cores main container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:           string(uuid.NewUUID()),
+				PodNamespace:     testName,
+				PodName:          testName,
+				ContainerName:    testName,
+				ContainerType:    pluginapi.ContainerType_MAIN,
+				ContainerIndex:   0,
+				ResourceName:     ResourceNameNetwork,
+				ResourceRequests: make(map[string]float64),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+				},
+			},
+			expectedResp: &pluginapi.ResourceAllocationResponse{
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   ResourceNameNetwork,
+				AllocationResult: &pluginapi.ResourceAllocation{
+					ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+						ResourceNameNetwork: {},
+					},
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+				},
+			},
+		},
+		{
+			description: "req for dedicated_cores main container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:           string(uuid.NewUUID()),
+				PodNamespace:     testName,
+				PodName:          testName,
+				ContainerName:    testName,
+				ContainerType:    pluginapi.ContainerType_MAIN,
+				ContainerIndex:   0,
+				ResourceName:     ResourceNameNetwork,
+				ResourceRequests: make(map[string]float64),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+				},
+			},
+			expectedResp: &pluginapi.ResourceAllocationResponse{
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   ResourceNameNetwork,
+				AllocationResult: &pluginapi.ResourceAllocation{
+					ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+						ResourceNameNetwork: {},
+					},
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		dynamicPolicy := makeDynamicPolicy(t)
+
+		resp, err := dynamicPolicy.Allocate(context.Background(), tc.req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		tc.expectedResp.PodUid = tc.req.PodUid
+		assert.Equal(t, tc.expectedResp, resp)
+	}
+}
+
+func TestGetNetClassID(t *testing.T) {
+	dynamicPolicy := makeDynamicPolicy(t)
+	dynamicPolicy.netClassMap = map[string]uint32{
+		consts.PodAnnotationQoSLevelReclaimedCores: 10,
+		consts.PodAnnotationQoSLevelSharedCores:    20,
+		consts.PodAnnotationQoSLevelDedicatedCores: 30,
+		consts.PodAnnotationQoSLevelSystemCores:    70,
+	}
+	dynamicPolicy.podLevelNetClassAnnoKey = consts.PodAnnotationNetClassKey
+
+	testCases := []struct {
+		description     string
+		pod             *v1.Pod
+		expectedClassID uint32
+	}{
+		{
+			description: "get net class id for shared_cores",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-1",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					},
+					Labels: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					},
+				},
+			},
+			expectedClassID: 20,
+		},
+		{
+			description: "get net class id for reclaimed_cores",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-1",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+					},
+					Labels: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+					},
+				},
+			},
+			expectedClassID: 10,
+		},
+		{
+			description: "get net class id for dedicated_cores",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-1",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+					},
+					Labels: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+					},
+				},
+			},
+			expectedClassID: 30,
+		},
+		{
+			description: "get net class id for system_cores",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-1",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+					},
+					Labels: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+					},
+				},
+			},
+			expectedClassID: 70,
+		},
+		{
+			description: "get pod-level net class id",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-1",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey:       consts.PodAnnotationQoSLevelSharedCores,
+						dynamicPolicy.podLevelNetClassAnnoKey: fmt.Sprintf("%d", 100),
+					},
+					Labels: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					},
+				},
+			},
+			expectedClassID: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		gotClassID, err := dynamicPolicy.getNetClassID(tc.pod, dynamicPolicy.podLevelNetClassAnnoKey)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedClassID, gotClassID)
+	}
+}
+
+func TestName(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	assert.Equal(t, "qrm_network_plugin_dynamic", policy.Name())
+}
+
+func TestResourceName(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	assert.Equal(t, ResourceNameNetwork, policy.ResourceName())
+}
+
+func TestGetTopologyHints(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	testName := "test"
+
+	req := &pluginapi.ResourceRequest{
+		PodUid:           string(uuid.NewUUID()),
+		PodNamespace:     testName,
+		PodName:          testName,
+		ContainerName:    testName,
+		ContainerType:    pluginapi.ContainerType_MAIN,
+		ContainerIndex:   0,
+		ResourceName:     ResourceNameNetwork,
+		ResourceRequests: make(map[string]float64),
+		Labels: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+		},
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+		},
+	}
+
+	_, err := policy.GetTopologyHints(context.TODO(), req)
+	assert.NoError(t, err)
+}
+
+func TestGetResourcesAllocation(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	_, err := policy.GetResourcesAllocation(context.TODO(), &pluginapi.GetResourcesAllocationRequest{})
+	assert.NoError(t, err)
+}
+
+func TestGetTopologyAwareResources(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	req := &pluginapi.GetTopologyAwareResourcesRequest{
+		PodUid:        string(uuid.NewUUID()),
+		ContainerName: "test-container-name",
+	}
+
+	_, err := policy.GetTopologyAwareResources(context.TODO(), req)
+	assert.NoError(t, err)
+}
+
+func TestGetTopologyAwareAllocatableResources(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	_, err := policy.GetTopologyAwareAllocatableResources(context.TODO(), &pluginapi.GetTopologyAwareAllocatableResourcesRequest{})
+	assert.NoError(t, err)
+}
+
+func TestGetResourcePluginOptions(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	expectedResp := &pluginapi.ResourcePluginOptions{
+		PreStartRequired:      false,
+		WithTopologyAlignment: false,
+		NeedReconcile:         false,
+	}
+
+	resp, err := policy.GetResourcePluginOptions(context.TODO(), &pluginapi.Empty{})
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResp, resp)
+}
+
+func TestPreStartContainer(t *testing.T) {
+	policy := makeDynamicPolicy(t)
+	assert.NotNil(t, policy)
+
+	req := &pluginapi.PreStartContainerRequest{
+		PodUid:        string(uuid.NewUUID()),
+		PodNamespace:  "test-namespace",
+		PodName:       "test-pod-name",
+		ContainerName: "test-container-name",
+	}
+
+	_, err := policy.PreStartContainer(context.TODO(), req)
+	assert.NoError(t, err)
+}

--- a/pkg/agent/qrm-plugins/network/network.go
+++ b/pkg/agent/qrm-plugins/network/network.go
@@ -1,0 +1,24 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent/qrm"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/network/dynamicpolicy"
+)
+
+func init() {
+	qrm.RegisterNetworkPolicyInitializer(dynamicpolicy.NetworkResourcePluginPolicyNameDynamic, dynamicpolicy.NewDynamicPolicy)
+}

--- a/pkg/config/agent/qrm/network_plugin.go
+++ b/pkg/config/agent/qrm/network_plugin.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qrm
+
+import (
+	"github.com/kubewharf/katalyst-core/pkg/config/dynamic"
+)
+
+// NetworkQRMPluginConfig is the config of network QRM plugin
+type NetworkQRMPluginConfig struct {
+	// PolicyName is used to switch between several strategies
+	PolicyName                    string
+	NetClass                      NetClassConfig
+	PodLevelNetClassAnnoKey       string
+	PodLevelNetAttributesAnnoKeys string
+}
+
+type NetClassConfig struct {
+	// ReclaimedCores is the network class id for reclaimed_cores
+	ReclaimedCores uint32
+	// SharedCores is the network class id for shared_cores
+	SharedCores uint32
+	// DedicatedCores is the network class id for dedicated_cores
+	DedicatedCores uint32
+	// SystemCores is the network class id for system_cores
+	SystemCores uint32
+}
+
+// NewNetworkQRMPluginConfig returns a NetworkQRMPluginConfig
+func NewNetworkQRMPluginConfig() *NetworkQRMPluginConfig {
+	return &NetworkQRMPluginConfig{}
+}
+
+// ApplyConfiguration applies the DynamicConfigCRD to NetworkQRMPluginConfig
+func (c *NetworkQRMPluginConfig) ApplyConfiguration(defaultConf *NetworkQRMPluginConfig, conf *dynamic.DynamicConfigCRD) {
+}

--- a/pkg/config/agent/qrm/qrm_base.go
+++ b/pkg/config/agent/qrm/qrm_base.go
@@ -30,6 +30,7 @@ type GenericQRMPluginConfiguration struct {
 type QRMPluginsConfiguration struct {
 	*CPUQRMPluginConfig
 	*MemoryQRMPluginConfig
+	*NetworkQRMPluginConfig
 }
 
 func NewGenericQRMPluginConfiguration() *GenericQRMPluginConfiguration {
@@ -41,12 +42,14 @@ func (c *GenericQRMPluginConfiguration) ApplyConfiguration(*GenericQRMPluginConf
 
 func NewQRMPluginsConfiguration() *QRMPluginsConfiguration {
 	return &QRMPluginsConfiguration{
-		CPUQRMPluginConfig:    NewCPUQRMPluginConfig(),
-		MemoryQRMPluginConfig: NewMemoryQRMPluginConfig(),
+		CPUQRMPluginConfig:     NewCPUQRMPluginConfig(),
+		MemoryQRMPluginConfig:  NewMemoryQRMPluginConfig(),
+		NetworkQRMPluginConfig: NewNetworkQRMPluginConfig(),
 	}
 }
 
 func (c *QRMPluginsConfiguration) ApplyConfiguration(defaultConf *QRMPluginsConfiguration, conf *dynamic.DynamicConfigCRD) {
 	c.CPUQRMPluginConfig.ApplyConfiguration(defaultConf.CPUQRMPluginConfig, conf)
 	c.MemoryQRMPluginConfig.ApplyConfiguration(defaultConf.MemoryQRMPluginConfig, conf)
+	c.NetworkQRMPluginConfig.ApplyConfiguration(defaultConf.NetworkQRMPluginConfig, conf)
 }

--- a/pkg/metaserver/external/cgroupid/manager.go
+++ b/pkg/metaserver/external/cgroupid/manager.go
@@ -14,8 +14,14 @@
 
 package cgroupid
 
-import "context"
+import (
+	"context"
+)
 
+// CgroupIDManager maintains the mapping of pod to cgroup id.
 type CgroupIDManager interface {
 	Run(ctx context.Context)
+
+	GetCgroupIDForContainer(podUID, containerID string) (uint64, error)
+	ListCgroupIDsForPod(podUID string) ([]uint64, error)
 }

--- a/pkg/metaserver/external/cgroupid/manager_linux_test.go
+++ b/pkg/metaserver/external/cgroupid/manager_linux_test.go
@@ -41,7 +41,7 @@ var (
 )
 
 func TestGetCgroupIDForContainer(t *testing.T) {
-	cgroupIDManager := NewCgroupIDManager(podFetcher).(*DefaultCgroupIDManager)
+	cgroupIDManager := NewCgroupIDManager(podFetcher).(*cgroupIDManagerImpl)
 	assert.NotNil(t, cgroupIDManager)
 
 	cgroupIDManager.setCgroupID(podUIDList[0], containerIDList[0], cgIDList[0])
@@ -77,7 +77,7 @@ func TestGetCgroupIDForContainer(t *testing.T) {
 }
 
 func TestListCgroupIDsForPod(t *testing.T) {
-	cgroupIDManager := NewCgroupIDManager(podFetcher).(*DefaultCgroupIDManager)
+	cgroupIDManager := NewCgroupIDManager(podFetcher).(*cgroupIDManagerImpl)
 	assert.NotNil(t, cgroupIDManager)
 
 	cgroupIDManager.setCgroupID(podUIDList[0], containerIDList[0], cgIDList[0])
@@ -113,7 +113,7 @@ func TestListCgroupIDsForPod(t *testing.T) {
 }
 
 func TestGetAbsentContainers(t *testing.T) {
-	cgroupIDManager := NewCgroupIDManager(podFetcher).(*DefaultCgroupIDManager)
+	cgroupIDManager := NewCgroupIDManager(podFetcher).(*cgroupIDManagerImpl)
 	assert.NotNil(t, cgroupIDManager)
 
 	cgroupIDManager.setCgroupID(podUIDList[0], containerIDList[0], cgIDList[0])
@@ -149,7 +149,7 @@ func TestGetAbsentContainers(t *testing.T) {
 }
 
 func TestClearResidualPodsInCache(t *testing.T) {
-	cgroupIDManager := NewCgroupIDManager(podFetcher).(*DefaultCgroupIDManager)
+	cgroupIDManager := NewCgroupIDManager(podFetcher).(*cgroupIDManagerImpl)
 	assert.NotNil(t, cgroupIDManager)
 
 	cgroupIDManager.setCgroupID(podUIDList[0], containerIDList[0], cgIDList[0])

--- a/pkg/metaserver/external/cgroupid/manager_unsupported.go
+++ b/pkg/metaserver/external/cgroupid/manager_unsupported.go
@@ -23,14 +23,24 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 )
 
-// DefaultCgroupIDManager maintains the mapping of pod to cgroup id.
 type unsupportedCgroupIDManager struct {
 }
 
+// NewCgroupIDManager returns a CgroupIDManager
 func NewCgroupIDManager(_ pod.PodFetcher) CgroupIDManager {
 	return &unsupportedCgroupIDManager{}
 }
 
-// Run starts a DefaultCgroupIDManager
+// Run starts a cgroupIDManagerImpl
 func (m *unsupportedCgroupIDManager) Run(_ context.Context) {
+}
+
+// GetCgroupIDForContainer returns the cgroup id of a given container.
+func (m *unsupportedCgroupIDManager) GetCgroupIDForContainer(podUID, containerID string) (uint64, error) {
+	return 0, nil
+}
+
+// ListCgroupIDsForPod returns the cgroup ids of a given pod.
+func (m *unsupportedCgroupIDManager) ListCgroupIDsForPod(podUID string) ([]uint64, error) {
+	return nil, nil
 }

--- a/pkg/metaserver/external/manager.go
+++ b/pkg/metaserver/external/manager.go
@@ -17,22 +17,16 @@ package external
 import (
 	"context"
 
-	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/external/cgroupid"
+	"github.com/kubewharf/katalyst-core/pkg/util/external/network"
+	"github.com/kubewharf/katalyst-core/pkg/util/external/rdt"
 )
 
 // ExternalManager contains a set of managers that execute configurations beyond the OCI spec.
 type ExternalManager interface {
+	cgroupid.CgroupIDManager
+	network.NetworkManager
+	rdt.RDTManager
+
 	Run(ctx context.Context)
-
-	GetCgroupIDForContainer(podUID, containerID string) (uint64, error)
-	ListCgroupIDsForPod(podUID string) ([]uint64, error)
-
-	ApplyNetClass(podUID, containerId string, data *common.NetClsData) error
-	ClearNetClass(cgroupID uint64) error
-
-	CheckSupportRDT() (bool, error)
-	InitRDT() error
-	ApplyTasks(clos string, tasks []string) error
-	ApplyCAT(clos string, cat map[int]int) error
-	ApplyMBA(clos string, mba map[int]int) error
 }

--- a/pkg/metaserver/external/manager_linux.go
+++ b/pkg/metaserver/external/manager_linux.go
@@ -31,11 +31,10 @@ import (
 
 var (
 	initManagerOnce sync.Once
-	manager         *ExternalManagerImpl
+	manager         *externalManagerImpl
 )
 
-// ExternalManagerImpl contains a set of managers that execute configurations beyond the OCI spec.
-type ExternalManagerImpl struct {
+type externalManagerImpl struct {
 	mutex sync.Mutex
 	start bool
 	cgroupid.CgroupIDManager
@@ -44,13 +43,13 @@ type ExternalManagerImpl struct {
 	rdt.RDTManager
 }
 
-// InitExternalManager initializes an ExternalManagerImpl
+// InitExternalManager initializes an externalManagerImpl
 func InitExternalManager(podFetcher pod.PodFetcher) ExternalManager {
 	initManagerOnce.Do(func() {
-		manager = &ExternalManagerImpl{
+		manager = &externalManagerImpl{
 			start:           false,
 			CgroupIDManager: cgroupid.NewCgroupIDManager(podFetcher),
-			NetworkManager:  network.NewDefaultManager(),
+			NetworkManager:  network.NewNetworkManager(),
 			RDTManager:      rdt.NewDefaultManager(),
 		}
 	})
@@ -58,8 +57,8 @@ func InitExternalManager(podFetcher pod.PodFetcher) ExternalManager {
 	return manager
 }
 
-// Run starts an ExternalManagerImpl
-func (m *ExternalManagerImpl) Run(ctx context.Context) {
+// Run starts an externalManagerImpl
+func (m *externalManagerImpl) Run(ctx context.Context) {
 	m.mutex.Lock()
 	if m.start {
 		m.mutex.Unlock()
@@ -74,13 +73,13 @@ func (m *ExternalManagerImpl) Run(ctx context.Context) {
 }
 
 // SetNetworkManager replaces defaultNetworkManager with a custom implementation
-func (m *ExternalManagerImpl) SetNetworkManager(n network.NetworkManager) {
+func (m *externalManagerImpl) SetNetworkManager(n network.NetworkManager) {
 	m.setComponentImplementation(func() {
 		m.NetworkManager = n
 	})
 }
 
-func (m *ExternalManagerImpl) setComponentImplementation(setter func()) {
+func (m *externalManagerImpl) setComponentImplementation(setter func()) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/metaserver/external/manager_linux_test.go
+++ b/pkg/metaserver/external/manager_linux_test.go
@@ -39,7 +39,7 @@ func TestInitExternalManager(t *testing.T) {
 }
 
 func TestSetNetworkManager(t *testing.T) {
-	externalManager := InitExternalManager(podFetcher).(*ExternalManagerImpl)
+	externalManager := InitExternalManager(podFetcher).(*externalManagerImpl)
 	assert.NotNil(t, externalManager)
 
 	externalManager.start = false

--- a/pkg/metaserver/external/manager_unsupported.go
+++ b/pkg/metaserver/external/manager_unsupported.go
@@ -21,16 +21,24 @@ import (
 	"context"
 
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/external/cgroupid"
+	"github.com/kubewharf/katalyst-core/pkg/util/external/network"
+	"github.com/kubewharf/katalyst-core/pkg/util/external/rdt"
 )
 
-// ExternalManagerImpl contains a set of managers that execute configurations beyond the OCI spec.
 type unsupportedExternalManager struct {
+	cgroupid.CgroupIDManager
+
+	network.NetworkManager
+	rdt.RDTManager
 }
 
+// Run starts an unsupportedExternalManager
 func (m *unsupportedExternalManager) Run(_ context.Context) {
 
 }
 
+// InitExternalManager initializes an externalManagerImpl
 func InitExternalManager(podFetcher pod.PodFetcher) ExternalManager {
 	return &unsupportedExternalManager{}
 }

--- a/pkg/util/cgroup/common/path.go
+++ b/pkg/util/cgroup/common/path.go
@@ -113,3 +113,12 @@ func GetPodAbsCgroupPath(subsys, podUID string) (string, error) {
 func GetContainerAbsCgroupPath(subsys, podUID, containerId string) (string, error) {
 	return GetKubernetesAnyExistAbsCgroupPath(subsys, path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
 }
+
+func IsContainerCgroupExist(podUID, containerID string) (bool, error) {
+	containerAbsCGPath, err := GetContainerAbsCgroupPath("", podUID, containerID)
+	if err != nil {
+		return false, fmt.Errorf("GetContainerAbsCgroupPath failed, err: %v", err)
+	}
+
+	return general.IsPathExists(containerAbsCGPath), nil
+}

--- a/pkg/util/cgroup/common/path_test.go
+++ b/pkg/util/cgroup/common/path_test.go
@@ -53,3 +53,9 @@ func TestGetContainerAbsCgroupPath(t *testing.T) {
 	_, err := GetContainerAbsCgroupPath("cpuset", "", "")
 	as.NotNil(err)
 }
+
+func TestIsContainerCgroupExist(t *testing.T) {
+	as := require.New(t)
+	_, err := IsContainerCgroupExist("fake-pod-uid", "fake-container-id")
+	as.NotNil(err)
+}

--- a/pkg/util/external/network/manager.go
+++ b/pkg/util/external/network/manager.go
@@ -15,37 +15,11 @@
 package network
 
 import (
-	"errors"
-
 	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
-)
-
-const (
-	// SubManagerName is the name of NetworkManager.
-	SubManagerName = "network"
 )
 
 // NetworkManager provides methods that control network resources.
 type NetworkManager interface {
 	ApplyNetClass(podUID, containerId string, data *common.NetClsData) error
 	ClearNetClass(cgroupID uint64) error
-}
-
-type defaultNetworkManager struct{}
-
-// NewDefaultManager returns a defaultNetworkManager.
-func NewDefaultManager() NetworkManager {
-	return &defaultNetworkManager{}
-}
-
-// ApplyNetClass applies the net class config for a container.
-func (*defaultNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData) error {
-	// TODO: implement traffic tagging by using eBPF
-	return errors.New("not implemented yet")
-}
-
-// ClearNetClass clears the net class config for a container.
-func (*defaultNetworkManager) ClearNetClass(cgroupID uint64) error {
-	// TODO: clear the eBPF map when a pod is removed
-	return errors.New("not implemented yet")
 }

--- a/pkg/util/external/network/manager_linux.go
+++ b/pkg/util/external/network/manager_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"errors"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+)
+
+type defaultNetworkManager struct{}
+
+// NewNetworkManager returns a defaultNetworkManager.
+func NewNetworkManager() NetworkManager {
+	return &defaultNetworkManager{}
+}
+
+// ApplyNetClass applies the net class config for a container.
+func (*defaultNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData) error {
+	// TODO: implement traffic tagging by using eBPF
+	return errors.New("not implemented yet")
+}
+
+// ClearNetClass clears the net class config for a container.
+func (*defaultNetworkManager) ClearNetClass(cgroupID uint64) error {
+	// TODO: clear the eBPF map when a pod is removed
+	return errors.New("not implemented yet")
+}

--- a/pkg/util/external/network/manager_linux_test.go
+++ b/pkg/util/external/network/manager_linux_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 // Copyright 2022 The Katalyst Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,14 +33,14 @@ var (
 )
 
 func TestNewDefaultManager(t *testing.T) {
-	defaultManager := NewDefaultManager()
+	defaultManager := NewNetworkManager()
 	assert.NotNil(t, defaultManager)
 
 	return
 }
 
 func TestApplyNetClass(t *testing.T) {
-	defaultManager := NewDefaultManager()
+	defaultManager := NewNetworkManager()
 	assert.NotNil(t, defaultManager)
 
 	err := defaultManager.ApplyNetClass(podUID, containerID, &common.NetClsData{
@@ -50,7 +53,7 @@ func TestApplyNetClass(t *testing.T) {
 }
 
 func TestClearNetClass(t *testing.T) {
-	defaultManager := NewDefaultManager()
+	defaultManager := NewNetworkManager()
 	assert.NotNil(t, defaultManager)
 
 	err := defaultManager.ClearNetClass(cgID)

--- a/pkg/util/external/network/manager_unsupported.go
+++ b/pkg/util/external/network/manager_unsupported.go
@@ -1,3 +1,6 @@
+//go:build !linux
+// +build !linux
+
 // Copyright 2022 The Katalyst Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,27 +15,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package external
+package network
 
 import (
-	"context"
-
 	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
 )
 
-// ExternalManager contains a set of managers that execute configurations beyond the OCI spec.
-type ExternalManager interface {
-	Run(ctx context.Context)
+type unsupportedNetworkManager struct{}
 
-	GetCgroupIDForContainer(podUID, containerID string) (uint64, error)
-	ListCgroupIDsForPod(podUID string) ([]uint64, error)
+// NewNetworkManager returns a defaultNetworkManager.
+func NewNetworkManager() NetworkManager {
+	return &unsupportedNetworkManager{}
+}
 
-	ApplyNetClass(podUID, containerId string, data *common.NetClsData) error
-	ClearNetClass(cgroupID uint64) error
+// ApplyNetClass applies the net class config for a container.
+func (*unsupportedNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData) error {
+	return nil
+}
 
-	CheckSupportRDT() (bool, error)
-	InitRDT() error
-	ApplyTasks(clos string, tasks []string) error
-	ApplyCAT(clos string, cat map[int]int) error
-	ApplyMBA(clos string, mba map[int]int) error
+// ClearNetClass clears the net class config for a container.
+func (*unsupportedNetworkManager) ClearNetClass(cgroupID uint64) error {
+	return nil
 }

--- a/pkg/util/external/rdt/manager.go
+++ b/pkg/util/external/rdt/manager.go
@@ -14,15 +14,6 @@
 
 package rdt
 
-import (
-	"errors"
-)
-
-const (
-	// SubManagerName is the name of NetworkManager.
-	SubManagerName = "rdt"
-)
-
 // RDTManager provides methods that control RDT related resources.
 type RDTManager interface {
 	CheckSupportRDT() (bool, error)
@@ -30,41 +21,4 @@ type RDTManager interface {
 	ApplyTasks(clos string, tasks []string) error
 	ApplyCAT(clos string, cat map[int]int) error
 	ApplyMBA(clos string, mba map[int]int) error
-}
-
-type defaultRDTManager struct{}
-
-// NewDefaultManager returns a defaultRDTManager.
-func NewDefaultManager() RDTManager {
-	return &defaultRDTManager{}
-}
-
-// CheckSupportRDT checks whether RDT is supported by the CPU and the kernel.
-func (*defaultRDTManager) CheckSupportRDT() (bool, error) {
-	// TODO: implement CheckSupportRDT
-	return false, errors.New("not implemented yet")
-}
-
-// InitRDT performs some RDT-related initializations.
-func (*defaultRDTManager) InitRDT() error {
-	// TODO: implement InitRDT
-	return errors.New("not implemented yet")
-}
-
-// ApplyTasks synchronizes the tasks of each CLOS.
-func (*defaultRDTManager) ApplyTasks(clos string, tasks []string) error {
-	// TODO: implement ApplyTasks
-	return errors.New("not implemented yet")
-}
-
-// ApplyCAT applies the CAT configurations for each CLOS.
-func (*defaultRDTManager) ApplyCAT(clos string, cat map[int]int) error {
-	// TODO: implement ApplyCAT
-	return errors.New("not implemented yet")
-}
-
-// ApplyMBA applies the MBA configurations for each CLOS.
-func (*defaultRDTManager) ApplyMBA(clos string, mba map[int]int) error {
-	// TODO: implement ApplyMBA
-	return errors.New("not implemented yet")
 }

--- a/pkg/util/external/rdt/manager_linux.go
+++ b/pkg/util/external/rdt/manager_linux.go
@@ -1,0 +1,59 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdt
+
+import (
+	"errors"
+)
+
+type defaultRDTManager struct{}
+
+// NewDefaultManager returns a defaultRDTManager.
+func NewDefaultManager() RDTManager {
+	return &defaultRDTManager{}
+}
+
+// CheckSupportRDT checks whether RDT is supported by the CPU and the kernel.
+func (*defaultRDTManager) CheckSupportRDT() (bool, error) {
+	// TODO: implement CheckSupportRDT
+	return false, errors.New("not implemented yet")
+}
+
+// InitRDT performs some RDT-related initializations.
+func (*defaultRDTManager) InitRDT() error {
+	// TODO: implement InitRDT
+	return errors.New("not implemented yet")
+}
+
+// ApplyTasks synchronizes the tasks of each CLOS.
+func (*defaultRDTManager) ApplyTasks(clos string, tasks []string) error {
+	// TODO: implement ApplyTasks
+	return errors.New("not implemented yet")
+}
+
+// ApplyCAT applies the CAT configurations for each CLOS.
+func (*defaultRDTManager) ApplyCAT(clos string, cat map[int]int) error {
+	// TODO: implement ApplyCAT
+	return errors.New("not implemented yet")
+}
+
+// ApplyMBA applies the MBA configurations for each CLOS.
+func (*defaultRDTManager) ApplyMBA(clos string, mba map[int]int) error {
+	// TODO: implement ApplyMBA
+	return errors.New("not implemented yet")
+}

--- a/pkg/util/external/rdt/manager_linux_test.go
+++ b/pkg/util/external/rdt/manager_linux_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 // Copyright 2022 The Katalyst Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/util/external/rdt/manager_unsupported.go
+++ b/pkg/util/external/rdt/manager_unsupported.go
@@ -1,0 +1,50 @@
+//go:build !linux
+// +build !linux
+
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdt
+
+type unsupportedRDTManager struct{}
+
+// NewDefaultManager returns a defaultRDTManager.
+func NewDefaultManager() RDTManager {
+	return &unsupportedRDTManager{}
+}
+
+// CheckSupportRDT checks whether RDT is supported by the CPU and the kernel.
+func (*unsupportedRDTManager) CheckSupportRDT() (bool, error) {
+	return false, nil
+}
+
+// InitRDT performs some RDT-related initializations.
+func (*unsupportedRDTManager) InitRDT() error {
+	return nil
+}
+
+// ApplyTasks synchronizes the tasks of each CLOS.
+func (*unsupportedRDTManager) ApplyTasks(clos string, tasks []string) error {
+	return nil
+}
+
+// ApplyCAT applies the CAT configurations for each CLOS.
+func (*unsupportedRDTManager) ApplyCAT(clos string, cat map[int]int) error {
+	return nil
+}
+
+// ApplyMBA applies the MBA configurations for each CLOS.
+func (*unsupportedRDTManager) ApplyMBA(clos string, mba map[int]int) error {
+	return nil
+}

--- a/pkg/util/native/pods.go
+++ b/pkg/util/native/pods.go
@@ -326,3 +326,16 @@ func DeepCopyPodContainers(pod *v1.Pod) (containers []v1.Container) {
 	}
 	return
 }
+
+// FilterPodAnnotations returns the needed annotations for the given pod.
+func FilterPodAnnotations(filterKeys []string, pod *v1.Pod) map[string]string {
+	netAttrMap := make(map[string]string)
+
+	for _, attrKey := range filterKeys {
+		if attrVal, ok := pod.GetAnnotations()[attrKey]; ok {
+			netAttrMap[attrKey] = attrVal
+		}
+	}
+
+	return netAttrMap
+}

--- a/pkg/util/native/pods_test.go
+++ b/pkg/util/native/pods_test.go
@@ -1,0 +1,61 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package native
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFilterPodAnnotations(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		pod        *v1.Pod
+		filterKeys []string
+		expected   map[string]string
+	}{
+		{
+			name: "test case 1",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod",
+					Annotations: map[string]string{
+						"key-1": "val-1",
+						"key-2": "val-2",
+						"key-3": "val-3",
+					},
+				},
+			},
+			filterKeys: []string{
+				"key-1",
+				"key-2",
+				"key-4",
+			},
+			expected: map[string]string{
+				"key-1": "val-1",
+				"key-2": "val-2",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("case: %v", tc.name)
+			got := FilterPodAnnotations(tc.filterKeys, tc.pod)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/util/qos/net_enhancement.go
+++ b/pkg/util/qos/net_enhancement.go
@@ -12,15 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rdt
+package qos
 
-// RDTManager provides methods that control RDT related resources.
-// Note: OCI Spec and runC already support the configuration of RDT-related parameters, but CRI and containerd do not yet support it.
-// Therefore, we plan to support the configuration of RDT-related parameters through NRI or CRI in the future.
-type RDTManager interface {
-	CheckSupportRDT() (bool, error)
-	InitRDT() error
-	ApplyTasks(clos string, tasks []string) error
-	ApplyCAT(clos string, cat map[int]int) error
-	ApplyMBA(clos string, mba map[int]int) error
+import (
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// GetPodNetClassID parses net class id for the given pod.
+// if the given pod doesn't specify a class id, the first value returned will be false
+func GetPodNetClassID(pod *v1.Pod, podLevelNetClassAnnoKey string) (bool, uint32, error) {
+	classIDStr, ok := pod.GetAnnotations()[podLevelNetClassAnnoKey]
+
+	if !ok {
+		return false, 0, nil
+	}
+
+	classID, err := strconv.ParseUint(classIDStr, 10, 64)
+	if err != nil {
+		return true, 0, err
+	}
+	return true, uint32(classID), nil
 }

--- a/pkg/util/qos/net_enhancement_test.go
+++ b/pkg/util/qos/net_enhancement_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 The Katalyst Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+)
+
+func TestGetPodNetClassID(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		pod           *v1.Pod
+		expectExist   bool
+		expectClassID uint32
+	}{
+		{
+			name: "pod-level net class id exists",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-1",
+					Annotations: map[string]string{
+						consts.PodAnnotationNetClassKey: "123456",
+					},
+				},
+			},
+			expectExist:   true,
+			expectClassID: 123456,
+		},
+		{
+			name: "pod-level net class id doesn't exist",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pod-2",
+				},
+			},
+			expectExist:   false,
+			expectClassID: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("case: %v", tc.name)
+			gotExist, gotClassID, err := GetPodNetClassID(tc.pod)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectExist, gotExist)
+			assert.Equal(t, tc.expectClassID, gotClassID)
+		})
+	}
+}

--- a/pkg/util/qos/net_enhancement_test.go
+++ b/pkg/util/qos/net_enhancement_test.go
@@ -57,7 +57,7 @@ func TestGetPodNetClassID(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("case: %v", tc.name)
-			gotExist, gotClassID, err := GetPodNetClassID(tc.pod)
+			gotExist, gotClassID, err := GetPodNetClassID(tc.pod, consts.PodAnnotationNetClassKey)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectExist, gotExist)
 			assert.Equal(t, tc.expectClassID, gotClassID)


### PR DESCRIPTION
#### What type of PR is this?
Features
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:
- Introduce a network QRM plugin with the following capabilities:
  - Packet tagging
    - In cgroups v1 environments, configure the net_cls cgroup through the Cgroup Manager to enable outbound traffic tagging for containers.
    - In cgroups v2 environments, use eBPF through the External Manager to support traffic tagging.
  - Network bandwidth control (will be implemented in future PRs)
- Refactor external manager to support multiple operating systems.

#### Which issue(s) this PR fixes:
Fix #5 

#### Special notes for your reviewer:
Related PR: https://github.com/kubewharf/katalyst-api/pull/2