### PR TITLE
refactor(sysadvisor): set min reserved memory limit for reclaim group

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
@@ -311,6 +311,11 @@ var cgroupMetrics = []cgroupMetric{
 		metricValue: metricutil.MetricData{Value: 100 << 30},
 		cgroupPath:  "/kubepods/besteffort",
 	},
+	{
+		metricName:  coreconsts.MetricMemUsageCgroup,
+		metricValue: metricutil.MetricData{Value: 110 << 30},
+		cgroupPath:  "/kubepods/besteffort",
+	},
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
If buffer and reclaim group rss are both zero, qrm plugin will do nothing. In that case, the memory usage of reclaim group will not be throttled.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
