### PR TITLE
enhancement(eviction): avoid misjudgment by checking metric timestamp

### DIFF
--- a/pkg/agent/evictionmanager/plugin/memory/helper.go
+++ b/pkg/agent/evictionmanager/plugin/memory/helper.go
@@ -161,10 +161,14 @@ func (e *EvictionHelper) getWatermarkMetrics(numaID int) (free, total, scaleFact
 	return free, total, scaleFactor, nil
 }
 
-func (e *EvictionHelper) getSystemKswapdStealMetrics() (float64, error) {
+func (e *EvictionHelper) getSystemKswapdStealMetrics() (metric.MetricData, error) {
 	m, err := e.metaServer.GetNodeMetric(consts.MetricMemKswapdstealSystem)
 	if err != nil {
-		return 0, fmt.Errorf(errMsgGetSystemMetrics, "mem.kswapdsteal.system", err)
+		return m, fmt.Errorf(errMsgGetSystemMetrics, consts.MetricMemKswapdstealSystem, err)
+	}
+
+	if m.Time == nil {
+		return m, fmt.Errorf(errMsgGetSystemMetrics, consts.MetricMemKswapdstealSystem, fmt.Errorf("metric timestamp is nil"))
 	}
 
 	kswapdSteal := m.Value
@@ -173,7 +177,7 @@ func (e *EvictionHelper) getSystemKswapdStealMetrics() (float64, error) {
 			metricsTagKeyMetricName: consts.MetricMemKswapdstealSystem,
 		})...)
 
-	return kswapdSteal, nil
+	return m, nil
 }
 
 func (e *EvictionHelper) selectTopNPodsToEvictByMetrics(activePods []*v1.Pod, topN uint64, numaID,


### PR DESCRIPTION
#### What type of PR is this?

Enhancements

#### What this PR does / why we need it:
system pressure eviction plugin use the diff value of kswapdsteal metric between two rounds of sync to check if the system is under memory pressure. But sometimes the metric is not updated as in time as we expected, it will lead to misjudgment. This PR checks the metric timestamp to prevent that misjudgment. When the metric timestamp is same with it in last round, we ignore this round.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
