### PR TITLE
refactor spd fetcher to async get spd from remote

### DIFF
--- a/cmd/katalyst-agent/app/options/global/metaserver.go
+++ b/cmd/katalyst-agent/app/options/global/metaserver.go
@@ -28,7 +28,7 @@ import (
 const (
 	defaultCustomNodeResourceCacheTTL     = 15 * time.Second
 	defaultCustomNodeConfigCacheTTL       = 15 * time.Second
-	defaultServiceProfileCacheTTL         = 15 * time.Second
+	defaultServiceProfileCacheTTL         = 1 * time.Minute
 	defaultConfigCacheTTL                 = 15 * time.Second
 	defaultConfigDisableDynamic           = false
 	defaultConfigSkipFailedInitialization = true

--- a/pkg/metaserver/metaserver_test.go
+++ b/pkg/metaserver/metaserver_test.go
@@ -104,7 +104,7 @@ func TestMetaServer_SetServiceProfilingManager(t *testing.T) {
 
 	go meta.Run(context.Background())
 
-	time.Sleep(3 * time.Millisecond)
+	time.Sleep(3 * time.Second)
 
 	err = meta.SetServiceProfilingManager(&spd.DummyServiceProfilingManager{})
 	assert.Error(t, err)

--- a/pkg/metaserver/spd/fetcher_test.go
+++ b/pkg/metaserver/spd/fetcher_test.go
@@ -201,8 +201,10 @@ func Test_spdManager_GetSPD(t *testing.T) {
 			require.NotNil(t, s)
 
 			ctx := context.TODO()
+
+			_, _ = s.GetSPD(ctx, tt.args.pod)
 			go s.Run(ctx)
-			time.Sleep(1 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 
 			got, err := s.GetSPD(ctx, tt.args.pod)
 			if (err != nil) != tt.wantErr {

--- a/pkg/metaserver/spd/manager_test.go
+++ b/pkg/metaserver/spd/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -268,7 +269,10 @@ func Test_serviceProfilingManager_ServiceBusinessPerformanceLevel(t *testing.T) 
 			m := NewServiceProfilingManager(s)
 			require.NoError(t, err)
 
+			// first get spd add spd key to cache
+			_, _ = s.GetSPD(context.Background(), tt.args.pod)
 			go m.Run(context.Background())
+			time.Sleep(1 * time.Second)
 
 			got, err := m.ServiceBusinessPerformanceLevel(context.Background(), tt.args.pod)
 			if (err != nil) != tt.wantErr {
@@ -402,7 +406,11 @@ func Test_serviceProfilingManager_ServiceSystemPerformanceTarget(t *testing.T) {
 			m := NewServiceProfilingManager(s)
 			require.NoError(t, err)
 
+			// first get spd add pod spd key to cache
+			_, _ = s.GetSPD(context.Background(), tt.args.pod)
 			go m.Run(context.Background())
+			time.Sleep(1 * time.Second)
+
 			got, err := m.ServiceSystemPerformanceTarget(context.Background(), tt.args.pod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ServiceSystemPerformanceTarget() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Refactor the SPD fetcher to asynchronously retrieve SPD from a remote source, preventing it from blocking the service profiling manager during the profiling process.