### PR TITLE
fallback to canonical when reclaim disabled; add buffer ratio for cpu estimation

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama.go
@@ -139,7 +139,19 @@ func (p *PolicyRama) sanityCheck() error {
 		errList []error
 	)
 
-	// 1. check control knob legality
+	enableReclaim := p.conf.GetDynamicConfiguration().EnableReclaim
+
+	// 1. check if enable reclaim
+	if !enableReclaim {
+		errList = append(errList, fmt.Errorf("reclaim disabled"))
+	}
+
+	// 2. check margin. skip update when margin is non zero
+	if p.ResourceEssentials.ReservedForAllocate != 0 {
+		errList = append(errList, fmt.Errorf("margin exists"))
+	}
+
+	// 3. check control knob legality
 	isLegal = true
 	if p.ControlKnobs == nil || len(p.ControlKnobs) <= 0 {
 		isLegal = false
@@ -153,14 +165,9 @@ func (p *PolicyRama) sanityCheck() error {
 		errList = append(errList, fmt.Errorf("illegal control knob %v", p.ControlKnobs))
 	}
 
-	// 2. check indicators legality
+	// 4. check indicators legality
 	if p.Indicators == nil {
 		errList = append(errList, fmt.Errorf("illegal indicators"))
-	}
-
-	// 4. check margin. skip update when margin is non zero
-	if p.ResourceEssentials.ReservedForAllocate != 0 {
-		errList = append(errList, fmt.Errorf("margin exists"))
 	}
 
 	return errors.NewAggregate(errList)

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama_test.go
@@ -97,6 +97,8 @@ func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string)
 		},
 	}
 
+	conf.GetDynamicConfiguration().EnableReclaim = true
+
 	return conf
 }
 


### PR DESCRIPTION
#### What type of PR is this?
Features/Bug fixes

#### What this PR does / why we need it:
Fallback from rama to canonical policy when reclaim is disabled.
Add buffer ratio for cpu estimation in canonical policy.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
