### PR TITLE
chore(doc): update enhanced k8s installation guide

### DIFF
--- a/docs/install-enhanced-k8s.md
+++ b/docs/install-enhanced-k8s.md
@@ -17,7 +17,7 @@ cd deploy
 wget https://github.com/containerd/containerd/releases/download/v1.4.12/containerd-1.4.12-linux-amd64.tar.gz
 wget https://github.com/opencontainers/runc/releases/download/v1.1.1/runc.amd64
 wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.25.0/crictl-v1.25.0-linux-amd64.tar.gz
-wget https://github.com/kubewharf/enhanced-k8s/releases/download/v1.24.6-kubewharf.4/kubernetes-node-linux-amd64.tar.gz
+wget https://github.com/kubewharf/enhanced-k8s/releases/download/v1.24.6-kubewharf.7/kubernetes-node-linux-amd64.tar.gz
 
 cd -
 ```
@@ -254,7 +254,7 @@ etcd:
     dataDir: /var/lib/etcd
 imageRepository: kubewharf
 kind: ClusterConfiguration
-kubernetesVersion: v1.24.6-kubewharf.4
+kubernetesVersion: v1.24.6-kubewharf.7
 networking:
   dnsDomain: cluster.local
   serviceSubnet: 172.23.192.0/18


### PR DESCRIPTION
#### What this PR does / why we need it:
katalyst's dependency on enhanced-k8s bumped from 1.24.6-kubewharf.4 to 1.24.6-kubewharf.7 since v0.3.0

#### Which issue(s) this PR fixes:
update docs

#### Special notes for your reviewer:
