### PR TITLE
change log format to export the entire pkg name

### DIFF
--- a/pkg/util/general/log.go
+++ b/pkg/util/general/log.go
@@ -25,6 +25,7 @@ import (
 )
 
 const callDepth = 3
+const pkgPrefix = "github.com/kubewharf/"
 
 // loggingWithDepth returns the logging-prefix for caller.
 // it will help to avoid hardcode function names in logging
@@ -35,12 +36,8 @@ func loggingWithDepth() string {
 		return ""
 	}
 
-	funcPaths := strings.Split(runtime.FuncForPC(pc).Name(), "/")
-	if len(funcPaths) == 0 {
-		return ""
-	}
-
-	funcNames := strings.Split(funcPaths[len(funcPaths)-1], ".")
+	funcPaths := strings.TrimPrefix(runtime.FuncForPC(pc).Name(), pkgPrefix)
+	funcNames := strings.Split(funcPaths, ".")
 	switch len(funcNames) {
 	case 0, 1:
 	case 2:

--- a/pkg/util/general/log_test.go
+++ b/pkg/util/general/log_test.go
@@ -35,7 +35,7 @@ func TestLoggingPrefix(t *testing.T) {
 	require.Equal(t, "[testing/tRunner] extra 1 test", withoutStruct)
 
 	withStruct := test{}.log("extra %v %v", 1, "test")
-	require.Equal(t, "[general/TestLoggingPrefix] extra 1 test", withStruct)
+	require.Equal(t, "[katalyst-core/pkg/util/general/TestLoggingPrefix] extra 1 test", withStruct)
 
 	InfoS("test-InfoS", "param-key", "param-InfoS")
 	Infof("test-Infof %v", "extra-Infof")


### PR DESCRIPTION
#### What type of PR is this?
chore

#### What this PR does / why we need it:
format the logging styles in general util to export the entire pkg name