### PR TITLE
feat(eviciton): rss overuse eviction support pod filter

### DIFF
--- a/cmd/katalyst-agent/app/options/eviction/memory_pressure_eviction_plugin_test.go
+++ b/cmd/katalyst-agent/app/options/eviction/memory_pressure_eviction_plugin_test.go
@@ -1,20 +1,18 @@
 /*
- *
- * Copyright 2022 The Katalyst Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * /
- */
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package eviction
 

--- a/cmd/katalyst-agent/app/options/eviction/memory_pressure_eviction_plugin_test.go
+++ b/cmd/katalyst-agent/app/options/eviction/memory_pressure_eviction_plugin_test.go
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2022 The Katalyst Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/eviction"
+)
+
+func TestMemoryPressureEvictionPluginOptions_ApplyTo(t *testing.T) {
+	options := NewMemoryPressureEvictionPluginOptions()
+	configuration := eviction.NewMemoryPressureEvictionPluginConfiguration()
+
+	options.RssOveruseEvictionFilter = "canEvict=true,canBeEvict=true"
+	err := options.ApplyTo(configuration)
+
+	assert.NoError(t, err)
+	assert.Equal(t, configuration.RssOveruseEvictionFilter, labels.Set{"canEvict": "true", "canBeEvict": "true"})
+}

--- a/pkg/config/agent/eviction/memory_pressure_eviction_plugin.go
+++ b/pkg/config/agent/eviction/memory_pressure_eviction_plugin.go
@@ -16,8 +16,11 @@ limitations under the License.
 
 package eviction
 
+import "k8s.io/apimachinery/pkg/labels"
+
 // MemoryPressureEvictionPluginConfiguration is the config of MemoryPressureEvictionPlugin
 type MemoryPressureEvictionPluginConfiguration struct {
+	RssOveruseEvictionFilter labels.Set
 }
 
 // NewMemoryPressureEvictionPluginConfiguration returns a new MemoryPressureEvictionPluginConfiguration


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
A k8s cluster might contains many types of workloads, in them some might need to be evicted when rss over used than user expected meanwhile some might not need this feature. So we need a way to let user to select pods which can be evicted by rss overuse eviction plugin. This PR adds a new labels configuration which user can use it to select pods which can be evicted by rss overuse eviction plugin.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
