### PR TITLE
some rand functions are deprecated

### DIFF
--- a/cmd/katalyst-agent/main.go
+++ b/cmd/katalyst-agent/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -42,7 +40,6 @@ func main() {
 	}
 	_ = commandLine.Parse(os.Args[1:])
 
-	rand.Seed(time.Now().UnixNano())
 	conf, err := opt.Config()
 	if err != nil {
 		fmt.Printf("parse config error: %v\n", err)

--- a/cmd/katalyst-controller/main.go
+++ b/cmd/katalyst-controller/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -43,7 +41,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	if err := app.Run(opt); err != nil {
 		fmt.Printf("run command error: %v\n", err)
 		os.Exit(1)

--- a/cmd/katalyst-metric/main.go
+++ b/cmd/katalyst-metric/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -43,7 +41,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	if err := app.Run(opt); err != nil {
 		fmt.Printf("run command error: %v\n", err)
 		os.Exit(1)

--- a/cmd/katalyst-scheduler/main.go
+++ b/cmd/katalyst-scheduler/main.go
@@ -17,9 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/component-base/logs"
@@ -32,8 +30,6 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
-
 	// Register custom plugins to the scheduler framework.
 	// Later they can consist of scheduler profile(s) and hence
 	// used by various kinds of workloads.

--- a/cmd/katalyst-webhook/main.go
+++ b/cmd/katalyst-webhook/main.go
@@ -18,9 +18,7 @@ package main
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -42,8 +40,6 @@ func main() {
 		fmt.Printf("parse command error: %v\n", err)
 		os.Exit(1)
 	}
-
-	rand.Seed(time.Now().UnixNano())
 	if err := app.Run(opt); err != nil {
 		fmt.Printf("run command error: %v\n", err)
 		os.Exit(1)

--- a/pkg/agent/qrm-plugins/network/staticpolicy/util.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/util.go
@@ -227,8 +227,8 @@ func filterNICsByHint(nics []machine.InterfaceInfo, req *pluginapi.ResourceReque
 }
 
 func getRandomNICs(nics []machine.InterfaceInfo) machine.InterfaceInfo {
-	rand.Seed(time.Now().UnixNano())
-	return nics[rand.Intn(len(nics))]
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return nics[r.Intn(len(nics))]
 }
 
 func selectOneNIC(nics []machine.InterfaceInfo, policy NICSelectionPoligy) machine.InterfaceInfo {

--- a/pkg/metaserver/agent/metric/malachite/fetcher.go
+++ b/pkg/metaserver/agent/metric/malachite/fetcher.go
@@ -18,8 +18,8 @@ package malachite
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
 	"sync"


### PR DESCRIPTION
#### What type of PR is this?
<!--
Enhancements
-->

#### What this PR does / why we need it:
1. rand.Seed:
Deprecated: Programs that call Seed and then expect a specific sequence of results from the global random source (using functions such as Int) can be broken when a dependency changes how much it consumes from the global random source. To avoid such breakages, programs that need a specific result sequence should use NewRand(NewSource(seed)) to obtain a random generator that other packages cannot access.
2. rand.Read
Deprecated: For almost all use cases, crypto/rand.Read is more appropriate.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
