### PR TITLE
Fix reporter plugin re-register data loss

### DIFF
--- a/pkg/agent/resourcemanager/fetcher/plugin/endpoint.go
+++ b/pkg/agent/resourcemanager/fetcher/plugin/endpoint.go
@@ -61,7 +61,8 @@ type Endpoint interface {
 
 // NewRemoteEndpoint creates a new Endpoint for the given reporter' plugin name.
 // This is to be used during normal reporter' plugin registration.
-func NewRemoteEndpoint(socketPath, pluginName string, emitter metrics.MetricEmitter, callback ListAndWatchCallback) (Endpoint, error) {
+func NewRemoteEndpoint(socketPath, pluginName string, cache *v1alpha1.GetReportContentResponse,
+	emitter metrics.MetricEmitter, callback ListAndWatchCallback) (Endpoint, error) {
 	c, err := process.Dial(socketPath, dialRemoteEndpointTimeout)
 	if err != nil {
 		klog.Errorf("Can't create new Endpoint with path %s err %v", socketPath, err)
@@ -74,6 +75,7 @@ func NewRemoteEndpoint(socketPath, pluginName string, emitter metrics.MetricEmit
 
 		socketPath: socketPath,
 		pluginName: pluginName,
+		cache:      cache,
 		emitter:    emitter,
 
 		cb:          callback,

--- a/pkg/agent/resourcemanager/fetcher/plugin/endpoint_test.go
+++ b/pkg/agent/resourcemanager/fetcher/plugin/endpoint_test.go
@@ -193,7 +193,7 @@ func esetup(t *testing.T, content []*v1alpha1.ReportContent, socket, pluginName 
 	err := p.Start()
 	require.NoError(t, err)
 
-	e, err := NewRemoteEndpoint(path.Join(socket, fmt.Sprintf("%s.sock", p.Name())), pluginName, metrics.DummyMetrics{}, callback)
+	e, err := NewRemoteEndpoint(path.Join(socket, fmt.Sprintf("%s.sock", p.Name())), pluginName, nil, metrics.DummyMetrics{}, callback)
 	require.NoError(t, err)
 
 	return ps, p, e


### PR DESCRIPTION
…tReportContent return error

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Fixed the issue of data loss in the reporter plugin when the plugin is re-registered and the first call to GetReportContent returns an error.
