### PR TITLE
fix(qrm): ensures dedicated_cores owner pool non-empty

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/allocation_handlers.go
@@ -370,13 +370,7 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingAllocationSidecarHandler(ct
 		return &pluginapi.ResourceAllocationResponse{}, nil
 	}
 
-	var mainContainerAllocationInfo *state.AllocationInfo
-	for _, siblingAllocationInfo := range podEntries[req.PodUid] {
-		if siblingAllocationInfo.ContainerType == pluginapi.ContainerType_MAIN.String() {
-			mainContainerAllocationInfo = siblingAllocationInfo
-			break
-		}
-	}
+	mainContainerAllocationInfo := podEntries[req.PodUid].GetMainContainerEntry()
 
 	// todo: consider sidecar without reconcile in vpa
 	if mainContainerAllocationInfo == nil {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
@@ -134,6 +135,19 @@ func (ce ContainerEntries) GetPoolEntry() *AllocationInfo {
 		return nil
 	}
 	return ce[""]
+}
+
+func (ce ContainerEntries) GetMainContainerEntry() *AllocationInfo {
+	var mainContainerEntry *AllocationInfo
+
+	for _, siblingEntry := range ce {
+		if siblingEntry != nil && siblingEntry.ContainerType == pluginapi.ContainerType_MAIN.String() {
+			mainContainerEntry = siblingEntry
+			break
+		}
+	}
+
+	return mainContainerEntry
 }
 
 func (pe PodEntries) String() string {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util.go
@@ -147,6 +147,10 @@ func GetPoolsQuantityMapFromPodEntries(podEntries PodEntries, ignoreAllocationIn
 	return ret
 }
 
+func GetMainContainerPoolName(containerEntries ContainerEntries) string {
+	return GetRealOwnerPoolName(containerEntries.GetMainContainerEntry())
+}
+
 // GetSpecifiedPoolName parses the belonging pool name for a given allocation according to QoS level
 func GetSpecifiedPoolName(allocationInfo *AllocationInfo) string {
 	if allocationInfo == nil {
@@ -162,6 +166,8 @@ func GetSpecifiedPoolName(allocationInfo *AllocationInfo) string {
 		return PoolNameShare
 	case consts.PodAnnotationQoSLevelReclaimedCores:
 		return PoolNameReclaim
+	case consts.PodAnnotationQoSLevelDedicatedCores:
+		return PoolNameDedicated
 	default:
 		return ""
 	}


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

There are existing dedicated_cores sicar with empty owner pool name. It will influence sys advisor calculation. This pr is to ensure dedicated_cores owner pool non-empty.