### PR TITLE
feat(metaserver): support getting pods from kubelet secure port

### DIFF
--- a/cmd/katalyst-agent/app/options/global/metaserver.go
+++ b/cmd/katalyst-agent/app/options/global/metaserver.go
@@ -46,6 +46,7 @@ const (
 	defaultKubeletPodCacheSyncBurstBulk = 1
 	defaultKubeletConfigURI             = "/configz"
 	defaultAPIAuthTokenFile             = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultKubeletPodsEndpoint          = "/pods"
 )
 
 const (
@@ -74,6 +75,7 @@ type MetaServerOptions struct {
 	KubeletPodCacheSyncBurstBulk int
 	KubeletConfigEndpoint        string
 	APIAuthTokenFile             string
+	KubeletPodsEndpoint          string
 
 	RemoteRuntimeEndpoint     string
 	RuntimePodCacheSyncPeriod time.Duration
@@ -105,6 +107,7 @@ func NewMetaServerOptions() *MetaServerOptions {
 		EnableMetricsFetcher:           defaultEnableMetricsFetcher,
 		EnableCNCFetcher:               defaultEnableCNCFetcher,
 		KubeletConfigEndpoint:          defaultKubeletConfigURI,
+		KubeletPodsEndpoint:            defaultKubeletPodsEndpoint,
 		APIAuthTokenFile:               defaultAPIAuthTokenFile,
 	}
 }
@@ -151,6 +154,8 @@ func (o *MetaServerOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"Whether to enable cnc fetcher")
 	fs.StringVar(&o.KubeletConfigEndpoint, "kubelet-config-endpoint", o.KubeletConfigEndpoint,
 		"The URI of kubelet config endpoint")
+	fs.StringVar(&o.KubeletPodsEndpoint, "kubelet-pods-endpoint", o.KubeletPodsEndpoint,
+		"The URI of kubelet pods endpoint")
 	fs.StringVar(&o.APIAuthTokenFile, "api-auth-token-file", o.APIAuthTokenFile,
 		"The path of the API auth token file")
 }
@@ -176,6 +181,7 @@ func (o *MetaServerOptions) ApplyTo(c *global.MetaServerConfiguration) error {
 	c.EnableMetricsFetcher = o.EnableMetricsFetcher
 	c.EnableCNCFetcher = o.EnableCNCFetcher
 	c.KubeletConfigEndpoint = o.KubeletConfigEndpoint
+	c.KubeletPodsEndpoint = o.KubeletPodsEndpoint
 	c.APIAuthTokenFile = o.APIAuthTokenFile
 
 	return nil

--- a/pkg/config/agent/global/metaserver.go
+++ b/pkg/config/agent/global/metaserver.go
@@ -38,6 +38,7 @@ type MetaServerConfiguration struct {
 	KubeletPodCacheSyncMaxRate   rate.Limit
 	KubeletPodCacheSyncBurstBulk int
 	KubeletConfigEndpoint        string
+	KubeletPodsEndpoint          string
 	APIAuthTokenFile             string
 
 	RemoteRuntimeEndpoint     string

--- a/pkg/metaserver/agent/pod/pod.go
+++ b/pkg/metaserver/agent/pod/pod.go
@@ -85,7 +85,7 @@ func NewPodFetcher(conf *config.Configuration, emitter metrics.MetricEmitter) (P
 	}
 
 	return &podFetcherImpl{
-		kubeletPodFetcher: NewKubeletPodFetcher(),
+		kubeletPodFetcher: NewKubeletPodFetcher(conf),
 		runtimePodFetcher: runtimePodFetcher,
 		emitter:           emitter,
 		conf:              conf,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features

#### What this PR does / why we need it:
Currently, katalyst fetches pods from the kubelet's read-only port, which may be not secure. This PR enables katalyst to fetch pods from the kubelet secure port.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
This PR needs https://github.com/kubewharf/katalyst-core/pull/150 to be merged first.
