### PR TITLE
store metric by pod-uid and container-name

### DIFF
--- a/pkg/metaserver/agent/metric/malachite/client/client_pod.go
+++ b/pkg/metaserver/agent/metric/malachite/client/client_pod.go
@@ -62,7 +62,7 @@ func (c *MalachiteClient) GetPodStats(ctx context.Context, podUID string) (map[s
 			general.Errorf("GetPodStats err %v", err)
 			continue
 		}
-		containersStats[containerID] = stats
+		containersStats[containerStatus.Name] = stats
 	}
 	return containersStats, nil
 }

--- a/pkg/metaserver/agent/metric/malachite/client/client_pod_test.go
+++ b/pkg/metaserver/agent/metric/malachite/client/client_pod_test.go
@@ -169,15 +169,15 @@ func TestGetPodContainerStats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(stats))
 
-	assert.NotNil(t, stats["p-uid1"]["p1-c-uid1"].V1)
-	assert.Nil(t, stats["p-uid1"]["p1-c-uid1"].V2)
+	assert.NotNil(t, stats["p-uid1"]["p1-c-name1"].V1)
+	assert.Nil(t, stats["p-uid1"]["p1-c-name1"].V2)
 
-	assert.NotNil(t, stats["p-uid1"]["p1-c-uid2"].V2)
-	assert.Nil(t, stats["p-uid1"]["p1-c-uid2"].V1)
+	assert.NotNil(t, stats["p-uid1"]["p1-c-name2"].V2)
+	assert.Nil(t, stats["p-uid1"]["p1-c-name2"].V1)
 
-	assert.NotNil(t, stats["p-uid2"]["p2-c-uid1"].V1)
-	assert.Nil(t, stats["p-uid2"]["p2-c-uid1"].V2)
+	assert.NotNil(t, stats["p-uid2"]["p2-c-name1"].V1)
+	assert.Nil(t, stats["p-uid2"]["p2-c-name1"].V2)
 
-	assert.NotNil(t, stats["p-uid3"]["p3-c-uid1"].V2)
-	assert.Nil(t, stats["p-uid3"]["p3-c-uid1"].V1)
+	assert.NotNil(t, stats["p-uid3"]["p3-c-name1"].V2)
+	assert.Nil(t, stats["p-uid3"]["p3-c-name1"].V1)
 }


### PR DESCRIPTION
#### What type of PR is this?
bug fixes

#### What this PR does / why we need it:
use container name instead of container id in metric store
