### PR TITLE
chores(eviction): rename metric

### DIFF
--- a/pkg/agent/evictionmanager/eviction_resp_collector.go
+++ b/pkg/agent/evictionmanager/eviction_resp_collector.go
@@ -18,6 +18,7 @@ package evictionmanager
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	//nolint
@@ -146,11 +147,12 @@ func (e *evictionRespCollector) collectMetThreshold(dryRunPlugins []string, plug
 	if resp.Condition != nil && resp.Condition.MetCondition {
 		general.Infof("%v plugin: %s requests to set condition: %s of type: %s",
 			e.getLogPrefix(dryRun), pluginName, resp.Condition.ConditionName, resp.Condition.ConditionType.String())
-		_ = e.emitter.StoreInt64(MetricsNameDryRunConditionCNT, 1, metrics.MetricTypeNameRaw,
+		_ = e.emitter.StoreInt64(MetricsNameRequestConditionCNT, 1, metrics.MetricTypeNameRaw,
 			metrics.MetricTag{Key: "name", Val: pluginName},
 			metrics.MetricTag{Key: "condition_name", Val: resp.Condition.ConditionName},
 			metrics.MetricTag{Key: "condition_type", Val: fmt.Sprint(resp.Condition.ConditionType)},
 			metrics.MetricTag{Key: "effects", Val: strings.Join(resp.Condition.Effects, effectTagValueSeparator)},
+			metrics.MetricTag{Key: "dryrun", Val: strconv.FormatBool(dryRun)},
 		)
 
 		if !dryRun {

--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -49,11 +49,11 @@ import (
 )
 
 const (
-	MetricsNameVictimPodCNT       = "victims_cnt"
-	MetricsNameRunningPodCNT      = "running_pod_cnt"
-	MetricsNameCandidatePodCNT    = "candidate_pod_cnt"
-	MetricsNameDryRunVictimPodCNT = "dryrun_victims_cnt"
-	MetricsNameDryRunConditionCNT = "dryrun_condition_cnt"
+	MetricsNameVictimPodCNT        = "victims_cnt"
+	MetricsNameRunningPodCNT       = "running_pod_cnt"
+	MetricsNameCandidatePodCNT     = "candidate_pod_cnt"
+	MetricsNameDryRunVictimPodCNT  = "dryrun_victims_cnt"
+	MetricsNameRequestConditionCNT = "request_condition_cnt"
 )
 
 // LatestCNRGetter returns the latest CNR resources.


### PR DESCRIPTION
#### What type of PR is this?
Chores

#### What this PR does / why we need it:
the metric name contains "dryrun" but it will emit data when it's not in dryrun mode.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
