### PR TITLE
feat(overcommit): add node overcommit webhook

### DIFF
--- a/cmd/katalyst-webhook/app/webhook.go
+++ b/cmd/katalyst-webhook/app/webhook.go
@@ -115,6 +115,7 @@ func NewWebhookInitializers() map[string]InitFunc {
 	webhooks := make(map[string]InitFunc)
 	webhooks[validating.VPAWebhookName] = validating.StartVPAWebhook
 	webhooks[mutating.PodWebhookName] = mutating.StartPodWebhook
+	webhooks[mutating.NodeWebhookName] = mutating.StartNodeWebhook
 	return webhooks
 }
 

--- a/cmd/katalyst-webhook/app/webhook/mutating/node.go
+++ b/cmd/katalyst-webhook/app/webhook/mutating/node.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutating
+
+import (
+	"context"
+
+	katalyst "github.com/kubewharf/katalyst-core/cmd/base"
+	webhookconsts "github.com/kubewharf/katalyst-core/cmd/katalyst-webhook/app/webhook"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	webhookconfig "github.com/kubewharf/katalyst-core/pkg/config/webhook"
+	"github.com/kubewharf/katalyst-core/pkg/webhook/mutating/node"
+)
+
+const (
+	NodeWebhookName = "node"
+)
+
+func StartNodeWebhook(
+	ctx context.Context,
+	webhookCtx *katalyst.GenericContext,
+	genericConf *generic.GenericConfiguration,
+	webhookGenericConf *webhookconfig.GenericWebhookConfiguration,
+	webhookConf *webhookconfig.WebhooksConfiguration,
+	name string,
+) (*webhookconsts.WebhookWrapper, error) {
+	v, run, err := node.NewWebhookNode(ctx, webhookCtx, genericConf, webhookGenericConf, webhookConf)
+	if err != nil {
+		return nil, err
+	}
+	return &webhookconsts.WebhookWrapper{
+		Name:      name,
+		StartFunc: run,
+		Webhook:   v,
+	}, nil
+}

--- a/pkg/util/native/resources.go
+++ b/pkg/util/native/resources.go
@@ -227,3 +227,45 @@ func ResourceQuantityToInt64Value(resourceName v1.ResourceName, quantity resourc
 func getResourceMetricsName(resourceName v1.ResourceName, quantity resource.Quantity) (string, int64) {
 	return resourceName.String(), ResourceQuantityToInt64Value(resourceName, quantity)
 }
+
+// MultiplyResourceQuantity scales quantity according to its resource name.
+func MultiplyResourceQuantity(resourceName v1.ResourceName, quantity resource.Quantity, y float64) resource.Quantity {
+	switch resourceName {
+	case v1.ResourceCPU:
+		return MultiplyMilliQuantity(quantity, y)
+	case v1.ResourceMemory:
+		fallthrough
+	default:
+		return MultiplyQuantity(quantity, y)
+	}
+}
+
+// MultiplyMilliQuantity scales quantity by y.
+func MultiplyMilliQuantity(quantity resource.Quantity, y float64) resource.Quantity {
+	if 0 == y {
+		return *resource.NewMilliQuantity(0, quantity.Format)
+	}
+
+	milliValue := quantity.MilliValue()
+	if 0 == milliValue {
+		return quantity
+	}
+
+	milliValue = int64(float64(milliValue) * y)
+	return *resource.NewMilliQuantity(milliValue, quantity.Format)
+}
+
+// MultiplyQuantity scales quantity by y.
+func MultiplyQuantity(quantity resource.Quantity, y float64) resource.Quantity {
+	if 0 == y {
+		return *resource.NewQuantity(0, quantity.Format)
+	}
+
+	value := quantity.Value()
+	if 0 == value {
+		return quantity
+	}
+
+	value = int64(float64(value) * y)
+	return *resource.NewQuantity(value, quantity.Format)
+}

--- a/pkg/webhook/mutating/node/allocatable_mutator.go
+++ b/pkg/webhook/mutating/node/allocatable_mutator.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"strconv"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	core "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+const (
+	nodeAllocatableMutatorName = "nodeAllocatableMutator"
+)
+
+// WebhookNodeAllocatableMutator mutate node allocatable according to overcommit annotation
+type WebhookNodeAllocatableMutator struct{}
+
+func NewWebhookNodeAllocatableMutator() *WebhookNodeAllocatableMutator {
+	return &WebhookNodeAllocatableMutator{}
+}
+
+func (na *WebhookNodeAllocatableMutator) MutateNode(node *core.Node, admissionRequest *admissionv1beta1.AdmissionRequest) error {
+	if admissionv1beta1.Update != admissionRequest.Operation || admissionRequest.SubResource != "status" {
+		return nil
+	}
+
+	if node == nil {
+		err := fmt.Errorf("node is nil")
+		klog.Error(err)
+		return err
+	}
+
+	nodeAnnotations := node.Annotations
+	if nodeAnnotations == nil {
+		nodeAnnotations = make(map[string]string)
+	}
+
+	nodeAnnotations[consts.NodeAnnotationOriginalCapacityCPUKey] = node.Status.Capacity.Cpu().String()
+	nodeAnnotations[consts.NodeAnnotationOriginalCapacityMemoryKey] = node.Status.Capacity.Memory().String()
+	nodeAnnotations[consts.NodeAnnotationOriginalAllocatableCPUKey] = node.Status.Allocatable.Cpu().String()
+	nodeAnnotations[consts.NodeAnnotationOriginalAllocatableMemoryKey] = node.Status.Allocatable.Memory().String()
+	node.Annotations = nodeAnnotations
+
+	CPUOvercommitRatioValue, ok := node.Annotations[consts.NodeAnnotationCPUOvercommitRatioKey]
+	if ok {
+		CPUOvercommitRatio, err := overcommitRatioValidate(CPUOvercommitRatioValue)
+		if err != nil {
+			klog.Errorf("node %s %s validate fail, value: %s, err: %v", node.Name, consts.NodeAnnotationCPUOvercommitRatioKey, CPUOvercommitRatioValue, err)
+		} else {
+			if CPUOvercommitRatio > 1.0 {
+				allocatable := node.Status.Allocatable.Cpu()
+				capacity := node.Status.Capacity.Cpu()
+				newAllocatable := native.MultiplyResourceQuantity(core.ResourceCPU, *allocatable, CPUOvercommitRatio)
+				newCapacity := native.MultiplyResourceQuantity(core.ResourceCPU, *capacity, CPUOvercommitRatio)
+				klog.V(6).Infof(
+					"node %s %s capacity: %v, allocatable: %v, newCapacity: %v, newAllocatable: %v",
+					node.Name, core.ResourceCPU,
+					capacity.String(), newCapacity.String(),
+					allocatable.String(), newAllocatable.String())
+				node.Status.Allocatable[core.ResourceCPU] = newAllocatable
+				node.Status.Capacity[core.ResourceCPU] = newCapacity
+			}
+		}
+	}
+
+	memoryOvercommitRatioValue, ok := node.Annotations[consts.NodeAnnotationMemoryOvercommitRatioKey]
+	if ok {
+		memoryOvercommitRatio, err := overcommitRatioValidate(memoryOvercommitRatioValue)
+		if err != nil {
+			klog.Errorf("node %s %s validate fail, value: %s, err: %v", node.Name, consts.NodeAnnotationMemoryOvercommitRatioKey, memoryOvercommitRatioValue, err)
+		} else {
+			if memoryOvercommitRatio > 1.0 {
+				allocatable := node.Status.Allocatable.Memory()
+				capacity := node.Status.Capacity.Memory()
+				newAllocatable := native.MultiplyResourceQuantity(core.ResourceMemory, *allocatable, memoryOvercommitRatio)
+				newCapacity := native.MultiplyResourceQuantity(core.ResourceMemory, *capacity, memoryOvercommitRatio)
+				klog.V(6).Infof("node %s %s capacity: %v, allocatable: %v, newCapacity: %v, newAllocatable: %v",
+					node.Name, core.ResourceMemory,
+					capacity.String(), newCapacity.String(),
+					allocatable.String(), newAllocatable.String())
+				node.Status.Allocatable[core.ResourceMemory] = newAllocatable
+				node.Status.Capacity[core.ResourceMemory] = newCapacity
+			}
+		}
+	}
+
+	return nil
+}
+
+func (na *WebhookNodeAllocatableMutator) Name() string {
+	return nodeAllocatableMutatorName
+}
+
+func overcommitRatioValidate(overcommitRatioAnnotation string) (float64, error) {
+	overcommitRatio, err := strconv.ParseFloat(overcommitRatioAnnotation, 64)
+	if err != nil {
+		return 1, err
+	}
+
+	if overcommitRatio < 1.0 {
+		err = fmt.Errorf("overcommitRatio should be greater than 1")
+		return 1, err
+	}
+
+	return overcommitRatio, nil
+}

--- a/pkg/webhook/mutating/node/node.go
+++ b/pkg/webhook/mutating/node/node.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kubewebhook "github.com/slok/kubewebhook/pkg/webhook"
+	whcontext "github.com/slok/kubewebhook/pkg/webhook/context"
+	"github.com/slok/kubewebhook/pkg/webhook/mutating"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	katalystbase "github.com/kubewharf/katalyst-core/cmd/base"
+	webhookconsts "github.com/kubewharf/katalyst-core/cmd/katalyst-webhook/app/webhook"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	webhookconfig "github.com/kubewharf/katalyst-core/pkg/config/webhook"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+type WebhookNodeMutator interface {
+	MutateNode(node *core.Node, admissionRequest *admissionv1beta1.AdmissionRequest) error
+	Name() string
+}
+
+// WebhookNode is the implementation of Kubernetes Webhook
+// any implementation should at least implement the interface of mutating.Mutator of validating.Validator
+type WebhookNode struct {
+	ctx context.Context
+
+	metricEmitter metrics.MetricEmitter
+
+	mutators []WebhookNodeMutator
+}
+
+func NewWebhookNode(
+	ctx context.Context,
+	webhookCtx *katalystbase.GenericContext,
+	_ *generic.GenericConfiguration,
+	_ *webhookconfig.GenericWebhookConfiguration,
+	_ *webhookconfig.WebhooksConfiguration,
+) (kubewebhook.Webhook, webhookconsts.GenericStartFunc, error) {
+	metricEmitter := webhookCtx.EmitterPool.GetDefaultMetricsEmitter()
+	if metricEmitter == nil {
+		metricEmitter = metrics.DummyMetrics{}
+	}
+
+	wn := &WebhookNode{
+		ctx:           ctx,
+		metricEmitter: metricEmitter,
+		mutators:      []WebhookNodeMutator{},
+	}
+
+	wn.mutators = append(
+		wn.mutators,
+		NewWebhookNodeAllocatableMutator(),
+	)
+
+	cfg := mutating.WebhookConfig{
+		Name: "nodeMutator",
+		Obj:  &core.Node{},
+	}
+	webhook, err := mutating.NewWebhook(cfg, wn, nil, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return webhook, wn.Run, nil
+}
+
+func (wn *WebhookNode) Run() bool {
+	klog.Infof("node webhook run")
+
+	return true
+}
+
+func (wn *WebhookNode) Mutate(ctx context.Context, obj metav1.Object) (bool, error) {
+	klog.V(5).Info("webhookNode notice an obj to be mutated")
+
+	node, ok := obj.(*core.Node)
+	if !ok {
+		err := fmt.Errorf("failed to convert obj to node: %v", obj)
+		klog.Error(err)
+		return false, err
+	}
+	if node == nil {
+		err := fmt.Errorf("node can't be nil")
+		klog.Error(err)
+		return false, err
+	}
+
+	admissionRequest := whcontext.GetAdmissionRequest(ctx)
+	if admissionRequest == nil {
+		err := fmt.Errorf("failed to get admission request from ctx")
+		klog.Error(err)
+		return false, err
+	}
+
+	klog.V(5).Infof("begin to mutate node %s", node.Name)
+	for _, mutator := range wn.mutators {
+		start := time.Now()
+		err := mutator.MutateNode(node, admissionRequest)
+		if err != nil {
+			klog.Errorf("failed to mutate node %s: %v", node.Name, err)
+			wn.emitMetrics(false, start, mutator)
+			return false, err
+		}
+		wn.emitMetrics(true, start, mutator)
+	}
+	klog.Infof("node %s was mutated", node.Name)
+	return true, nil
+}
+
+func (wn *WebhookNode) emitMetrics(success bool, start time.Time, mutator WebhookNodeMutator) {
+	_ = wn.metricEmitter.StoreInt64("node_mutator_request_total", 1, metrics.MetricTypeNameCount, metrics.MetricTag{Key: "type", Val: mutator.Name()})
+	_ = wn.metricEmitter.StoreFloat64("node_mutator_latency", time.Since(start).Seconds(), metrics.MetricTypeNameCount, metrics.MetricTag{Key: "type", Val: mutator.Name()})
+	if !success {
+		_ = wn.metricEmitter.StoreInt64("node_mutator_request_fail", 1, metrics.MetricTypeNameCount, metrics.MetricTag{Key: "type", Val: mutator.Name()})
+	}
+}

--- a/pkg/webhook/mutating/node/node_test.go
+++ b/pkg/webhook/mutating/node/node_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	whcontext "github.com/slok/kubewebhook/pkg/webhook/context"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	katalystbase "github.com/kubewharf/katalyst-core/cmd/base"
+)
+
+func TestMutateNode(t *testing.T) {
+	t.Parallel()
+
+	node0 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				apiconsts.NodeAnnotationCPUOvercommitRatioKey:    "2",
+				apiconsts.NodeAnnotationMemoryOvercommitRatioKey: "1.2",
+			},
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("192Gi"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(44, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("186Gi"),
+			},
+		},
+	}
+	node1 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node1",
+			Namespace: "default",
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("192Gi"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(44, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("186Gi"),
+			},
+		},
+	}
+	node2 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node2",
+			Namespace: "default",
+			Annotations: map[string]string{
+				apiconsts.NodeAnnotationCPUOvercommitRatioKey: "2",
+			},
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("192Gi"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(44, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("186Gi"),
+			},
+		},
+	}
+	node3 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node3",
+			Namespace: "default",
+			Annotations: map[string]string{
+				apiconsts.NodeAnnotationMemoryOvercommitRatioKey: "1.2",
+			},
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("192Gi"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(44, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("186Gi"),
+			},
+		},
+	}
+	node4 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node4",
+			Namespace: "default",
+			Annotations: map[string]string{
+				apiconsts.NodeAnnotationMemoryOvercommitRatioKey: "1.2",
+				apiconsts.NodeAnnotationCPUOvercommitRatioKey:    "illegal value",
+			},
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("192Gi"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(44, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("186Gi"),
+			},
+		},
+	}
+	node5 := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node5",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"testKey": "testVal",
+			},
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(48, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("192Gi"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(44, resource.DecimalSI),
+				v1.ResourceMemory: resource.MustParse("186Gi"),
+			},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		review   *admissionv1beta1.AdmissionReview
+		expPatch []string
+		allow    bool
+	}{
+		{
+			name: "node with overcommit annotation",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case0",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node0),
+					},
+					Operation:   admissionv1beta1.Update,
+					SubResource: "status",
+				},
+			},
+			// 44 * 2 = 88, 186 * 1024 * 1024 * 1024 * 1.2 = 239659175116.8
+			expPatch: []string{
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_cpu","value":"44"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_memory","value":"186Gi"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_cpu","value":"48"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_memory","value":"192Gi"}`,
+				`{"op":"replace","path":"/status/allocatable/cpu","value":"88"},{"op":"replace","path":"/status/allocatable/memory","value":"239659175116"}`,
+				`{"op":"replace","path":"/status/capacity/cpu","value":"96"},{"op":"replace","path":"/status/capacity/memory","value":"247390116249"}`,
+			},
+			allow: true,
+		},
+		{
+			name: "node without annotation",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case1",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node1),
+					},
+					Operation:   admissionv1beta1.Update,
+					SubResource: "status",
+				},
+			},
+			expPatch: []string{
+				`{"op":"add","path":"/metadata/annotations","value":{"katalyst.kubewharf.io/original_allocatable_cpu":"44","katalyst.kubewharf.io/original_allocatable_memory":"186Gi","katalyst.kubewharf.io/original_capacity_cpu":"48","katalyst.kubewharf.io/original_capacity_memory":"192Gi"}}`,
+			},
+			allow: true,
+		},
+		{
+			name: "node with only CPU overcommit annotation",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case2",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node2),
+					},
+					Operation:   admissionv1beta1.Update,
+					SubResource: "status",
+				},
+			},
+			expPatch: []string{
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_cpu","value":"44"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_memory","value":"186Gi"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_cpu","value":"48"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_memory","value":"192Gi"}`,
+				`{"op":"replace","path":"/status/allocatable/cpu","value":"88"}`,
+				`{"op":"replace","path":"/status/capacity/cpu","value":"96"}`,
+			},
+			allow: true,
+		},
+		{
+			name: "node with only memory overcommit annotation",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case3",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node3),
+					},
+					Operation:   admissionv1beta1.Update,
+					SubResource: "status",
+				},
+			},
+			expPatch: []string{
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_cpu","value":"44"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_memory","value":"186Gi"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_cpu","value":"48"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_memory","value":"192Gi"}`,
+				`{"op":"replace","path":"/status/allocatable/memory","value":"239659175116"}`,
+				`{"op":"replace","path":"/status/capacity/memory","value":"247390116249"}`,
+			},
+			allow: true,
+		},
+		{
+			name: "node with illegal overcommit annotation",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case4",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node4),
+					},
+					Operation:   admissionv1beta1.Update,
+					SubResource: "status",
+				},
+			},
+			expPatch: []string{
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_cpu","value":"44"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_memory","value":"186Gi"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_cpu","value":"48"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_memory","value":"192Gi"}`,
+				`{"op":"replace","path":"/status/allocatable/memory","value":"239659175116"}`,
+				`{"op":"replace","path":"/status/capacity/memory","value":"247390116249"}`,
+			},
+			allow: true,
+		},
+		{
+			name: "CREATE request",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case5",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node0),
+					},
+					Operation:   admissionv1beta1.Create,
+					SubResource: "status",
+				},
+			},
+			expPatch: []string{`[]`},
+			allow:    true,
+		},
+		{
+			name: "node without overcommit annotation",
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID: "case6",
+					Object: runtime.RawExtension{
+						Raw: nodeToJson(node5),
+					},
+					Operation:   admissionv1beta1.Update,
+					SubResource: "status",
+				},
+			},
+			expPatch: []string{
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_cpu","value":"44"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_allocatable_memory","value":"186Gi"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_cpu","value":"48"}`,
+				`{"op":"add","path":"/metadata/annotations/katalyst.kubewharf.io~1original_capacity_memory","value":"192Gi"}`,
+			},
+			allow: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			controlCtx, err := katalystbase.GenerateFakeGenericContext()
+			assert.NoError(t, err)
+
+			ctx := context.Background()
+			ctx = whcontext.SetAdmissionRequest(ctx, c.review.Request)
+
+			wh, _, err := NewWebhookNode(context.TODO(), controlCtx, nil, nil, nil)
+			assert.NoError(t, err)
+
+			gotResponse := wh.Review(ctx, c.review)
+			assert.Equal(t, gotResponse.Allowed, c.allow)
+			assert.Equal(t, gotResponse.UID, c.review.Request.UID)
+			for i := range c.expPatch {
+				assert.Contains(t, string(gotResponse.Patch), c.expPatch[i])
+			}
+		})
+	}
+}
+
+func nodeToJson(node *v1.Node) []byte {
+	nj, _ := json.Marshal(node)
+	return nj
+}


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
add a node mutatingwebhook.
this webhook hijack node.status updating requests, amplify node allocatable and capacity by node overcommitment annotations, which supports node resource overcommitment without users' awareness

#### Which issue(s) this PR fixes:
#214 
