### PR TITLE
feat(eviction): rss overuse eviction base on request

### DIFF
--- a/pkg/agent/evictionmanager/plugin/memory/rss_overuse_test.go
+++ b/pkg/agent/evictionmanager/plugin/memory/rss_overuse_test.go
@@ -67,7 +67,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -103,7 +103,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -139,7 +139,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -147,7 +147,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-2",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -166,7 +166,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -191,7 +191,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -199,7 +199,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-2",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("4Gi"),
 							},
 						},
@@ -221,7 +221,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -229,7 +229,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-2",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("4Gi"),
 							},
 						},
@@ -252,7 +252,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 					{
 						Name: "container-1",
 						Resources: v1.ResourceRequirements{
-							Limits: v1.ResourceList{
+							Requests: v1.ResourceList{
 								"memory": resource.MustParse("10Gi"),
 							},
 						},
@@ -310,7 +310,7 @@ func TestRssOveruseEvictionPlugin_GetEvictPods(t *testing.T) {
 		{
 			name:                       "enable rss overuse eviction, threshold is 1",
 			enableRssOveruse:           true,
-			defaultRssOveruseThreshold: 1,
+			defaultRssOveruseThreshold: 1.05,
 			wantedResult: map[string]sets.Empty{
 				"pod-3": {},
 				"pod-8": {},

--- a/pkg/config/agent/eviction/memory_pressure_eviction_plugin.go
+++ b/pkg/config/agent/eviction/memory_pressure_eviction_plugin.go
@@ -47,7 +47,7 @@ const (
 	// DefaultEnableRssOveruseDetection is the default value of whether enable pod-level rss overuse detection
 	DefaultEnableRssOveruseDetection = false
 	// DefaultRssOveruseRateThreshold is the default threshold for the rate of rss
-	DefaultRssOveruseRateThreshold = 0.8
+	DefaultRssOveruseRateThreshold = 1.05
 )
 
 var (

--- a/pkg/util/qos/mem_enhancement.go
+++ b/pkg/util/qos/mem_enhancement.go
@@ -73,5 +73,5 @@ func GetRSSOverUseEvictThreshold(qosConf *generic.QoSConfiguration, pod *v1.Pod)
 }
 
 func isValidRatioThreshold(threshold float64) bool {
-	return threshold > 0 && threshold <= 1
+	return threshold > 0
 }


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
this is a modification of pr [feat(eviction manager): support pod-level rss overuse evict](https://github.com/kubewharf/katalyst-core/pull/57). The plugin use pod memory request to calculate the threshold instead of pod memory limit.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
