### PR TITLE
support service profiling manager

### DIFF
--- a/cmd/katalyst-agent/app/options/global/metaserver.go
+++ b/cmd/katalyst-agent/app/options/global/metaserver.go
@@ -30,6 +30,7 @@ const (
 	defaultCustomNodeConfigCacheTTL       = 15 * time.Second
 	defaultServiceProfileCacheTTL         = 15 * time.Second
 	defaultConfigCacheTTL                 = 15 * time.Second
+	defaultConfigDisableDynamic           = false
 	defaultConfigSkipFailedInitialization = true
 	defaultConfigCheckpointGraceTime      = 2 * time.Hour
 )
@@ -73,6 +74,7 @@ func NewMetaServerOptions() *MetaServerOptions {
 		CustomNodeConfigCacheTTL:       defaultCustomNodeConfigCacheTTL,
 		ServiceProfileCacheTTL:         defaultServiceProfileCacheTTL,
 		ConfigCacheTTL:                 defaultConfigCacheTTL,
+		ConfigDisableDynamic:           defaultConfigDisableDynamic,
 		ConfigSkipFailedInitialization: defaultConfigSkipFailedInitialization,
 		ConfigCheckpointGraceTime:      defaultConfigCheckpointGraceTime,
 		KubeletReadOnlyPort:            defaultKubeletReadOnlyPort,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/helper.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/helper.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/spd"
+)
+
+// PodEnableReclaim checks whether the pod can be reclaimed,
+// if node does not enable reclaim, it will return false directly,
+// if node enable reclaim, it will check whether the pod is degraded.
+func PodEnableReclaim(ctx context.Context, metaServer *metaserver.MetaServer,
+	podUID string, nodeEnableReclaim bool) (bool, error) {
+	if !nodeEnableReclaim {
+		return false, nil
+	}
+
+	if metaServer == nil {
+		return false, fmt.Errorf("metaServer is nil")
+	}
+
+	pod, err := metaServer.GetPod(ctx, podUID)
+	if err != nil {
+		return false, err
+	}
+
+	// get current service performance level of the pod
+	pLevel, err := metaServer.ServiceBusinessPerformanceLevel(ctx, pod)
+	if err != nil && !errors.IsNotFound(err) {
+		return false, err
+	} else if err != nil {
+		return true, nil
+	}
+
+	// if performance level not poor, it can not be reclaimed
+	return pLevel != spd.PerformanceLevelPoor, nil
+}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_canonical.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_canonical.go
@@ -17,6 +17,7 @@ limitations under the License.
 package headroompolicy
 
 import (
+	"context"
 	"fmt"
 	"math"
 
@@ -66,7 +67,13 @@ func (p *PolicyCanonical) estimateNonReclaimedQoSMemoryRequirement() (float64, e
 	)
 
 	f := func(podUID string, containerName string, ci *types.ContainerInfo) bool {
-		containerEstimation, err := helper.EstimateContainerMemoryUsage(ci, p.metaReader, p.essentials.EnableReclaim)
+		enableReclaim, err := helper.PodEnableReclaim(context.Background(), p.metaServer, podUID, p.essentials.EnableReclaim)
+		if err != nil {
+			errList = append(errList, err)
+			return true
+		}
+
+		containerEstimation, err := helper.EstimateContainerMemoryUsage(ci, p.metaReader, enableReclaim)
 		if err != nil {
 			errList = append(errList, err)
 			return true

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_canonical_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/headroompolicy/policy_canonical_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/spd"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
@@ -84,6 +85,7 @@ func generateTestMetaServer(t *testing.T, podList []*v1.Pod,
 			PodFetcher:     &pod.PodFetcherStub{PodList: podList},
 			MetricsFetcher: metricsFetcher,
 		},
+		ServiceProfilingManager: &spd.DummyServiceProfilingManager{},
 	}
 	return metaServer
 }

--- a/pkg/metaserver/spd/fetcher.go
+++ b/pkg/metaserver/spd/fetcher.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spd
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+
+	configapis "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	workloadapis "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/client"
+	pkgconfig "github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/cnc"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+const (
+	defaultClearUnusedSPDPeriod = 10 * time.Minute
+)
+
+const (
+	metricsNameGetCNCTargetConfigFailed = "spd_manager_get_cnc_target_failed"
+	metricsNameUpdateCacheFailed        = "spd_manager_update_cache_failed"
+	metricsNameCacheNotFound            = "spd_manager_cache_not_found"
+)
+
+type GetPodSPDNameFunc func(pod *v1.Pod) (string, error)
+
+type SPDFetcher interface {
+	// GetSPD get spd for given pod
+	GetSPD(ctx context.Context, pod *v1.Pod) (*workloadapis.ServiceProfileDescriptor, error)
+
+	// Run async loop to clear unused spd
+	Run(ctx context.Context)
+}
+
+type spdFetcher struct {
+	started *atomic.Bool
+	mux     sync.Mutex
+
+	client            *client.GenericClientSet
+	emitter           metrics.MetricEmitter
+	cncFetcher        cnc.CNCFetcher
+	checkpointManager checkpointmanager.CheckpointManager
+	getPodSPDNameFunc GetPodSPDNameFunc
+
+	ServiceProfileCacheTTL time.Duration
+
+	// spdCache is a cache of namespace/name to current target spd
+	spdCache *Cache
+}
+
+// NewSPDFetcher creates a spd manager to implement SPDFetcher
+func NewSPDFetcher(clientSet *client.GenericClientSet, emitter metrics.MetricEmitter,
+	cncFetcher cnc.CNCFetcher, conf *pkgconfig.Configuration) (SPDFetcher, error) {
+	checkpointManager, err := checkpointmanager.NewCheckpointManager(conf.CheckpointManagerDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize checkpoint manager: %v", err)
+	}
+
+	m := &spdFetcher{
+		started:                atomic.NewBool(false),
+		client:                 clientSet,
+		emitter:                emitter,
+		checkpointManager:      checkpointManager,
+		cncFetcher:             cncFetcher,
+		ServiceProfileCacheTTL: conf.ServiceProfileCacheTTL,
+	}
+
+	m.getPodSPDNameFunc = util.GetPodSPDName
+	m.spdCache = NewSPDCache(checkpointManager, defaultClearUnusedSPDPeriod)
+
+	return m, nil
+}
+
+func (s *spdFetcher) GetSPD(ctx context.Context, pod *v1.Pod) (*workloadapis.ServiceProfileDescriptor, error) {
+	spdName, err := s.getPodSPDNameFunc(pod)
+	if err != nil {
+		return nil, fmt.Errorf("get pod spd name failed: %v", err)
+	}
+
+	return s.getSPDByNamespaceName(ctx, pod.GetNamespace(), spdName)
+}
+
+// SetGetPodSPDNameFunc set get spd name function to override default getPodSPDNameFunc before started
+func (s *spdFetcher) SetGetPodSPDNameFunc(f GetPodSPDNameFunc) {
+	if s.started.Load() {
+		klog.Warningf("spd manager has already started, not allowed to set implementations")
+		return
+	}
+
+	s.getPodSPDNameFunc = f
+}
+
+func (s *spdFetcher) Run(ctx context.Context) {
+	if s.started.Swap(true) {
+		return
+	}
+
+	s.spdCache.Run(ctx)
+	<-ctx.Done()
+}
+
+func (s *spdFetcher) getSPDByNamespaceName(ctx context.Context, namespace, name string) (*workloadapis.ServiceProfileDescriptor, error) {
+	key := native.GenerateNamespaceNameKey(namespace, name)
+	baseTag := []metrics.MetricTag{
+		{Key: "spdNamespace", Val: namespace},
+		{Key: "spdName", Val: name},
+	}
+
+	// first get spd origin spd from local cache
+	originSPD := s.spdCache.GetSPD(key)
+
+	// get spd current target config from cnc to limit rate of get remote spd by comparing local spd
+	// hash with cnc target config hash, if cnc target config not found it will get remote spd directly
+	targetConfig, err := s.getSPDTargetConfig(ctx, namespace, name)
+	if err != nil {
+		klog.Errorf("[spd-manager] get spd targetConfig config failed: %v, use local cache instead", err)
+		targetConfig = &configapis.TargetConfig{
+			ConfigNamespace: namespace,
+			ConfigName:      name,
+		}
+		_ = s.emitter.StoreInt64(metricsNameGetCNCTargetConfigFailed, 1, metrics.MetricTypeNameCount, baseTag...)
+	}
+
+	// try to update spd cache from remote if cache spd hash is not equal to target config hash,
+	// the rate of getting remote spd will be limited by spd ServiceProfileCacheTTL
+	err = s.updateSPDCacheIfNeed(ctx, originSPD, targetConfig)
+	if err != nil {
+		klog.Errorf("[spd-manager] failed update spd cache from remote: %v, use local cache instead", err)
+		_ = s.emitter.StoreInt64(metricsNameUpdateCacheFailed, 1, metrics.MetricTypeNameCount, baseTag...)
+	}
+
+	// get current spd after cache updated
+	currentSPD := s.spdCache.GetSPD(key)
+	if currentSPD != nil {
+		return currentSPD, nil
+	}
+
+	_ = s.emitter.StoreInt64(metricsNameCacheNotFound, 1, metrics.MetricTypeNameCount, baseTag...)
+
+	return nil, errors.NewNotFound(workloadapis.Resource(workloadapis.ResourceNameServiceProfileDescriptors), name)
+}
+
+// getSPDTargetConfig get spd target config from cnc
+func (s *spdFetcher) getSPDTargetConfig(ctx context.Context, namespace, name string) (*configapis.TargetConfig, error) {
+	currentCNC, err := s.cncFetcher.GetCNC(ctx)
+	if err != nil {
+		return &configapis.TargetConfig{}, err
+	}
+
+	for _, target := range currentCNC.Status.ServiceProfileConfigList {
+		if target.ConfigNamespace == namespace && target.ConfigName == name {
+			return &target, nil
+		}
+	}
+
+	return nil, fmt.Errorf("get target spd %s/%s not found", namespace, name)
+}
+
+// updateSPDCacheIfNeed checks if the previous spd has changed, and
+// re-get from APIServer if the previous is out-of date.
+func (s *spdFetcher) updateSPDCacheIfNeed(ctx context.Context, originSPD *workloadapis.ServiceProfileDescriptor,
+	targetConfig *configapis.TargetConfig) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	if originSPD == nil && targetConfig == nil {
+		return nil
+	}
+
+	now := time.Now()
+	if originSPD == nil || util.GetSPDHash(originSPD) != targetConfig.Hash {
+		key := native.GenerateNamespaceNameKey(targetConfig.ConfigNamespace, targetConfig.ConfigName)
+		if lastFetchRemoteTime := s.spdCache.GetLastFetchRemoteTime(key); lastFetchRemoteTime.Add(s.ServiceProfileCacheTTL).After(time.Now()) {
+			return nil
+		} else {
+			// first update the timestamp of the last attempt to fetch the remote spd to
+			// avoid frequent requests to the api-server in some bad situations
+			s.spdCache.SetLastFetchRemoteTime(key, now)
+		}
+
+		klog.Infof("[spd-manager] spd %s targetConfig hash is changed from %s to %s", key, util.GetSPDHash(originSPD), targetConfig.Hash)
+		spd, err := s.client.InternalClient.WorkloadV1alpha1().ServiceProfileDescriptors(targetConfig.ConfigNamespace).
+			Get(ctx, targetConfig.ConfigName, metav1.GetOptions{ResourceVersion: "0"})
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("get spd %s from remote failed: %v", key, err)
+		} else if err != nil {
+			err = s.spdCache.DeleteSPD(key)
+			if err != nil {
+				return fmt.Errorf("delete spd %s from cache failed: %v", key, err)
+			}
+
+			klog.Infof("[spd-manager] spd %s cache has been deleted", key)
+			return nil
+		}
+
+		err = s.spdCache.SetSPD(key, spd)
+		if err != nil {
+			return err
+		}
+		klog.Infof("[spd-manager] spd %s cache has been updated to %v", key, spd)
+	}
+
+	return nil
+}

--- a/pkg/metaserver/spd/fetcher_test.go
+++ b/pkg/metaserver/spd/fetcher_test.go
@@ -21,23 +21,35 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
 
 	"github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
 	workloadapis "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/consts"
 	katalyst_base "github.com/kubewharf/katalyst-core/cmd/base"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
+	pkgconfig "github.com/kubewharf/katalyst-core/pkg/config"
 	pkgconsts "github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/cnc"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
 
-func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) {
+func generateTestConfiguration(t *testing.T, nodeName string, checkpoint string) *pkgconfig.Configuration {
+	testConfiguration, err := options.NewOptions().Config()
+	require.NoError(t, err)
+	require.NotNil(t, testConfiguration)
+
+	testConfiguration.NodeName = nodeName
+	testConfiguration.CheckpointManagerDir = checkpoint
+	return testConfiguration
+}
+
+func Test_spdManager_GetSPD(t *testing.T) {
 	type fields struct {
 		nodeName string
 		spd      *workloadapis.ServiceProfileDescriptor
@@ -50,11 +62,11 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 		name    string
 		fields  fields
 		args    args
-		want    PerformanceLevel
+		want    *workloadapis.ServiceProfileDescriptor
 		wantErr bool
 	}{
 		{
-			name: "service performance is good",
+			name: "test-1",
 			fields: fields{
 				nodeName: "node-1",
 				spd: &workloadapis.ServiceProfileDescriptor{
@@ -63,31 +75,6 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 						Namespace: "default",
 						Annotations: map[string]string{
 							pkgconsts.ServiceProfileDescriptorAnnotationKeyConfigHash: "3c7e3ff3f218",
-						},
-					},
-					Spec: workloadapis.ServiceProfileDescriptorSpec{
-						BusinessIndicator: []workloadapis.ServiceBusinessIndicatorSpec{
-							{
-								Name: workloadapis.ServiceBusinessIndicatorNameRPCLatency,
-								Indicators: []workloadapis.Indicator{
-									{
-										IndicatorLevel: workloadapis.IndicatorLevelLowerBound,
-										Value:          10,
-									},
-									{
-										IndicatorLevel: workloadapis.IndicatorLevelUpperBound,
-										Value:          100,
-									},
-								},
-							},
-						},
-					},
-					Status: workloadapis.ServiceProfileDescriptorStatus{
-						BusinessStatus: []workloadapis.ServiceBusinessIndicatorStatus{
-							{
-								Name:    workloadapis.ServiceBusinessIndicatorNameRPCLatency,
-								Current: pointer.Float32(40),
-							},
 						},
 					},
 				},
@@ -117,10 +104,18 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 					},
 				},
 			},
-			want: PerformanceLevelGood,
+			want: &workloadapis.ServiceProfileDescriptor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spd-1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						pkgconsts.ServiceProfileDescriptorAnnotationKeyConfigHash: "3c7e3ff3f218",
+					},
+				},
+			},
 		},
 		{
-			name: "service performance large than upper bound",
+			name: "test-2",
 			fields: fields{
 				nodeName: "node-1",
 				spd: &workloadapis.ServiceProfileDescriptor{
@@ -135,20 +130,6 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 						BusinessIndicator: []workloadapis.ServiceBusinessIndicatorSpec{
 							{
 								Name: workloadapis.ServiceBusinessIndicatorNameRPCLatency,
-								Indicators: []workloadapis.Indicator{
-									{
-										IndicatorLevel: workloadapis.IndicatorLevelUpperBound,
-										Value:          50,
-									},
-								},
-							},
-						},
-					},
-					Status: workloadapis.ServiceProfileDescriptorStatus{
-						BusinessStatus: []workloadapis.ServiceBusinessIndicatorStatus{
-							{
-								Name:    workloadapis.ServiceBusinessIndicatorNameRPCLatency,
-								Current: pointer.Float32(60),
 							},
 						},
 					},
@@ -179,69 +160,22 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 					},
 				},
 			},
-			want: PerformanceLevelPoor,
-		},
-		{
-			name: "service performance lower than lower bound",
-			fields: fields{
-				nodeName: "node-1",
-				spd: &workloadapis.ServiceProfileDescriptor{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "spd-1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							pkgconsts.ServiceProfileDescriptorAnnotationKeyConfigHash: "3c7e3ff3f218",
-						},
-					},
-					Spec: workloadapis.ServiceProfileDescriptorSpec{
-						BusinessIndicator: []workloadapis.ServiceBusinessIndicatorSpec{
-							{
-								Name: workloadapis.ServiceBusinessIndicatorNameRPCLatency,
-								Indicators: []workloadapis.Indicator{
-									{
-										IndicatorLevel: workloadapis.IndicatorLevelLowerBound,
-										Value:          20,
-									},
-								},
-							},
-						},
-					},
-					Status: workloadapis.ServiceProfileDescriptorStatus{
-						BusinessStatus: []workloadapis.ServiceBusinessIndicatorStatus{
-							{
-								Name:    workloadapis.ServiceBusinessIndicatorNameRPCLatency,
-								Current: pointer.Float32(10),
-							},
-						},
+			want: &workloadapis.ServiceProfileDescriptor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "spd-1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						pkgconsts.ServiceProfileDescriptorAnnotationKeyConfigHash: "3c7e3ff3f218",
 					},
 				},
-				cnc: &v1alpha1.CustomNodeConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-					},
-					Status: v1alpha1.CustomNodeConfigStatus{
-						ServiceProfileConfigList: []v1alpha1.TargetConfig{
-							{
-								ConfigName:      "spd-1",
-								ConfigNamespace: "default",
-								Hash:            "3c7e3ff3f218",
-							},
+				Spec: workloadapis.ServiceProfileDescriptorSpec{
+					BusinessIndicator: []workloadapis.ServiceBusinessIndicatorSpec{
+						{
+							Name: workloadapis.ServiceBusinessIndicatorNameRPCLatency,
 						},
 					},
 				},
 			},
-			args: args{
-				pod: &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pod-1",
-						Namespace: "default",
-						Annotations: map[string]string{
-							consts.PodAnnotationSPDNameKey: "spd-1",
-						},
-					},
-				},
-			},
-			want: PerformanceLevelPerfect,
 		},
 	}
 	for _, tt := range tests {
@@ -262,19 +196,24 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 			require.NoError(t, err)
 			require.NotNil(t, s)
 
-			m, err := NewServiceProfilingManager(genericCtx.Client, metrics.DummyMetrics{}, cncFetcher, conf)
-			require.NoError(t, err)
+			ctx := context.TODO()
+			go s.Run(ctx)
+			time.Sleep(1 * time.Second)
 
-			go m.Run(context.Background())
-
-			got, err := m.ServiceBusinessPerformanceLevel(context.Background(), tt.args.pod)
+			got, err := s.GetSPD(ctx, tt.args.pod)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ServiceBusinessPerformanceLevel() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetSPD() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("ServiceBusinessPerformanceLevel() got = %v, want %v", got, tt.want)
+			require.Equal(t, tt.want, got)
+
+			// second GetSPD from local cache
+			got, err = s.GetSPD(ctx, tt.args.pod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetSPD() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/util/spd_indicator.go
+++ b/pkg/util/spd_indicator.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/utils/pointer"
+
+	workloadapis "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
+)
+
+type IndicatorTarget struct {
+	UpperBound *float32
+	LowerBound *float32
+}
+
+// GetServiceBusinessIndicatorTarget get service business indicator target from spd
+// if there are duplicate upper bound or lower bound, return error
+func GetServiceBusinessIndicatorTarget(spd *workloadapis.ServiceProfileDescriptor) (map[string]IndicatorTarget, error) {
+	var errList []error
+	indicators := make(map[string]IndicatorTarget)
+	for _, indicator := range spd.Spec.BusinessIndicator {
+		_, ok := indicators[string(indicator.Name)]
+		if ok {
+			errList = append(errList, fmt.Errorf("duplicate indicator %s", indicator.Name))
+			continue
+		}
+
+		targetIndicator := IndicatorTarget{}
+		for _, target := range indicator.Indicators {
+			switch target.IndicatorLevel {
+			case workloadapis.IndicatorLevelUpperBound:
+				if targetIndicator.UpperBound != nil {
+					errList = append(errList, fmt.Errorf("duplicate upper bound for indicator %s", indicator.Name))
+					continue
+				}
+				targetIndicator.UpperBound = pointer.Float32(target.Value)
+			case workloadapis.IndicatorLevelLowerBound:
+				if targetIndicator.LowerBound != nil {
+					errList = append(errList, fmt.Errorf("duplicate lower bound for indicator %s", indicator.Name))
+					continue
+				}
+				targetIndicator.LowerBound = pointer.Float32(target.Value)
+			default:
+				errList = append(errList, fmt.Errorf("invalid indicator level %s for indicator %s", target.IndicatorLevel, indicator.Name))
+				continue
+			}
+		}
+
+		// check whether target indicator is validated
+		if targetIndicator.LowerBound != nil && targetIndicator.UpperBound != nil &&
+			*targetIndicator.LowerBound > *targetIndicator.UpperBound {
+			errList = append(errList, fmt.Errorf("lower bound %v is higher than uppoer bound %v for indicator %s",
+				*targetIndicator.LowerBound, *targetIndicator.UpperBound, indicator.Name))
+			continue
+		}
+
+		indicators[string(indicator.Name)] = targetIndicator
+	}
+
+	if len(errList) > 0 {
+		return nil, fmt.Errorf("failed to get service business indicators: %v", errList)
+	}
+
+	return indicators, nil
+}
+
+// GetServiceBusinessIndicatorValue returns the current value of business indicators
+// The returned map is a map from indicator name to its current value, and if duplicate
+// indicators are found, the first one is used
+func GetServiceBusinessIndicatorValue(spd *workloadapis.ServiceProfileDescriptor) (map[string]float32, error) {
+	indicatorValues := make(map[string]float32)
+	for _, indicator := range spd.Status.BusinessStatus {
+		if indicator.Current == nil {
+			continue
+		}
+
+		_, ok := indicatorValues[string(indicator.Name)]
+		if ok {
+			continue
+		}
+
+		indicatorValues[string(indicator.Name)] = *indicator.Current
+	}
+
+	return indicatorValues, nil
+}


### PR DESCRIPTION
#### What type of PR is this?
Features
#### What this PR does / why we need it:
We need use a service profiling manager implemented in the meta server to manage service level status for each pod. For example, agents can use it to judge whether this pod can be reclaimed according to this service performance.