### PR TITLE
fix(qrm_sysadvisor): ensure directories of qrm sysadvisor communication socks existing before listening them

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -253,9 +253,7 @@ func (p *DynamicPolicy) Start() (err error) {
 	go wait.Until(p.checkCPUSet, cpusetCheckPeriod, p.stopCh)
 
 	if p.enableSyncingCPUIdle {
-		if !cgroupcm.IsCPUIdleSupported() {
-			return fmt.Errorf("enable cpu idle in unsupported environment")
-		} else if p.reclaimRelativeRootCgroupPath == "" {
+		if p.reclaimRelativeRootCgroupPath == "" {
 			return fmt.Errorf("enable syncing cpu idle but not set reclaiemd relative root cgroup path in configuration")
 		}
 
@@ -2124,6 +2122,11 @@ func GetReadonlyState() (state.ReadonlyState, error) {
 
 func (p *DynamicPolicy) syncCPUIdle() {
 	klog.Infof("[CPUDynamicPolicy] exec syncCPUIdle")
+
+	if !cgroupcm.IsCPUIdleSupported() {
+		klog.Warningf("[CPUDynamicPolicy.syncCPUIdle] cpu idle isn't unsupported, skip syncing")
+		return
+	}
 
 	err := cgroupcmutils.ApplyCPUWithRelativePath(p.reclaimRelativeRootCgroupPath, &cgroupcm.CPUData{CpuIdlePtr: &p.enableCPUIdle})
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -270,7 +271,11 @@ func (p *DynamicPolicy) Start() (err error) {
 	if !p.enableCPUSysAdvisor {
 		klog.Infof("[CPUDynamicPolicy.Start] start dynamic policy cpu plugin without sys-advisor")
 		return nil
+	} else if p.cpuAdvisorSocketAbsPath == "" || p.cpuPluginSocketAbsPath == "" {
+		return fmt.Errorf("invalid cpuAdvisorSocketAbsPath: %s or cpuPluginSocketAbsPath: %s",
+			p.cpuAdvisorSocketAbsPath, p.cpuPluginSocketAbsPath)
 	}
+
 	klog.Infof("[CPUDynamicPolicy.Start] start dynamic policy cpu plugin with sys-advisor")
 
 	err = p.initialize()
@@ -1938,6 +1943,17 @@ func (p *DynamicPolicy) allocateByCPUAdvisorServerListAndWatchResp(resp *advisor
 }
 
 func (p *DynamicPolicy) serveCPUPluginCheckpoint(stopCh <-chan struct{}) {
+	cpuPluginSocketDir := path.Dir(p.cpuPluginSocketAbsPath)
+
+	err := general.EnsureDirectory(cpuPluginSocketDir)
+	if err != nil {
+		klog.Errorf("[CPUDynamicPolicy.ServeCPUPluginCheckpoint] ensure cpuPluginSocketDir: %s failed with error: %v",
+			cpuPluginSocketDir, err)
+		return
+	}
+
+	klog.Infof("[CPUDynamicPolicy.ServeCPUPluginCheckpoint] ensure cpuPluginSocketDir: %s successfully", cpuPluginSocketDir)
+
 	if err := os.Remove(p.cpuPluginSocketAbsPath); err != nil && !os.IsNotExist(err) {
 		klog.Errorf("[CPUDynamicPolicy.ServeCPUPluginCheckpoint] failed to remove %s: %v", p.cpuPluginSocketAbsPath, err)
 		return
@@ -1948,6 +1964,8 @@ func (p *DynamicPolicy) serveCPUPluginCheckpoint(stopCh <-chan struct{}) {
 		klog.Errorf("[CPUDynamicPolicy.ServeCPUPluginCheckpoint] listen at socket: %s faield with err: %v", p.cpuPluginSocketAbsPath, err)
 		return
 	}
+
+	klog.Infof("[CPUDynamicPolicy.ServeCPUPluginCheckpoint] listen at: %s successfully", p.cpuPluginSocketAbsPath)
 
 	grpcServer := grpc.NewServer()
 	advisorapi.RegisterCPUPluginServer(grpcServer, p)

--- a/pkg/agent/sysadvisor/plugin/qosaware/server/cpu/cpu_server.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/server/cpu/cpu_server.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"time"
 
 	"google.golang.org/grpc"
@@ -288,6 +289,16 @@ func (cs *cpuServer) startToGetCheckpointFromCPUPlugin() error {
 }
 
 func (cs *cpuServer) serve() error {
+	cpuAdvisorSocketDir := path.Dir(cs.cpuAdvisorSocketPath)
+
+	err := general.EnsureDirectory(cpuAdvisorSocketDir)
+	if err != nil {
+		return fmt.Errorf("ensure cpuAdvisorSocketDir: %s failed with error: %v",
+			cpuAdvisorSocketDir, err)
+	}
+
+	klog.Infof("[qosaware-server-cpu] ensure cpuAdvisorSocketDir: %s successfully", cpuAdvisorSocketDir)
+
 	if err := os.Remove(cs.cpuAdvisorSocketPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove %v failed: %v", cs.cpuAdvisorSocketPath, err)
 	}
@@ -296,6 +307,8 @@ func (cs *cpuServer) serve() error {
 	if err != nil {
 		return fmt.Errorf("listen %s failed: %v", cs.cpuAdvisorSocketPath, err)
 	}
+
+	klog.Infof("[qosaware-server-cpu] listen at: %s successfully", cs.cpuAdvisorSocketPath)
 
 	grpcServer := grpc.NewServer()
 	cpuadvisor.RegisterCPUAdvisorServer(grpcServer, cs)

--- a/pkg/util/cgroup/manager/v2/fs_linux.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux.go
@@ -60,7 +60,7 @@ func (m *manager) ApplyMemory(absCgroupPath string, data *common.MemoryData) err
 		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.wmark_ratio", newRatio); err != nil {
 			return err
 		} else if applied {
-			klog.Infof("[CgroupV1] apply memory wmark successfully, cgroupPath: %s, data: %v, old data: %v\n", absCgroupPath, data.WmarkRatio, oldData)
+			klog.Infof("[CgroupV2] apply memory wmark successfully, cgroupPath: %s, data: %v, old data: %v\n", absCgroupPath, data.WmarkRatio, oldData)
 		}
 	}
 
@@ -109,7 +109,7 @@ func (m *manager) ApplyCPU(absCgroupPath string, data *common.CPUData) error {
 		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "cpu.idle", strconv.FormatInt(cpuIdleValue, 10)); err != nil {
 			lastErrors = append(lastErrors, err)
 		} else if applied {
-			klog.Infof("[CgroupV1] apply cpu.idle successfully, cgroupPath: %s, data: %d, old data: %s\n", absCgroupPath, cpuIdleValue, oldData)
+			klog.Infof("[CgroupV2] apply cpu.idle successfully, cgroupPath: %s, data: %d, old data: %s\n", absCgroupPath, cpuIdleValue, oldData)
 		}
 	}
 


### PR DESCRIPTION
…on socks existing before listening them

#### What type of PR is this?
fix
<!--
Features/Bug fixes/Enhancements
-->

#### Which issue(s) this PR fixes:
ensure directories of qrm sysadvisor communication socks existing before listening them