### PR TITLE
feat(eviction): support dryrun plugin

### DIFF
--- a/cmd/katalyst-agent/app/options/eviction/eviction_base.go
+++ b/cmd/katalyst-agent/app/options/eviction/eviction_base.go
@@ -67,7 +67,7 @@ func (o *GenericEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"A list of eviction plugins to enable. '*' enables all on-by-default eviction plugins, 'foo' enables the eviction plugin "+
 		"named 'foo', '-foo' disables the eviction plugin named 'foo'"))
 
-	fs.StringSliceVar(&o.DryRunPlugins, "dry-run-plugins", o.DryRunPlugins, fmt.Sprintf(" A list of "+
+	fs.StringSliceVar(&o.DryRunPlugins, "eviction-dry-run-plugins", o.DryRunPlugins, fmt.Sprintf(" A list of "+
 		"eviction plugins to dry run. If a plugin in this list, it will enter dry run mode"))
 
 	fs.DurationVar(&o.ConditionTransitionPeriod, "eviction-condition-transition-period", o.ConditionTransitionPeriod,

--- a/cmd/katalyst-agent/app/options/eviction/eviction_base.go
+++ b/cmd/katalyst-agent/app/options/eviction/eviction_base.go
@@ -88,7 +88,7 @@ func (o *GenericEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 // ApplyTo fills up config with options
 func (o *GenericEvictionOptions) ApplyTo(c *evictionconfig.GenericEvictionConfiguration) error {
 	c.InnerPlugins = o.InnerPlugins
-	c.DryrunPlugins = o.DryRunPlugins
+	c.DryRunPlugins = o.DryRunPlugins
 	c.ConditionTransitionPeriod = o.ConditionTransitionPeriod
 	c.EvictionManagerSyncPeriod = o.EvictionManagerSyncPeriod
 	c.EvictionSkippedAnnotationKeys.Insert(o.EvictionSkippedAnnotationKeys...)

--- a/cmd/katalyst-agent/app/options/eviction/eviction_base.go
+++ b/cmd/katalyst-agent/app/options/eviction/eviction_base.go
@@ -30,6 +30,8 @@ import (
 type GenericEvictionOptions struct {
 	InnerPlugins []string
 
+	DryRunPlugins []string
+
 	// ConditionTransitionPeriod is duration the eviction manager has to wait before transitioning out of a condition.
 	ConditionTransitionPeriod time.Duration
 
@@ -48,6 +50,7 @@ type GenericEvictionOptions struct {
 func NewGenericEvictionOptions() *GenericEvictionOptions {
 	return &GenericEvictionOptions{
 		InnerPlugins:                  []string{},
+		DryRunPlugins:                 []string{},
 		ConditionTransitionPeriod:     5 * time.Minute,
 		EvictionManagerSyncPeriod:     5 * time.Second,
 		EvictionSkippedAnnotationKeys: []string{},
@@ -63,6 +66,9 @@ func (o *GenericEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringSliceVar(&o.InnerPlugins, "eviction-plugins", o.InnerPlugins, fmt.Sprintf(""+
 		"A list of eviction plugins to enable. '*' enables all on-by-default eviction plugins, 'foo' enables the eviction plugin "+
 		"named 'foo', '-foo' disables the eviction plugin named 'foo'"))
+
+	fs.StringSliceVar(&o.DryRunPlugins, "dry-run-plugins", o.DryRunPlugins, fmt.Sprintf(" A list of "+
+		"eviction plugins to dry run. If a plugin in this list, it will enter dry run mode"))
 
 	fs.DurationVar(&o.ConditionTransitionPeriod, "eviction-condition-transition-period", o.ConditionTransitionPeriod,
 		"duration the eviction manager has to wait before transitioning out of a condition")
@@ -82,6 +88,7 @@ func (o *GenericEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 // ApplyTo fills up config with options
 func (o *GenericEvictionOptions) ApplyTo(c *evictionconfig.GenericEvictionConfiguration) error {
 	c.InnerPlugins = o.InnerPlugins
+	c.DryrunPlugins = o.DryRunPlugins
 	c.ConditionTransitionPeriod = o.ConditionTransitionPeriod
 	c.EvictionManagerSyncPeriod = o.EvictionManagerSyncPeriod
 	c.EvictionSkippedAnnotationKeys.Insert(o.EvictionSkippedAnnotationKeys...)

--- a/pkg/agent/evictionmanager/eviction_resp_collector.go
+++ b/pkg/agent/evictionmanager/eviction_resp_collector.go
@@ -1,0 +1,219 @@
+/*
+ *
+ * Copyright 2022 The Katalyst Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package evictionmanager
+
+import (
+	"fmt"
+
+	//nolint
+	"github.com/golang/protobuf/proto"
+	v1 "k8s.io/api/core/v1"
+
+	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/agent/evictionmanager/rule"
+	pkgconfig "github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+// evictionRespCollector is used to collect eviction result from plugins, it also handles some logic such as dry run.
+type evictionRespCollector struct {
+	conf *pkgconfig.Configuration
+
+	currentMetThresholds map[string]*pluginapi.ThresholdMetResponse
+	currentConditions    map[string]*pluginapi.Condition
+
+	// softEvictPods are candidates (among which only one will be chosen);
+	// forceEvictPods are pods that should be killed immediately (but can be withdrawn)
+	softEvictPods  map[string]*rule.RuledEvictPod
+	forceEvictPods map[string]*rule.RuledEvictPod
+
+	// emitter is used to emit metrics.
+	emitter metrics.MetricEmitter
+}
+
+func newEvictionRespCollector(conf *pkgconfig.Configuration, emitter metrics.MetricEmitter) *evictionRespCollector {
+	return &evictionRespCollector{
+		conf:                 conf,
+		currentMetThresholds: make(map[string]*pluginapi.ThresholdMetResponse),
+		currentConditions:    make(map[string]*pluginapi.Condition),
+
+		softEvictPods:  make(map[string]*rule.RuledEvictPod),
+		forceEvictPods: make(map[string]*rule.RuledEvictPod),
+
+		emitter: emitter,
+	}
+}
+
+func (e *evictionRespCollector) isDryRun(pluginName string) bool {
+	if e.conf.DryrunPlugins == nil {
+		return false
+	}
+
+	for _, dryRunPlugin := range e.conf.DryrunPlugins {
+		if dryRunPlugin == pluginName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (e *evictionRespCollector) getLogPrefix(dryRun bool) string {
+	if dryRun {
+		return "[DryRun]"
+	}
+
+	return ""
+}
+
+func (e *evictionRespCollector) collectEvictPods(pluginName string, resp *pluginapi.GetEvictPodsResponse) {
+	dryRun := e.isDryRun(pluginName)
+
+	evictPods := make([]*pluginapi.EvictPod, 0, len(resp.EvictPods))
+	for i, evictPod := range resp.EvictPods {
+		if evictPod == nil || evictPod.Pod == nil {
+			general.Errorf("%v skip nil evict pod of plugin: %s", e.getLogPrefix(dryRun), pluginName)
+			continue
+		}
+
+		general.Infof("%v plugin: %s requests to evict pod: %s/%s with reason: %s, forceEvict: %v",
+			e.getLogPrefix(dryRun), pluginName, evictPod.Pod.Namespace, evictPod.Pod.Name, evictPod.Reason, evictPod.ForceEvict)
+
+		if dryRun {
+			_ = e.emitter.StoreInt64(MetricsNameDryrunVictimPodCNT, 1, metrics.MetricTypeNameRaw,
+				metrics.MetricTag{Key: "name", Val: pluginName})
+		} else {
+			evictPods = append(evictPods, resp.EvictPods[i])
+		}
+	}
+
+	for _, evictPod := range evictPods {
+
+		// to avoid plugins forget to set EvictionPluginName property
+		evictPod.EvictionPluginName = pluginName
+
+		if evictPod.ForceEvict {
+			e.getForceEvictPods()[string(evictPod.Pod.UID)] = &rule.RuledEvictPod{
+				EvictPod: proto.Clone(evictPod).(*pluginapi.EvictPod),
+				Scope:    rule.EvictionScopeForce,
+			}
+		} else {
+			e.getSoftEvictPods()[string(evictPod.Pod.UID)] = &rule.RuledEvictPod{
+				EvictPod: proto.Clone(evictPod).(*pluginapi.EvictPod),
+				Scope:    rule.EvictionScopeSoft,
+			}
+		}
+	}
+
+	if resp.Condition != nil && resp.Condition.MetCondition {
+		general.Infof("%v plugin: %s requests set condition: %s of type: %s",
+			e.getLogPrefix(dryRun), pluginName, resp.Condition.ConditionName, resp.Condition.ConditionType.String())
+
+		if !dryRun {
+			e.getCurrentConditions()[resp.Condition.ConditionName] = proto.Clone(resp.Condition).(*pluginapi.Condition)
+		}
+	}
+}
+
+func (e *evictionRespCollector) collectMetThreshold(pluginName string, resp *pluginapi.ThresholdMetResponse) {
+	dryRun := e.isDryRun(pluginName)
+
+	if resp.MetType == pluginapi.ThresholdMetType_NOT_MET {
+		general.InfofV(6, "%v plugin: %s threshold isn't met", e.getLogPrefix(dryRun), pluginName)
+		return
+	}
+
+	// save thresholds to currentMetThreshold even in dry run mode so that GetTopEvictionPods function will be called
+	e.getCurrentMetThresholds()[pluginName] = proto.Clone(resp).(*pluginapi.ThresholdMetResponse)
+
+	general.Infof("%v plugin: %s met threshold: %s", e.getLogPrefix(dryRun), pluginName, resp.String())
+	if resp.Condition != nil && resp.Condition.MetCondition {
+		general.Infof("%v plugin: %s requests to set condition: %s of type: %s",
+			e.getLogPrefix(dryRun), pluginName, resp.Condition.ConditionName, resp.Condition.ConditionType.String())
+
+		if !dryRun {
+			e.getCurrentConditions()[resp.Condition.ConditionName] = proto.Clone(resp.Condition).(*pluginapi.Condition)
+		}
+	}
+}
+
+func (e *evictionRespCollector) collectTopEvictionPods(pluginName string, threshold *pluginapi.ThresholdMetResponse, resp *pluginapi.GetTopEvictionPodsResponse) {
+	dryRun := e.isDryRun(pluginName)
+
+	targetPods := make([]*v1.Pod, 0, len(resp.TargetPods))
+	for i, pod := range resp.TargetPods {
+		if pod == nil {
+			continue
+		}
+
+		if dryRun {
+			general.Infof("%v plugin %v request to evict topN pod %v/%v, reason: met threshold in scope [%v]",
+				e.getLogPrefix(dryRun), pluginName, pod.Namespace, pod.Namespace, threshold.EvictionScope)
+
+			_ = e.emitter.StoreInt64(MetricsNameDryrunVictimPodCNT, 1, metrics.MetricTypeNameRaw,
+				metrics.MetricTag{Key: "name", Val: pluginName})
+		} else {
+			targetPods = append(targetPods, resp.TargetPods[i])
+		}
+	}
+
+	for _, pod := range targetPods {
+		deletionOptions := resp.DeletionOptions
+		reason := fmt.Sprintf(" met threshold in scope: %s from plugin: %s", threshold.EvictionScope, pluginName)
+
+		forceEvictPod := e.getForceEvictPods()[string(pod.UID)]
+		if forceEvictPod != nil {
+			if deletionOptions != nil && forceEvictPod.EvictPod.DeletionOptions != nil {
+				deletionOptions.GracePeriodSeconds = general.MaxInt64(deletionOptions.GracePeriodSeconds,
+					forceEvictPod.EvictPod.DeletionOptions.GracePeriodSeconds)
+			} else if forceEvictPod.EvictPod.DeletionOptions != nil {
+				deletionOptions.GracePeriodSeconds = forceEvictPod.EvictPod.DeletionOptions.GracePeriodSeconds
+			}
+			reason = fmt.Sprintf("%s; %s", reason, forceEvictPod.EvictPod.Reason)
+		}
+
+		e.getForceEvictPods()[string(pod.UID)] = &rule.RuledEvictPod{
+			EvictPod: &pluginapi.EvictPod{
+				Pod:                pod.DeepCopy(),
+				Reason:             reason,
+				DeletionOptions:    deletionOptions,
+				ForceEvict:         true,
+				EvictionPluginName: pluginName, // only count this pod to one plugin
+			},
+			Scope: threshold.EvictionScope,
+		}
+	}
+}
+
+func (e *evictionRespCollector) getCurrentConditions() map[string]*pluginapi.Condition {
+	return e.currentConditions
+}
+
+func (e *evictionRespCollector) getCurrentMetThresholds() map[string]*pluginapi.ThresholdMetResponse {
+	return e.currentMetThresholds
+}
+
+func (e *evictionRespCollector) getSoftEvictPods() map[string]*rule.RuledEvictPod {
+	return e.softEvictPods
+}
+
+func (e *evictionRespCollector) getForceEvictPods() map[string]*rule.RuledEvictPod {
+	return e.forceEvictPods
+}

--- a/pkg/agent/evictionmanager/eviction_resp_collector.go
+++ b/pkg/agent/evictionmanager/eviction_resp_collector.go
@@ -1,20 +1,18 @@
 /*
- *
- * Copyright 2022 The Katalyst Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * /
- */
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package evictionmanager
 

--- a/pkg/agent/evictionmanager/eviction_resp_collector.go
+++ b/pkg/agent/evictionmanager/eviction_resp_collector.go
@@ -60,17 +60,11 @@ func newEvictionRespCollector(conf *pkgconfig.Configuration, emitter metrics.Met
 }
 
 func (e *evictionRespCollector) isDryRun(pluginName string) bool {
-	if e.conf.DryrunPlugins == nil {
+	if e.conf.DryRunPlugins == nil {
 		return false
 	}
 
-	for _, dryRunPlugin := range e.conf.DryrunPlugins {
-		if dryRunPlugin == pluginName {
-			return true
-		}
-	}
-
-	return false
+	return general.IsNameEnabled(pluginName, nil, e.conf.DryRunPlugins)
 }
 
 func (e *evictionRespCollector) getLogPrefix(dryRun bool) string {

--- a/pkg/agent/evictionmanager/eviction_resp_collector.go
+++ b/pkg/agent/evictionmanager/eviction_resp_collector.go
@@ -47,7 +47,7 @@ type evictionRespCollector struct {
 }
 
 func newEvictionRespCollector(conf *pkgconfig.Configuration, emitter metrics.MetricEmitter) *evictionRespCollector {
-	return &evictionRespCollector{
+	collector := &evictionRespCollector{
 		conf:                 conf,
 		currentMetThresholds: make(map[string]*pluginapi.ThresholdMetResponse),
 		currentConditions:    make(map[string]*pluginapi.Condition),
@@ -57,14 +57,16 @@ func newEvictionRespCollector(conf *pkgconfig.Configuration, emitter metrics.Met
 
 		emitter: emitter,
 	}
+	general.Infof("dry run plugins is %v", conf.GenericEvictionConfiguration.DryRunPlugins)
+	return collector
 }
 
 func (e *evictionRespCollector) isDryRun(pluginName string) bool {
-	if e.conf.DryRunPlugins == nil {
+	if e.conf.GenericEvictionConfiguration.DryRunPlugins == nil {
 		return false
 	}
 
-	return general.IsNameEnabled(pluginName, nil, e.conf.DryRunPlugins)
+	return general.IsNameEnabled(pluginName, nil, e.conf.GenericEvictionConfiguration.DryRunPlugins)
 }
 
 func (e *evictionRespCollector) getLogPrefix(dryRun bool) string {

--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/klog/v2"
 	clocks "k8s.io/utils/clock"
 
 	"github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
@@ -50,9 +49,10 @@ import (
 )
 
 const (
-	MetricsNameVictimPodCNT    = "victims_cnt"
-	MetricsNameRunningPodCNT   = "running_pod_cnt"
-	MetricsNameCandidatePodCNT = "candidate_pod_cnt"
+	MetricsNameVictimPodCNT       = "victims_cnt"
+	MetricsNameRunningPodCNT      = "running_pod_cnt"
+	MetricsNameCandidatePodCNT    = "candidate_pod_cnt"
+	MetricsNameDryrunVictimPodCNT = "dryrun_victims_cnt"
 )
 
 // LatestCNRGetter returns the latest CNR resources.
@@ -93,6 +93,194 @@ type EvictionManger struct {
 	conditionsLastObservedAt map[string]conditionObservedAt
 	// thresholdsFirstObservedAt map eviction plugin name to *pluginapi.Condition with firstly observed timestamp.
 	thresholdsFirstObservedAt map[string]thresholdObservedAt
+}
+
+// evictionRespCollector is used to collect eviction result from plugins, it also handles some logic such as dryrun.
+type evictionRespCollector struct {
+	conf *pkgconfig.Configuration
+
+	currentMetThresholds map[string]*pluginapi.ThresholdMetResponse
+	currentConditions    map[string]*pluginapi.Condition
+
+	// softEvictPods are candidates (among which only one will be chosen);
+	// forceEvictPods are pods that should be killed immediately (but can be withdrawn)
+	softEvictPods  map[string]*rule.RuledEvictPod
+	forceEvictPods map[string]*rule.RuledEvictPod
+
+	// emitter is used to emit metrics.
+	emitter metrics.MetricEmitter
+}
+
+func newEvictionRespCollector(conf *pkgconfig.Configuration, emitter metrics.MetricEmitter) *evictionRespCollector {
+	return &evictionRespCollector{
+		conf:                 conf,
+		currentMetThresholds: make(map[string]*pluginapi.ThresholdMetResponse),
+		currentConditions:    make(map[string]*pluginapi.Condition),
+
+		softEvictPods:  make(map[string]*rule.RuledEvictPod),
+		forceEvictPods: make(map[string]*rule.RuledEvictPod),
+
+		emitter: emitter,
+	}
+}
+
+func (e *evictionRespCollector) dryrun(pluginName string) bool {
+	if e.conf.DryrunPlugins == nil {
+		return false
+	}
+
+	for _, dryrunPlugin := range e.conf.DryrunPlugins {
+		if dryrunPlugin == pluginName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (e *evictionRespCollector) collectEvictPods(pluginName string, resp *pluginapi.GetEvictPodsResponse) {
+	dryrun := e.dryrun(pluginName)
+	if dryrun {
+		for _, evictPod := range resp.EvictPods {
+			if evictPod == nil || evictPod.Pod == nil {
+				general.Errorf("[dryrun] skip nil evict pod of plugin: %s", pluginName)
+				continue
+			}
+
+			general.Infof("[dryrun]plugin: %s requests to evict pod: %s/%s with reason: %s, forceEvict: %v",
+				pluginName, evictPod.Pod.Namespace, evictPod.Pod.Name, evictPod.Reason, evictPod.ForceEvict)
+		}
+
+		if resp.Condition != nil && resp.Condition.MetCondition {
+			general.Infof("[dryrun]plugin: %s requests set condition: %s of type: %s",
+				pluginName, resp.Condition.ConditionName, resp.Condition.ConditionType.String())
+		}
+
+		_ = e.emitter.StoreInt64(MetricsNameDryrunVictimPodCNT, int64(len(resp.EvictPods)), metrics.MetricTypeNameRaw,
+			metrics.MetricTag{Key: "name", Val: pluginName})
+		return
+	}
+
+	for _, evictPod := range resp.EvictPods {
+		if evictPod == nil || evictPod.Pod == nil {
+			general.Errorf(" skip nil evict pod of plugin: %s", pluginName)
+			continue
+		}
+
+		// to avoid plugins forget to set EvictionPluginName property
+		evictPod.EvictionPluginName = pluginName
+		general.Infof("plugin: %s requests to evict pod: %s/%s with reason: %s, forceEvict: %v",
+			pluginName, evictPod.Pod.Namespace, evictPod.Pod.Name, evictPod.Reason, evictPod.ForceEvict)
+
+		if evictPod.ForceEvict {
+			e.forceEvictPods[string(evictPod.Pod.UID)] = &rule.RuledEvictPod{
+				EvictPod: proto.Clone(evictPod).(*pluginapi.EvictPod),
+				Scope:    rule.EvictionScopeForce,
+			}
+		} else {
+			e.softEvictPods[string(evictPod.Pod.UID)] = &rule.RuledEvictPod{
+				EvictPod: proto.Clone(evictPod).(*pluginapi.EvictPod),
+				Scope:    rule.EvictionScopeSoft,
+			}
+		}
+	}
+
+	if resp.Condition != nil && resp.Condition.MetCondition {
+		general.Infof(" plugin: %s requests set condition: %s of type: %s",
+			pluginName, resp.Condition.ConditionName, resp.Condition.ConditionType.String())
+
+		e.currentConditions[resp.Condition.ConditionName] = proto.Clone(resp.Condition).(*pluginapi.Condition)
+	}
+}
+
+func (e *evictionRespCollector) collectMetThreshold(pluginName string, resp *pluginapi.ThresholdMetResponse) {
+	if resp.MetType == pluginapi.ThresholdMetType_NOT_MET {
+		general.InfofV(6, " plugin: %s threshold isn't met", pluginName)
+		return
+	}
+
+	dryrun := e.dryrun(pluginName)
+	if dryrun {
+		// save thresholds to currentMetThreshold so that GetTopEvictionPods function will be called
+		e.currentMetThresholds[pluginName] = proto.Clone(resp).(*pluginapi.ThresholdMetResponse)
+		general.Infof("[dryrun]plugin %v met threshold, threshold value: %v, ObservedValue value: %v, "+
+			"ThresholdOperator: %v, metType: %v, Condition: %v",
+			pluginName, resp.ThresholdValue, resp.ObservedValue, resp.ThresholdOperator, resp.MetType, resp.Condition)
+		return
+	}
+
+	general.Infof(" plugin: %s met threshold: %s", pluginName, resp.String())
+	if resp.Condition != nil && resp.Condition.MetCondition {
+		general.Infof(" plugin: %s requests to set condition: %s of type: %s",
+			pluginName, resp.Condition.ConditionName, resp.Condition.ConditionType.String())
+
+		e.currentConditions[resp.Condition.ConditionName] = proto.Clone(resp.Condition).(*pluginapi.Condition)
+	}
+
+	e.currentMetThresholds[pluginName] = proto.Clone(resp).(*pluginapi.ThresholdMetResponse)
+}
+
+func (e *evictionRespCollector) collectTopEvictionPods(pluginName string, threshold *pluginapi.ThresholdMetResponse, resp *pluginapi.GetTopEvictionPodsResponse) {
+	dryrun := e.dryrun(pluginName)
+	if dryrun {
+		for _, evictPod := range resp.TargetPods {
+			if evictPod == nil {
+				general.Errorf("[dryrun] skip nil evict pod of plugin: %s", pluginName)
+				continue
+			}
+
+			general.Infof("[dryrun]plugin: %s requests to evict TopN pod: %s/%s",
+				pluginName, evictPod.Namespace, evictPod.Name)
+		}
+		return
+	}
+
+	for _, pod := range resp.TargetPods {
+		if pod == nil {
+			continue
+		}
+
+		deletionOptions := resp.DeletionOptions
+		reason := fmt.Sprintf("met threshold in scope: %s from plugin: %s", threshold.EvictionScope, pluginName)
+
+		forceEvictPod := e.forceEvictPods[string(pod.UID)]
+		if forceEvictPod != nil {
+			if deletionOptions != nil && forceEvictPod.EvictPod.DeletionOptions != nil {
+				deletionOptions.GracePeriodSeconds = general.MaxInt64(deletionOptions.GracePeriodSeconds,
+					forceEvictPod.EvictPod.DeletionOptions.GracePeriodSeconds)
+			} else if forceEvictPod.EvictPod.DeletionOptions != nil {
+				deletionOptions.GracePeriodSeconds = forceEvictPod.EvictPod.DeletionOptions.GracePeriodSeconds
+			}
+			reason = fmt.Sprintf("%s; %s", reason, forceEvictPod.EvictPod.Reason)
+		}
+
+		e.forceEvictPods[string(pod.UID)] = &rule.RuledEvictPod{
+			EvictPod: &pluginapi.EvictPod{
+				Pod:                pod.DeepCopy(),
+				Reason:             reason,
+				DeletionOptions:    deletionOptions,
+				ForceEvict:         true,
+				EvictionPluginName: pluginName, // only count this pod to one plugin
+			},
+			Scope: threshold.EvictionScope,
+		}
+	}
+}
+
+func (e *evictionRespCollector) getCurrentConditions() map[string]*pluginapi.Condition {
+	return e.currentConditions
+}
+
+func (e *evictionRespCollector) getCurrentMetThresholds() map[string]*pluginapi.ThresholdMetResponse {
+	return e.currentMetThresholds
+}
+
+func (e *evictionRespCollector) getSoftEvictPods() map[string]*rule.RuledEvictPod {
+	return e.softEvictPods
+}
+
+func (e *evictionRespCollector) getForceEvictPods() map[string]*rule.RuledEvictPod {
+	return e.forceEvictPods
 }
 
 var InnerEvictionPluginsDisabledByDefault = sets.NewString()
@@ -138,7 +326,7 @@ func (m *EvictionManger) getEvictionPlugins(genericClient *client.GenericClientS
 	m.endpointLock.Lock()
 	for pluginName, initFn := range innerEvictionPluginInitializers {
 		if !general.IsNameEnabled(pluginName, InnerEvictionPluginsDisabledByDefault, conf.GenericEvictionConfiguration.InnerPlugins) {
-			klog.Warningf("[eviction manager] %s is disabled", pluginName)
+			general.Warningf(" %s is disabled", pluginName)
 			continue
 		}
 
@@ -149,8 +337,8 @@ func (m *EvictionManger) getEvictionPlugins(genericClient *client.GenericClientS
 }
 
 func (m *EvictionManger) Run(ctx context.Context) {
-	klog.Infof("[eviction manager] run with podKiller %v", m.podKiller.Name())
-	defer klog.Infof("[eviction manager] started")
+	general.Infof(" run with podKiller %v", m.podKiller.Name())
+	defer general.Infof(" started")
 
 	m.podKiller.Start(ctx)
 	go wait.UntilWithContext(ctx, m.sync, m.conf.EvictionManagerSyncPeriod)
@@ -161,24 +349,18 @@ func (m *EvictionManger) Run(ctx context.Context) {
 func (m *EvictionManger) sync(ctx context.Context) {
 	activePods, err := m.metaGetter.GetPodList(ctx, native.PodIsActive)
 	if err != nil {
-		klog.Errorf("failed to list pods from metaServer: %v", err)
+		general.Errorf("failed to list pods from metaServer: %v", err)
 		return
 	}
 
-	klog.Infof("[eviction manager] currently, there are %v active pods", len(activePods))
+	general.Infof(" currently, there are %v active pods", len(activePods))
 	_ = m.emitter.StoreInt64(MetricsNameRunningPodCNT, int64(len(activePods)), metrics.MetricTypeNameRaw)
 
 	pods := native.FilterOutSkipEvictionPods(activePods, m.conf.EvictionSkippedAnnotationKeys, m.conf.EvictionSkippedLabelKeys)
-	klog.Infof("[eviction manager] currently, there are %v candidate pods", len(pods))
+	general.Infof(" currently, there are %v candidate pods", len(pods))
 	_ = m.emitter.StoreInt64(MetricsNameCandidatePodCNT, int64(len(pods)), metrics.MetricTypeNameRaw)
 
-	currentMetThresholds := make(map[string]*pluginapi.ThresholdMetResponse)
-	currentConditions := make(map[string]*pluginapi.Condition)
-
-	// softEvictPods are candidates (among which only one will be chosen);
-	// forceEvictPods are pods that should be killed immediately (but can be withdrawn)
-	softEvictPods := make(map[string]*rule.RuledEvictPod)
-	forceEvictPods := make(map[string]*rule.RuledEvictPod)
+	collector := newEvictionRespCollector(m.conf, m.emitter)
 
 	m.endpointLock.RLock()
 	for pluginName, ep := range m.endpoints {
@@ -186,77 +368,35 @@ func (m *EvictionManger) sync(ctx context.Context) {
 			ActivePods: pods,
 		})
 		if err != nil {
-			klog.Errorf("[eviction manager] calling GetEvictPods of plugin: %s failed with error: %v", pluginName, err)
+			general.Errorf(" calling GetEvictPods of plugin: %s failed with error: %v", pluginName, err)
 		} else if getEvictResp == nil {
-			klog.Errorf("[eviction manager] calling GetEvictPods of plugin: %s and getting nil resp", pluginName)
+			general.Errorf(" calling GetEvictPods of plugin: %s and getting nil resp", pluginName)
 		} else {
-			klog.Infof("[eviction manager] GetEvictPods of plugin: %s with %d pods to evict", pluginName, len(getEvictResp.EvictPods))
-			for _, evictPod := range getEvictResp.EvictPods {
-				if evictPod == nil || evictPod.Pod == nil {
-					klog.Errorf("[eviction manager] skip nil evict pod of plugin: %s", pluginName)
-					continue
-				}
-
-				// to avoid plugins forget to set EvictionPluginName property
-				evictPod.EvictionPluginName = pluginName
-				klog.Infof("[eviction manager] plugin: %s requests to evict pod: %s/%s with reason: %s, forceEvict: %v",
-					pluginName, evictPod.Pod.Namespace, evictPod.Pod.Name, evictPod.Reason, evictPod.ForceEvict)
-
-				if evictPod.ForceEvict {
-					forceEvictPods[string(evictPod.Pod.UID)] = &rule.RuledEvictPod{
-						EvictPod: proto.Clone(evictPod).(*pluginapi.EvictPod),
-						Scope:    rule.EvictionScopeForce,
-					}
-				} else {
-					softEvictPods[string(evictPod.Pod.UID)] = &rule.RuledEvictPod{
-						EvictPod: proto.Clone(evictPod).(*pluginapi.EvictPod),
-						Scope:    rule.EvictionScopeSoft,
-					}
-				}
-			}
-
-			if getEvictResp.Condition != nil && getEvictResp.Condition.MetCondition {
-				klog.Infof("[eviction manager] plugin: %s requests set condition: %s of type: %s",
-					pluginName, getEvictResp.Condition.ConditionName, getEvictResp.Condition.ConditionType.String())
-
-				currentConditions[getEvictResp.Condition.ConditionName] = proto.Clone(getEvictResp.Condition).(*pluginapi.Condition)
-			}
+			general.Infof(" GetEvictPods of plugin: %s with %d pods to evict", pluginName, len(getEvictResp.EvictPods))
+			collector.collectEvictPods(pluginName, getEvictResp)
 		}
 
 		metResp, err := ep.ThresholdMet(context.Background())
 		if err != nil {
-			klog.Errorf("[eviction manager] calling ThresholdMet of plugin: %s failed with error: %v", pluginName, err)
+			general.Errorf(" calling ThresholdMet of plugin: %s failed with error: %v", pluginName, err)
 			continue
 		} else if metResp == nil {
-			klog.Errorf("[eviction manager] calling ThresholdMet of plugin: %s and getting nil resp", pluginName)
+			general.Errorf(" calling ThresholdMet of plugin: %s and getting nil resp", pluginName)
 			continue
 		}
 
-		if metResp.MetType == pluginapi.ThresholdMetType_NOT_MET {
-			klog.V(6).Infof("[eviction manager] plugin: %s threshold isn't met", pluginName)
-			continue
-		}
-
-		klog.Infof("[eviction manager] plugin: %s met threshold: %s", pluginName, metResp.String())
-		if metResp.Condition != nil && metResp.Condition.MetCondition {
-			klog.Infof("[eviction manager] plugin: %s requests to set condition: %s of type: %s",
-				pluginName, metResp.Condition.ConditionName, metResp.Condition.ConditionType.String())
-
-			currentConditions[metResp.Condition.ConditionName] = proto.Clone(metResp.Condition).(*pluginapi.Condition)
-		}
-
-		currentMetThresholds[pluginName] = proto.Clone(metResp).(*pluginapi.ThresholdMetResponse)
+		collector.collectMetThreshold(pluginName, metResp)
 	}
 	m.endpointLock.RUnlock()
 
 	// track when a threshold was first observed
 	now := m.clock.Now()
-	thresholdsFirstObservedAt := thresholdsFirstObservedAt(currentMetThresholds, m.thresholdsFirstObservedAt, now)
+	thresholdsFirstObservedAt := thresholdsFirstObservedAt(collector.currentMetThresholds, m.thresholdsFirstObservedAt, now)
 	thresholdsMet := thresholdsMetGracePeriod(thresholdsFirstObservedAt, now)
 	logConfirmedThresholdMet(thresholdsMet)
 
 	// track when a condition was last observed
-	conditionsLastObservedAt := conditionsLastObservedAt(currentConditions, m.conditionsLastObservedAt, now)
+	conditionsLastObservedAt := conditionsLastObservedAt(collector.currentConditions, m.conditionsLastObservedAt, now)
 	// conditions report true if it has been observed within the transition period window
 	conditions := conditionsObservedSince(conditionsLastObservedAt, m.conf.ConditionTransitionPeriod, now)
 	logConfirmedConditions(conditions)
@@ -269,13 +409,13 @@ func (m *EvictionManger) sync(ctx context.Context) {
 
 	for pluginName, threshold := range thresholdsMet {
 		if threshold.MetType != pluginapi.ThresholdMetType_HARD_MET {
-			klog.Infof("[eviction manager] the type: %s of met threshold from plugin: %s isn't  %s", threshold.MetType.String(), pluginName, pluginapi.ThresholdMetType_HARD_MET.String())
+			general.Infof(" the type: %s of met threshold from plugin: %s isn't  %s", threshold.MetType.String(), pluginName, pluginapi.ThresholdMetType_HARD_MET.String())
 			continue
 		}
 
 		m.endpointLock.RLock()
 		if m.endpoints[pluginName] == nil {
-			klog.Errorf("[eviction manager] pluginName points to nil endpoint, can't handle threshold from it")
+			general.Errorf(" pluginName points to nil endpoint, can't handle threshold from it")
 		}
 
 		resp, err := m.endpoints[pluginName].GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
@@ -286,72 +426,47 @@ func (m *EvictionManger) sync(ctx context.Context) {
 
 		m.endpointLock.RUnlock()
 		if err != nil {
-			klog.Errorf("[eviction manager] calling GetTopEvictionPods of plugin: %s failed with error: %v", pluginName, err)
+			general.Errorf(" calling GetTopEvictionPods of plugin: %s failed with error: %v", pluginName, err)
 			continue
 		} else if resp == nil {
-			klog.Errorf("[eviction manager] calling GetTopEvictionPods of plugin: %s and getting nil resp", pluginName)
+			general.Errorf(" calling GetTopEvictionPods of plugin: %s and getting nil resp", pluginName)
 			continue
 		} else if len(resp.TargetPods) == 0 {
-			klog.Warningf("[eviction manager] calling GetTopEvictionPods of plugin: %s and getting empty target pods", pluginName)
+			general.Warningf(" calling GetTopEvictionPods of plugin: %s and getting empty target pods", pluginName)
 			continue
 		}
 
-		for _, pod := range resp.TargetPods {
-			if pod == nil {
-				continue
-			}
-
-			deletionOptions := resp.DeletionOptions
-			reason := fmt.Sprintf("met threshold in scope: %s from plugin: %s", threshold.EvictionScope, pluginName)
-
-			forceEvictPod := forceEvictPods[string(pod.UID)]
-			if forceEvictPod != nil {
-				if deletionOptions != nil && forceEvictPod.EvictPod.DeletionOptions != nil {
-					deletionOptions.GracePeriodSeconds = general.MaxInt64(deletionOptions.GracePeriodSeconds,
-						forceEvictPod.EvictPod.DeletionOptions.GracePeriodSeconds)
-				} else if forceEvictPod.EvictPod.DeletionOptions != nil {
-					deletionOptions.GracePeriodSeconds = forceEvictPod.EvictPod.DeletionOptions.GracePeriodSeconds
-				}
-				reason = fmt.Sprintf("%s; %s", reason, forceEvictPod.EvictPod.Reason)
-			}
-
-			forceEvictPods[string(pod.UID)] = &rule.RuledEvictPod{
-				EvictPod: &pluginapi.EvictPod{
-					Pod:                pod.DeepCopy(),
-					Reason:             reason,
-					DeletionOptions:    deletionOptions,
-					ForceEvict:         true,
-					EvictionPluginName: pluginName, // only count this pod to one plugin
-				},
-				Scope: threshold.EvictionScope,
-			}
-		}
+		collector.collectTopEvictionPods(pluginName, threshold, resp)
 	}
 
+	m.doEvict(collector.getSoftEvictPods(), collector.getForceEvictPods())
+}
+
+func (m *EvictionManger) doEvict(softEvictPods, forceEvictPods map[string]*rule.RuledEvictPod) {
 	softEvictPods = filterOutCandidatePodsWithForcePods(softEvictPods, forceEvictPods)
 	bestSuitedCandidate := m.getEvictPodFromCandidates(softEvictPods)
 	if bestSuitedCandidate != nil && bestSuitedCandidate.Pod != nil {
-		klog.Infof("[eviction manager] choose best suited pod: %s/%s", bestSuitedCandidate.Pod.Namespace, bestSuitedCandidate.Pod.Name)
+		general.Infof(" choose best suited pod: %s/%s", bestSuitedCandidate.Pod.Namespace, bestSuitedCandidate.Pod.Name)
 		forceEvictPods[string(bestSuitedCandidate.Pod.UID)] = bestSuitedCandidate
 	}
 
 	rpList := rule.RuledEvictPodList{}
 	for _, rp := range forceEvictPods {
 		if rp != nil && rp.EvictPod.Pod != nil && m.killStrategy.CandidateValidate(rp) {
-			klog.Infof("[eviction manager] ready to evict %s/%s, reason: %s", rp.Pod.Namespace, rp.Pod.Name, rp.Reason)
+			general.Infof(" ready to evict %s/%s, reason: %s", rp.Pod.Namespace, rp.Pod.Name, rp.Reason)
 			rpList = append(rpList, rp)
 		} else {
-			klog.Warningf("[eviction manager] found nil pod in forceEvictPods")
+			general.Warningf(" found nil pod in forceEvictPods")
 		}
 	}
 
-	err = m.killWithRules(rpList)
+	err := m.killWithRules(rpList)
 	if err != nil {
-		klog.Errorf("[eviction manager] got err: %v in EvictPods", err)
+		general.Errorf(" got err: %v in EvictPods", err)
 		return
 	}
 
-	klog.Infof("[eviction manager] evict %d pods in evictionmanager", len(rpList))
+	general.Infof(" evict %d pods in evictionmanager", len(rpList))
 	_ = m.emitter.StoreInt64(MetricsNameVictimPodCNT, int64(len(rpList)), metrics.MetricTypeNameRaw,
 		metrics.MetricTag{Key: "type", Val: "total"})
 	metricPodsToEvict(m.emitter, rpList)
@@ -359,7 +474,7 @@ func (m *EvictionManger) sync(ctx context.Context) {
 
 // ValidatePlugin validates a plugin if the version is correct and the name has the format of an extended resource
 func (m *EvictionManger) ValidatePlugin(pluginName string, endpoint string, versions []string) error {
-	klog.Infof("[eviction manager] got plugin %s at endpoint %s with versions %v", pluginName, endpoint, versions)
+	general.Infof(" got plugin %s at endpoint %s with versions %v", pluginName, endpoint, versions)
 
 	if !m.isVersionCompatibleWithPlugin(versions) {
 		return fmt.Errorf("manager version, %s, is not among plugin supported versions %v", pluginapi.Version, versions)
@@ -369,11 +484,11 @@ func (m *EvictionManger) ValidatePlugin(pluginName string, endpoint string, vers
 }
 
 func (m *EvictionManger) RegisterPlugin(pluginName string, endpoint string, versions []string) error {
-	klog.Infof("[eviction manager] Registering Plugin %s at endpoint %s", pluginName, endpoint)
+	general.Infof(" Registering Plugin %s at endpoint %s", pluginName, endpoint)
 
 	e, err := endpointpkg.NewRemoteEndpointImpl(endpoint, pluginName)
 	if err != nil {
-		return fmt.Errorf("[eviction manager] failed to dial resource plugin with socketPath %s: %v", endpoint, err)
+		return fmt.Errorf(" failed to dial resource plugin with socketPath %s: %v", endpoint, err)
 	}
 
 	m.registerEndpoint(pluginName, e)
@@ -400,13 +515,13 @@ func (m *EvictionManger) registerEndpoint(pluginName string, e endpointpkg.Endpo
 
 	old, ok := m.endpoints[pluginName]
 	if ok && !old.IsStopped() {
-		klog.Infof("[eviction manager] stop old endpoint: %s", pluginName)
+		general.Infof(" stop old endpoint: %s", pluginName)
 		old.Stop()
 	}
 
 	m.endpoints[pluginName] = e
 
-	klog.Infof("[eviction manager] registered endpoint %s", pluginName)
+	general.Infof(" registered endpoint %s", pluginName)
 }
 
 func (m *EvictionManger) isVersionCompatibleWithPlugin(versions []string) bool {
@@ -507,13 +622,13 @@ func thresholdsMetGracePeriod(thresholdsObservedAt map[string]thresholdObservedA
 
 	for pluginName, observedAt := range thresholdsObservedAt {
 		if observedAt.threshold == nil {
-			klog.Errorf("[eviction manager] met nil threshold in observedAt of plugin: %s", pluginName)
+			general.Errorf(" met nil threshold in observedAt of plugin: %s", pluginName)
 			continue
 		}
 
 		duration := now.Sub(observedAt.timestamp)
 		if duration.Seconds() < float64(observedAt.threshold.GracePeriodSeconds) {
-			klog.InfoS("[eviction manager] eviction criteria not yet met", "threshold", observedAt.threshold.String(), "duration", duration)
+			general.InfoS(" eviction criteria not yet met", "threshold", observedAt.threshold.String(), "duration", duration)
 			continue
 		}
 		results[pluginName] = proto.Clone(observedAt.threshold).(*pluginapi.ThresholdMetResponse)
@@ -538,7 +653,7 @@ func filterOutCandidatePodsWithForcePods(candidateEvictPods, forceEvictPods map[
 
 func logConfirmedConditions(conditions map[string]*pluginapi.Condition) {
 	if len(conditions) == 0 {
-		klog.Infof("[eviction manager] there is no condition confirmed")
+		general.Infof(" there is no condition confirmed")
 	}
 
 	for _, condition := range conditions {
@@ -546,13 +661,13 @@ func logConfirmedConditions(conditions map[string]*pluginapi.Condition) {
 			continue
 		}
 
-		klog.Infof("[eviction manager] confirmed condition: %s", condition.String())
+		general.Infof(" confirmed condition: %s", condition.String())
 	}
 }
 
 func logConfirmedThresholdMet(thresholds map[string]*pluginapi.ThresholdMetResponse) {
 	if len(thresholds) == 0 {
-		klog.Infof("[eviction manager] there is no met threshold confirmed")
+		general.Infof(" there is no met threshold confirmed")
 	}
 
 	for pluginName, threshold := range thresholds {
@@ -560,13 +675,13 @@ func logConfirmedThresholdMet(thresholds map[string]*pluginapi.ThresholdMetRespo
 			continue
 		}
 
-		klog.Infof("[eviction manager] confirmed met threshold: %s from plugin: %s", threshold.String(), pluginName)
+		general.Infof(" confirmed met threshold: %s from plugin: %s", threshold.String(), pluginName)
 	}
 }
 
 func metricPodsToEvict(emitter metrics.MetricEmitter, rpList rule.RuledEvictPodList) {
 	if emitter == nil {
-		klog.Errorf("[eviction manager] metricPodsToEvict got nil emitter")
+		general.Errorf(" metricPodsToEvict got nil emitter")
 		return
 	}
 

--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -99,10 +99,10 @@ var InnerEvictionPluginsDisabledByDefault = sets.NewString()
 
 func NewInnerEvictionPluginInitializers() map[string]plugin.InitFunc {
 	innerEvictionPluginInitializers := make(map[string]plugin.InitFunc)
-	innerEvictionPluginInitializers["reclaimed-resources"] = plugin.NewReclaimedResourcesEvictionPlugin
-	innerEvictionPluginInitializers["numa-memory-pressure"] = memory.NewNumaMemoryPressureEvictionPlugin
-	innerEvictionPluginInitializers["system-memory-pressure"] = memory.NewSystemPressureEvictionPlugin
-	innerEvictionPluginInitializers["rss-overuse"] = memory.NewRssOveruseEvictionPlugin
+	innerEvictionPluginInitializers[plugin.ReclaimedResourcesEvictionPluginName] = plugin.NewReclaimedResourcesEvictionPlugin
+	innerEvictionPluginInitializers[memory.EvictionPluginNameNumaMemoryPressure] = memory.NewNumaMemoryPressureEvictionPlugin
+	innerEvictionPluginInitializers[memory.EvictionPluginNameSystemMemoryPressure] = memory.NewSystemPressureEvictionPlugin
+	innerEvictionPluginInitializers[memory.EvictionPluginNameRssOveruse] = memory.NewRssOveruseEvictionPlugin
 	return innerEvictionPluginInitializers
 }
 

--- a/pkg/agent/evictionmanager/manager_test.go
+++ b/pkg/agent/evictionmanager/manager_test.go
@@ -1,20 +1,18 @@
 /*
- *
- * Copyright 2022 The Katalyst Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * /
- */
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package evictionmanager
 

--- a/pkg/agent/evictionmanager/manager_test.go
+++ b/pkg/agent/evictionmanager/manager_test.go
@@ -1,0 +1,308 @@
+/*
+ *
+ * Copyright 2022 The Katalyst Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package evictionmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
+	endpointpkg "github.com/kubewharf/katalyst-core/pkg/agent/evictionmanager/endpoint"
+	"github.com/kubewharf/katalyst-core/pkg/client"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	evictionconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/eviction"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+var (
+	evictionManagerSyncPeriod = 10 * time.Second
+	pods                      = []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-1",
+				UID:  "pod-1",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-2",
+				UID:  "pod-2",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-3",
+				UID:  "pod-3",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-4",
+				UID:  "pod-4",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-5",
+				UID:  "pod-5",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+	}
+)
+
+func makeConf() *config.Configuration {
+	conf := config.NewConfiguration()
+	conf.EvictionManagerSyncPeriod = evictionManagerSyncPeriod
+	conf.MemoryPressureEvictionPluginConfiguration.DynamicConf.SetGracePeriod(evictionconfig.DefaultGracePeriod)
+
+	return conf
+}
+
+func makeMetaServer() *metaserver.MetaServer {
+	return &metaserver.MetaServer{
+		MetaAgent: &agent.MetaAgent{
+			PodFetcher: &pod.PodFetcherStub{PodList: pods},
+		},
+	}
+}
+
+type pluginSkeleton struct {
+}
+
+func (p *pluginSkeleton) Stop() {
+}
+
+func (p *pluginSkeleton) IsStopped() bool {
+	return false
+}
+
+func (p *pluginSkeleton) StopGracePeriodExpired() bool {
+	return false
+}
+
+type plugin1 struct {
+	pluginSkeleton
+}
+
+func (p *plugin1) ThresholdMet(c context.Context) (*pluginapi.ThresholdMetResponse, error) {
+	return &pluginapi.ThresholdMetResponse{
+		MetType: pluginapi.ThresholdMetType_NOT_MET,
+	}, nil
+}
+
+func (p *plugin1) GetTopEvictionPods(c context.Context, request *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error) {
+	return &pluginapi.GetTopEvictionPodsResponse{}, nil
+}
+
+func (p *plugin1) GetEvictPods(c context.Context, request *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error) {
+	return &pluginapi.GetEvictPodsResponse{
+		EvictPods: []*pluginapi.EvictPod{
+			{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-1",
+						UID:  "pod-1",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+				ForceEvict: false,
+			},
+			{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-2",
+						UID:  "pod-2",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+				ForceEvict: true,
+			},
+			{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod-5",
+						UID:  "pod-5",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+				ForceEvict: false,
+			},
+		},
+	}, nil
+}
+
+type plugin2 struct {
+	pluginSkeleton
+}
+
+func (p plugin2) ThresholdMet(c context.Context) (*pluginapi.ThresholdMetResponse, error) {
+	return &pluginapi.ThresholdMetResponse{
+		MetType:            pluginapi.ThresholdMetType_HARD_MET,
+		ThresholdValue:     0.8,
+		ObservedValue:      0.9,
+		ThresholdOperator:  pluginapi.ThresholdOperator_GREATER_THAN,
+		EvictionScope:      "plugin2_scope",
+		GracePeriodSeconds: -1,
+		Condition: &pluginapi.Condition{
+			ConditionType: pluginapi.ConditionType_NODE_CONDITION,
+			Effects:       []string{"NoSchedule"},
+			ConditionName: "diskPressure",
+			MetCondition:  true,
+		},
+	}, nil
+}
+
+func (p plugin2) GetTopEvictionPods(c context.Context, request *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error) {
+	return &pluginapi.GetTopEvictionPodsResponse{TargetPods: []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-3",
+				UID:  "pod-3",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodRunning,
+			},
+		},
+	}}, nil
+}
+
+func (p plugin2) GetEvictPods(c context.Context, request *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error) {
+	return &pluginapi.GetEvictPodsResponse{EvictPods: []*pluginapi.EvictPod{}}, nil
+}
+
+func makeEvictionManager() *EvictionManger {
+	mgr := NewEvictionManager(&client.GenericClientSet{}, nil, makeMetaServer(), metrics.DummyMetrics{}, makeConf())
+	mgr.endpoints = map[string]endpointpkg.Endpoint{
+		"plugin1": &plugin1{},
+		"plugin2": &plugin2{},
+	}
+
+	return mgr
+}
+
+func TestEvictionManger_collectEvictionResult(t *testing.T) {
+	mgr := makeEvictionManager()
+	tests := []struct {
+		name               string
+		dryrunPlugins      []string
+		wantSoftEvictPods  sets.String
+		wantForceEvictPods sets.String
+		wantConditions     sets.String
+	}{
+		{
+			name:          "no dryrun",
+			dryrunPlugins: []string{},
+			wantSoftEvictPods: sets.String{
+				"pod-1": sets.Empty{},
+				"pod-5": sets.Empty{},
+			},
+			wantForceEvictPods: sets.String{
+				"pod-2": sets.Empty{},
+				"pod-3": sets.Empty{},
+			},
+			wantConditions: sets.String{
+				"diskPressure": sets.Empty{},
+			},
+		},
+		{
+			name:              "dryrun plugin1",
+			dryrunPlugins:     []string{"plugin1"},
+			wantSoftEvictPods: sets.String{},
+			wantForceEvictPods: sets.String{
+				"pod-3": sets.Empty{},
+			},
+			wantConditions: sets.String{
+				"diskPressure": sets.Empty{},
+			},
+		},
+		{
+			name:          "dryrun plugin2",
+			dryrunPlugins: []string{"plugin2"},
+			wantSoftEvictPods: sets.String{
+				"pod-1": sets.Empty{},
+				"pod-5": sets.Empty{},
+			},
+			wantForceEvictPods: sets.String{
+				"pod-2": sets.Empty{},
+			},
+			wantConditions: sets.String{},
+		},
+		{
+			name:               "dryrun plugin1 & plugin2",
+			dryrunPlugins:      []string{"plugin1", "plugin2"},
+			wantSoftEvictPods:  sets.String{},
+			wantForceEvictPods: sets.String{},
+			wantConditions:     sets.String{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr.conf.DryrunPlugins = tt.dryrunPlugins
+
+			collector := mgr.collectEvictionResult(pods)
+			gotForceEvictPods := sets.String{}
+			gotSoftEvictPods := sets.String{}
+			gotConditions := sets.String{}
+			for _, evictPod := range collector.getForceEvictPods() {
+				gotForceEvictPods.Insert(evictPod.Pod.Name)
+			}
+
+			for _, evictPod := range collector.getSoftEvictPods() {
+				gotSoftEvictPods.Insert(evictPod.Pod.Name)
+			}
+
+			for name := range collector.getCurrentConditions() {
+				gotConditions.Insert(name)
+			}
+			assert.Equal(t, tt.wantForceEvictPods, gotForceEvictPods)
+			assert.Equal(t, tt.wantSoftEvictPods, gotSoftEvictPods)
+			assert.Equal(t, tt.wantConditions, gotConditions)
+		})
+	}
+}

--- a/pkg/agent/evictionmanager/manager_test.go
+++ b/pkg/agent/evictionmanager/manager_test.go
@@ -278,10 +278,17 @@ func TestEvictionManger_collectEvictionResult(t *testing.T) {
 			wantForceEvictPods: sets.String{},
 			wantConditions:     sets.String{},
 		},
+		{
+			name:               "dryrun *",
+			dryrunPlugins:      []string{"*"},
+			wantSoftEvictPods:  sets.String{},
+			wantForceEvictPods: sets.String{},
+			wantConditions:     sets.String{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mgr.conf.DryrunPlugins = tt.dryrunPlugins
+			mgr.conf.DryRunPlugins = tt.dryrunPlugins
 
 			collector := mgr.collectEvictionResult(pods)
 			gotForceEvictPods := sets.String{}

--- a/pkg/config/agent/eviction/eviciton_base.go
+++ b/pkg/config/agent/eviction/eviciton_base.go
@@ -36,7 +36,7 @@ type GenericEvictionConfiguration struct {
 	// '*' means "all dryrun by default"
 	// 'foo' means "dryrun 'foo'"
 	// first item for a particular name wins
-	DryrunPlugins []string
+	DryRunPlugins []string
 
 	// ConditionTransitionPeriod is duration the eviction manager has to wait before transitioning out of a condition.
 	ConditionTransitionPeriod time.Duration

--- a/pkg/config/agent/eviction/eviciton_base.go
+++ b/pkg/config/agent/eviction/eviciton_base.go
@@ -32,6 +32,12 @@ type GenericEvictionConfiguration struct {
 	// first item for a particular name wins
 	InnerPlugins []string
 
+	// Dryrun plugins is the list of plugins to dryrun
+	// '*' means "all dryrun by default"
+	// 'foo' means "dryrun 'foo'"
+	// first item for a particular name wins
+	DryrunPlugins []string
+
 	// ConditionTransitionPeriod is duration the eviction manager has to wait before transitioning out of a condition.
 	ConditionTransitionPeriod time.Duration
 


### PR DESCRIPTION
#### What type of PR is this?

Enhancements


#### What this PR does / why we need it:
When a new eviction plugin is added, user might not sure about the effect of this plugin. This pull request add a new configuration through which user can turn some certain plugins into dryrun mode. A plugin which in dryrun mode will only produce logs and metrics but not actually evict pods.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
