### PR TITLE
skip retry update config when skip failed initialization enable

### DIFF
--- a/pkg/metaserver/config/manager.go
+++ b/pkg/metaserver/config/manager.go
@@ -179,16 +179,17 @@ func (c *DynamicConfigManager) InitializeConfig(ctx context.Context) error {
 		if err == nil {
 			return true, nil
 		}
+
+		if c.defaultConfig.ConfigSkipFailedInitialization {
+			klog.Warningf("unable to update dynamic config: %v, fallback to default config", err)
+			return true, nil
+		}
+
+		klog.Errorf("unable to update dynamic config: %v, back off to retry", err)
 		return false, nil
 	})
 
-	if err != nil {
-		if !c.defaultConfig.ConfigSkipFailedInitialization {
-			return err
-		}
-		klog.Errorf("unable to update dynamic config: %v, fallback to default config", err)
-	}
-	return nil
+	return err
 }
 
 func (c *DynamicConfigManager) tryUpdateConfig(ctx context.Context, skipError bool) error {


### PR DESCRIPTION
#### What type of PR is this?
Features
#### What this PR does / why we need it:
Dynamic config manager support skip retry update config when skip failed initialization enable, because if skip failed initialization enable, it means that the agent can use default flags configuration to start and no need to retry, it can be updated later.