### PR TITLE
fix(sysadvisor): replace memory avaiable metric

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
@@ -183,6 +183,18 @@ var defaultNodeMetrics = []nodeMetric{
 		metricValue: metricutil.MetricData{Value: 300 << 30},
 	},
 	{
+		metricName:  coreconsts.MetricMemFreeSystem,
+		metricValue: metricutil.MetricData{Value: 100 << 30},
+	},
+	{
+		metricName:  coreconsts.MetricMemPageCacheSystem,
+		metricValue: metricutil.MetricData{Value: 100 << 30},
+	},
+	{
+		metricName:  coreconsts.MetricMemBufferSystem,
+		metricValue: metricutil.MetricData{Value: 100 << 30},
+	},
+	{
 		metricName:  coreconsts.MetricMemTotalSystem,
 		metricValue: metricutil.MetricData{Value: 500 << 30},
 	},

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -36,6 +36,7 @@ const (
 	MetricMemFreeSystem      = "mem.free.system"
 	MetricMemShmemSystem     = "mem.shmem.system"
 	MetricMemBufferSystem    = "mem.buffer.system"
+	MetricMemPageCacheSystem = "mem.pagecache.system"
 	MetricMemAvailableSystem = "mem.available.system"
 
 	MetricMemDirtySystem       = "mem.dirty.system"

--- a/pkg/metaserver/agent/metric/malachite/fetcher.go
+++ b/pkg/metaserver/agent/metric/malachite/fetcher.go
@@ -401,6 +401,8 @@ func (m *MalachiteMetricsFetcher) processSystemMemoryData(systemMemoryData *type
 		utilmetric.MetricData{Value: float64(mem.MemShm << 10), Time: &updateTime})
 	m.metricStore.SetNodeMetric(consts.MetricMemBufferSystem,
 		utilmetric.MetricData{Value: float64(mem.MemBuffers << 10), Time: &updateTime})
+	m.metricStore.SetNodeMetric(consts.MetricMemPageCacheSystem,
+		utilmetric.MetricData{Value: float64(mem.MemPageCache << 10), Time: &updateTime})
 	m.metricStore.SetNodeMetric(consts.MetricMemAvailableSystem,
 		utilmetric.MetricData{Value: float64(mem.MemAvailable << 10), Time: &updateTime})
 


### PR DESCRIPTION
If the value of "high_wmark_pages" in the system is large, "memory available" metric will be too low even zero from /proc/meminfo. We use "free+cache+buffer" as a substitute to figure this issue out.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
