### PR TITLE
cpu advisor support get pod indicator target from spd

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama_test.go
@@ -45,16 +45,23 @@ func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string)
 	conf.GenericSysAdvisorConfiguration.StateFileDirectory = stateFileDir
 	conf.MetaServerConfiguration.CheckpointManagerDir = checkpointDir
 
-	conf.PolicyRama = &provisionconf.PolicyRamaConfiguration{
-		IndicatorMetrics: map[types.QoSRegionType][]string{
-			types.QoSRegionTypeShare: {
-				consts.MetricCPUSchedwait,
-			},
-			types.QoSRegionTypeDedicatedNumaExclusive: {
-				consts.MetricCPUCPIContainer,
-				consts.MetricMemBandwidthNuma,
+	conf.RegionIndicatorTargetConfiguration = map[types.QoSRegionType][]provisionconf.IndicatorTargetConfiguration{
+		types.QoSRegionTypeShare: {
+			{
+				Name: consts.MetricCPUSchedwait,
 			},
 		},
+		types.QoSRegionTypeDedicatedNumaExclusive: {
+			{
+				Name: consts.MetricCPUCPIContainer,
+			},
+			{
+				Name: consts.MetricMemBandwidthNuma,
+			},
+		},
+	}
+
+	conf.PolicyRama = &provisionconf.PolicyRamaConfiguration{
 		PIDParameters: map[string]types.FirstOrderPIDParams{
 			consts.MetricCPUSchedwait: {
 				Kpp:                  10.0,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_base.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_base.go
@@ -17,9 +17,12 @@ limitations under the License.
 package region
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
@@ -353,4 +356,92 @@ func (r *QoSRegionBase) initHeadroomPolicy(conf *config.Configuration, extraConf
 			})
 		}
 	}
+}
+
+// getIndicators gets indicators by given map of indicator name to the getter of current value
+func (r *QoSRegionBase) getIndicators(indicatorCurrentGetterMap map[string]types.IndicatorCurrentGetter) (types.Indicator, error) {
+	ctx := context.Background()
+	indicatorTargetConfig, ok := r.conf.RegionIndicatorTargetConfiguration[r.regionType]
+	if !ok {
+		return nil, fmt.Errorf("get %v indicators failed", r.regionType)
+	}
+
+	indicators := make(types.Indicator)
+	for _, indicator := range indicatorTargetConfig {
+		indicatorName := indicator.Name
+		defaultTarget := indicator.Target
+		indicatorCurrentGetter, ok := indicatorCurrentGetterMap[indicatorName]
+		if !ok {
+			continue
+		}
+
+		current, err := indicatorCurrentGetter()
+		if err != nil {
+			return nil, err
+		}
+
+		minTarget := defaultTarget
+		if len(r.podSet) > 0 {
+			minTarget = math.MaxFloat64
+			for podUID := range r.podSet {
+				indicatorTarget, err := r.getPodIndicatorTarget(ctx, podUID, indicatorName, defaultTarget)
+				if err != nil {
+					return nil, err
+				}
+
+				minTarget = math.Min(minTarget, *indicatorTarget)
+			}
+		}
+
+		indicatorValue := types.IndicatorValue{
+			Current: current,
+			Target:  minTarget,
+		}
+
+		if indicatorValue.Target <= 0 || indicatorValue.Current <= 0 {
+			return nil, fmt.Errorf("%v with invalid indicator value %v", indicatorName, indicatorValue)
+		}
+
+		indicators[indicatorName] = indicatorValue
+	}
+
+	return indicators, nil
+}
+
+// getPodIndicatorTarget gets pod indicator target by given pod uid and indicator name,
+// if no performance target or indicator is found, it will return default target
+func (r *QoSRegionBase) getPodIndicatorTarget(ctx context.Context, podUID string,
+	indicatorName string, defaultTarget float64) (*float64, error) {
+	pod, err := r.metaServer.GetPod(ctx, podUID)
+	if err != nil {
+		return nil, err
+	}
+
+	indicatorTarget := defaultTarget
+	servicePerformanceTarget, err := r.metaServer.ServiceSystemPerformanceTarget(ctx, pod)
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	} else if err != nil {
+		return &indicatorTarget, nil
+	}
+
+	target, ok := servicePerformanceTarget[indicatorName]
+	if !ok {
+		return &indicatorTarget, nil
+	}
+
+	// get the indicator target in the following order:
+	// 1. service indicator upperBound
+	// 2. service indicator lowerBound
+	// 3. default indicator target
+
+	if target.LowerBound != nil {
+		indicatorTarget = *target.LowerBound
+	}
+
+	if target.UpperBound != nil {
+		indicatorTarget = *target.UpperBound
+	}
+
+	return &indicatorTarget, nil
 }

--- a/pkg/agent/sysadvisor/types/types.go
+++ b/pkg/agent/sysadvisor/types/types.go
@@ -226,9 +226,10 @@ type Indicator map[string]IndicatorValue
 type IndicatorValue struct {
 	Current float64
 	Target  float64
-	Upper   float64
-	Lower   float64
 }
+
+// IndicatorCurrentGetter get pod indicator current value by podUID
+type IndicatorCurrentGetter func() (float64, error)
 
 // PolicyUpdateStatus works as a flag indicating update result
 type PolicyUpdateStatus string

--- a/pkg/config/agent/sysadvisor/qosaware/resource/cpu/provision/policy_base.go
+++ b/pkg/config/agent/sysadvisor/qosaware/resource/cpu/provision/policy_base.go
@@ -16,12 +16,37 @@ limitations under the License.
 
 package provision
 
+import (
+	"github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
+)
+
+type IndicatorTargetConfiguration struct {
+	Name   string
+	Target float64
+}
+
 type CPUProvisionPolicyConfiguration struct {
-	PolicyRama *PolicyRamaConfiguration
+	RegionIndicatorTargetConfiguration map[types.QoSRegionType][]IndicatorTargetConfiguration
+	PolicyRama                         *PolicyRamaConfiguration
 }
 
 func NewCPUProvisionPolicyConfiguration() *CPUProvisionPolicyConfiguration {
 	return &CPUProvisionPolicyConfiguration{
+		RegionIndicatorTargetConfiguration: map[types.QoSRegionType][]IndicatorTargetConfiguration{
+			types.QoSRegionTypeShare: {
+				{
+					Name:   string(v1alpha1.TargetIndicatorNameCPUSchedWait),
+					Target: 460,
+				},
+			},
+			types.QoSRegionTypeDedicatedNumaExclusive: {
+				{
+					Name:   string(v1alpha1.TargetIndicatorNameCPI),
+					Target: 1.4,
+				},
+			},
+		},
 		PolicyRama: NewPolicyRamaConfiguration(),
 	}
 }

--- a/pkg/config/agent/sysadvisor/qosaware/resource/cpu/provision/policy_rama.go
+++ b/pkg/config/agent/sysadvisor/qosaware/resource/cpu/provision/policy_rama.go
@@ -17,28 +17,19 @@ limitations under the License.
 package provision
 
 import (
+	"github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
-	"github.com/kubewharf/katalyst-core/pkg/consts"
 )
 
 type PolicyRamaConfiguration struct {
-	IndicatorMetrics map[types.QoSRegionType][]string
-	PIDParameters    map[string]types.FirstOrderPIDParams
+	PIDParameters map[string]types.FirstOrderPIDParams
 }
 
 // todo: support update pid parameters by kcc
 func NewPolicyRamaConfiguration() *PolicyRamaConfiguration {
 	return &PolicyRamaConfiguration{
-		IndicatorMetrics: map[types.QoSRegionType][]string{
-			types.QoSRegionTypeShare: {
-				consts.MetricCPUSchedwait,
-			},
-			types.QoSRegionTypeDedicatedNumaExclusive: {
-				consts.MetricCPUCPIContainer,
-			},
-		},
 		PIDParameters: map[string]types.FirstOrderPIDParams{
-			consts.MetricCPUSchedwait: {
+			string(v1alpha1.TargetIndicatorNameCPUSchedWait): {
 				Kpp:                  5.0,
 				Kpn:                  0.9,
 				Kdp:                  0.0,
@@ -48,17 +39,7 @@ func NewPolicyRamaConfiguration() *PolicyRamaConfiguration {
 				DeadbandLowerPct:     0.8,
 				DeadbandUpperPct:     0.05,
 			},
-			consts.MetricCPUCPIContainer: {
-				Kpp:                  10.0,
-				Kpn:                  2.0,
-				Kdp:                  0.0,
-				Kdn:                  0.0,
-				AdjustmentUpperBound: types.MaxRampUpStep,
-				AdjustmentLowerBound: -types.MaxRampDownStep,
-				DeadbandLowerPct:     0.95,
-				DeadbandUpperPct:     0.01,
-			},
-			consts.MetricMemBandwidthNuma: {
+			string(v1alpha1.TargetIndicatorNameCPI): {
 				Kpp:                  10.0,
 				Kpn:                  2.0,
 				Kdp:                  0.0,

--- a/pkg/metaserver/metaserver.go
+++ b/pkg/metaserver/metaserver.go
@@ -70,15 +70,15 @@ func NewMetaServer(clientSet *client.GenericClientSet, emitter metrics.MetricEmi
 		configurationManager = &config.DummyConfigurationManager{}
 	}
 
-	serviceProfilingManager, err := spd.NewServiceProfilingManager(clientSet, emitter, metaAgent.CNCFetcher, conf)
+	spdFetcher, err := spd.NewSPDFetcher(clientSet, emitter, metaAgent.CNCFetcher, conf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initializes spd fetcher failed: %s", err)
 	}
 
 	return &MetaServer{
 		MetaAgent:               metaAgent,
 		ConfigurationManager:    configurationManager,
-		ServiceProfilingManager: serviceProfilingManager,
+		ServiceProfilingManager: spd.NewServiceProfilingManager(spdFetcher),
 		ExternalManager:         external.InitExternalManager(metaAgent.PodFetcher),
 	}, nil
 }

--- a/pkg/util/spd_indicator.go
+++ b/pkg/util/spd_indicator.go
@@ -19,14 +19,15 @@ package util
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/pointer"
 
 	workloadapis "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
 )
 
 type IndicatorTarget struct {
-	UpperBound *float32
-	LowerBound *float32
+	UpperBound *float64
+	LowerBound *float64
 }
 
 // GetServiceBusinessIndicatorTarget get service business indicator target from spd
@@ -41,40 +42,43 @@ func GetServiceBusinessIndicatorTarget(spd *workloadapis.ServiceProfileDescripto
 			continue
 		}
 
-		targetIndicator := IndicatorTarget{}
-		for _, target := range indicator.Indicators {
-			switch target.IndicatorLevel {
-			case workloadapis.IndicatorLevelUpperBound:
-				if targetIndicator.UpperBound != nil {
-					errList = append(errList, fmt.Errorf("duplicate upper bound for indicator %s", indicator.Name))
-					continue
-				}
-				targetIndicator.UpperBound = pointer.Float32(target.Value)
-			case workloadapis.IndicatorLevelLowerBound:
-				if targetIndicator.LowerBound != nil {
-					errList = append(errList, fmt.Errorf("duplicate lower bound for indicator %s", indicator.Name))
-					continue
-				}
-				targetIndicator.LowerBound = pointer.Float32(target.Value)
-			default:
-				errList = append(errList, fmt.Errorf("invalid indicator level %s for indicator %s", target.IndicatorLevel, indicator.Name))
-				continue
-			}
+		targetIndicator, err := getIndicatorTarget(indicator.Indicators)
+		if err != nil {
+			errList = append(errList, fmt.Errorf("get indicator %s failed: %v", indicator.Name, err))
 		}
 
-		// check whether target indicator is validated
-		if targetIndicator.LowerBound != nil && targetIndicator.UpperBound != nil &&
-			*targetIndicator.LowerBound > *targetIndicator.UpperBound {
-			errList = append(errList, fmt.Errorf("lower bound %v is higher than uppoer bound %v for indicator %s",
-				*targetIndicator.LowerBound, *targetIndicator.UpperBound, indicator.Name))
-			continue
-		}
-
-		indicators[string(indicator.Name)] = targetIndicator
+		indicators[string(indicator.Name)] = *targetIndicator
 	}
 
 	if len(errList) > 0 {
-		return nil, fmt.Errorf("failed to get service business indicators: %v", errList)
+		return nil, fmt.Errorf("failed to get service business indicators: %v", errors.NewAggregate(errList))
+	}
+
+	return indicators, nil
+}
+
+// GetServiceSystemIndicatorTarget get service system indicator target from spd
+// if there are duplicate upper bound or lower bound, return error
+func GetServiceSystemIndicatorTarget(spd *workloadapis.ServiceProfileDescriptor) (map[string]IndicatorTarget, error) {
+	var errList []error
+	indicators := make(map[string]IndicatorTarget)
+	for _, indicator := range spd.Spec.SystemIndicator {
+		_, ok := indicators[string(indicator.Name)]
+		if ok {
+			errList = append(errList, fmt.Errorf("duplicate indicator %s", indicator.Name))
+			continue
+		}
+
+		targetIndicator, err := getIndicatorTarget(indicator.Indicators)
+		if err != nil {
+			errList = append(errList, fmt.Errorf("get indicator %s failed: %v", indicator.Name, err))
+		}
+
+		indicators[string(indicator.Name)] = *targetIndicator
+	}
+
+	if len(errList) > 0 {
+		return nil, fmt.Errorf("failed to get service system indicators: %v", errors.NewAggregate(errList))
 	}
 
 	return indicators, nil
@@ -83,8 +87,8 @@ func GetServiceBusinessIndicatorTarget(spd *workloadapis.ServiceProfileDescripto
 // GetServiceBusinessIndicatorValue returns the current value of business indicators
 // The returned map is a map from indicator name to its current value, and if duplicate
 // indicators are found, the first one is used
-func GetServiceBusinessIndicatorValue(spd *workloadapis.ServiceProfileDescriptor) (map[string]float32, error) {
-	indicatorValues := make(map[string]float32)
+func GetServiceBusinessIndicatorValue(spd *workloadapis.ServiceProfileDescriptor) (map[string]float64, error) {
+	indicatorValues := make(map[string]float64)
 	for _, indicator := range spd.Status.BusinessStatus {
 		if indicator.Current == nil {
 			continue
@@ -95,8 +99,37 @@ func GetServiceBusinessIndicatorValue(spd *workloadapis.ServiceProfileDescriptor
 			continue
 		}
 
-		indicatorValues[string(indicator.Name)] = *indicator.Current
+		indicatorValues[string(indicator.Name)] = float64(*indicator.Current)
 	}
 
 	return indicatorValues, nil
+}
+
+func getIndicatorTarget(indicators []workloadapis.Indicator) (*IndicatorTarget, error) {
+	targetIndicator := &IndicatorTarget{}
+	for _, target := range indicators {
+		switch target.IndicatorLevel {
+		case workloadapis.IndicatorLevelUpperBound:
+			if targetIndicator.UpperBound != nil {
+				return nil, fmt.Errorf("duplicate upper bound for indicator")
+			}
+			targetIndicator.UpperBound = pointer.Float64(float64(target.Value))
+		case workloadapis.IndicatorLevelLowerBound:
+			if targetIndicator.LowerBound != nil {
+				return nil, fmt.Errorf("duplicate lower bound for indicator")
+			}
+			targetIndicator.LowerBound = pointer.Float64(float64(target.Value))
+		default:
+			return nil, fmt.Errorf("invalid indicator level %s", target.IndicatorLevel)
+		}
+	}
+
+	// check whether target indicator is validated
+	if targetIndicator.LowerBound != nil && targetIndicator.UpperBound != nil &&
+		*targetIndicator.LowerBound > *targetIndicator.UpperBound {
+		return nil, fmt.Errorf("lower bound %v is higher than uppoer bound %v for indicator",
+			*targetIndicator.LowerBound, *targetIndicator.UpperBound)
+	}
+
+	return targetIndicator, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
cpu advisor should get pod indicator target from spd to support more granular cpu provisioning policies
