### PR TITLE
filter out none-matched namespance in kcmas

### DIFF
--- a/pkg/custom-metric/store/data/cache.go
+++ b/pkg/custom-metric/store/data/cache.go
@@ -335,8 +335,13 @@ func (c *CachedMetric) GetMetricWithLimit(namespace, metricName string, gr *sche
 	if gr != nil {
 		metricMeta.SetObjectKind(gr.String())
 	}
+
 	if internalMap, ok := c.metricMap[metricMeta]; ok {
 		for _, internal := range internalMap {
+			if internal.ObjectNamespace != namespace {
+				continue
+			}
+
 			res = append(res, internal.DeepCopyWithLimit(limit))
 
 			if internal.Len() > 0 {

--- a/pkg/custom-metric/store/data/cache_test.go
+++ b/pkg/custom-metric/store/data/cache_test.go
@@ -164,6 +164,10 @@ func Test_cache(t *testing.T) {
 	names = c.ListAllMetricNames()
 	assert.ElementsMatch(t, []string{"m-1", "m-2", "m-3"}, names)
 
+	oneMetric, exist = c.GetMetric("n-4", "m-3", &schema.GroupResource{Resource: "pod"})
+	assert.Equal(t, true, exist)
+	assert.Equal(t, 0, len(oneMetric))
+
 	oneMetric, exist = c.GetMetric("n-3", "m-3", &schema.GroupResource{Resource: "pod"})
 	assert.Equal(t, true, exist)
 	assert.Equal(t, &InternalMetric{


### PR DESCRIPTION
#### What type of PR is this?
bug fixes

#### What this PR does / why we need it:
filter out namespace that are not matched with the given one
