### PR TITLE
fix kcc and target resource modify no trigger others update

### DIFF
--- a/pkg/controller/kcc/cnc_test.go
+++ b/pkg/controller/kcc/cnc_test.go
@@ -75,8 +75,8 @@ func TestCustomNodeConfigController_Run(t *testing.T) {
 				kccTargetList: []runtime.Object{
 					&v1alpha1.AdminQoSConfiguration{
 						TypeMeta: v1.TypeMeta{
-							Kind:       "EvictionConfiguration",
-							APIVersion: "config.katalyst.kubewharf.io/v1alpha1",
+							Kind:       crd.ResourceKindAdminQoSConfiguration,
+							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "default",

--- a/pkg/controller/kcc/kcc_test.go
+++ b/pkg/controller/kcc/kcc_test.go
@@ -107,8 +107,8 @@ func TestKatalystCustomConfigController_Run(t *testing.T) {
 				kccTargetList: []runtime.Object{
 					&v1alpha1.AdminQoSConfiguration{
 						TypeMeta: v1.TypeMeta{
-							Kind:       "EvictionConfiguration",
-							APIVersion: "config.katalyst.kubewharf.io/v1alpha1",
+							Kind:       crd.ResourceKindAdminQoSConfiguration,
+							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "default",
@@ -167,8 +167,8 @@ func TestKatalystCustomConfigController_Run(t *testing.T) {
 				kccTargetList: []runtime.Object{
 					&v1alpha1.AdminQoSConfiguration{
 						TypeMeta: v1.TypeMeta{
-							Kind:       "EvictionConfiguration",
-							APIVersion: "config.katalyst.kubewharf.io/v1alpha1",
+							Kind:       crd.ResourceKindAdminQoSConfiguration,
+							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "default",
@@ -231,8 +231,8 @@ func TestKatalystCustomConfigController_Run(t *testing.T) {
 				kccTargetList: []runtime.Object{
 					&v1alpha1.AdminQoSConfiguration{
 						TypeMeta: v1.TypeMeta{
-							Kind:       "EvictionConfiguration",
-							APIVersion: "config.katalyst.kubewharf.io/v1alpha1",
+							Kind:       crd.ResourceKindAdminQoSConfiguration,
+							APIVersion: v1alpha1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "default",

--- a/pkg/controller/spd/spd_test.go
+++ b/pkg/controller/spd/spd_test.go
@@ -230,7 +230,7 @@ func TestSPDController_Run(t *testing.T) {
 			go spdController.Run()
 			synced := cache.WaitForCacheSync(ctx.Done(), spdController.syncedFunc...)
 			assert.True(t, synced)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 
 			targetSPD := tt.fields.spd
 			if targetSPD == nil {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Fix bugs where modifying KCC or the target resource does not trigger updates for other KCCs or other target resources, requiring manual triggering of their updates.
