### PR TITLE
feat(overcommit): add nodeovercommit controller

### DIFF
--- a/cmd/base/context_fake.go
+++ b/cmd/base/context_fake.go
@@ -40,6 +40,7 @@ import (
 
 	apis "github.com/kubewharf/katalyst-api/pkg/apis/autoscaling/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	overcommitapis "github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
 	workloadapis "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
 	externalfake "github.com/kubewharf/katalyst-api/pkg/client/clientset/versioned/fake"
 	"github.com/kubewharf/katalyst-core/pkg/client"
@@ -235,6 +236,7 @@ func GenerateFakeGenericContext(objects ...[]runtime.Object) (*GenericContext, e
 	utilruntime.Must(apis.AddToScheme(scheme))
 	utilruntime.Must(workloadapis.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(overcommitapis.AddToScheme(scheme))
 
 	fakeMetaClient := metaFake.NewSimpleMetadataClient(scheme, nilObjectFilter(metaObjects)...)
 	fakeInternalClient := externalfake.NewSimpleClientset(nilObjectFilter(internalObjects)...)

--- a/cmd/katalyst-controller/app/controller/overcommit.go
+++ b/cmd/katalyst-controller/app/controller/overcommit.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+
+	katalyst "github.com/kubewharf/katalyst-core/cmd/base"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/controller/overcommit/node"
+)
+
+const (
+	OvercommitControllerName = "overcommit"
+)
+
+func StartOvercommitController(
+	ctx context.Context,
+	controlCtx *katalyst.GenericContext,
+	conf *config.Configuration,
+	_ interface{},
+	_ string,
+) (bool, error) {
+	noc, err := node.NewNodeOvercommitController(
+		ctx,
+		controlCtx,
+		conf.GenericConfiguration,
+		conf.ControllersConfiguration.OvercommitConfig,
+	)
+	if err != nil {
+		klog.Errorf("failed to new nodeOvercommit controller")
+		return false, err
+	}
+
+	go noc.Run()
+	return true, nil
+}

--- a/cmd/katalyst-controller/app/enablecontrollers.go
+++ b/cmd/katalyst-controller/app/enablecontrollers.go
@@ -52,6 +52,7 @@ func init() {
 	controllerInitializers.Store(controller.SPDControllerName, ControllerStarter{Starter: controller.StartSPDController})
 	controllerInitializers.Store(controller.LifeCycleControllerName, ControllerStarter{Starter: controller.StartLifeCycleController})
 	controllerInitializers.Store(controller.MonitorControllerName, ControllerStarter{Starter: controller.StartMonitorController})
+	controllerInitializers.Store(controller.OvercommitControllerName, ControllerStarter{Starter: controller.StartOvercommitController})
 }
 
 // RegisterControllerInitializer is used to register user-defined controllers

--- a/cmd/katalyst-controller/app/options/controller.go
+++ b/cmd/katalyst-controller/app/options/controller.go
@@ -29,15 +29,17 @@ type ControllersOptions struct {
 	*SPDOptions
 	*LifeCycleOptions
 	*MonitorOptions
+	*OvercommitOptions
 }
 
 func NewControllersOptions() *ControllersOptions {
 	return &ControllersOptions{
-		VPAOptions:       NewVPAOptions(),
-		KCCOptions:       NewKCCOptions(),
-		SPDOptions:       NewSPDOptions(),
-		LifeCycleOptions: NewLifeCycleOptions(),
-		MonitorOptions:   NewMonitorOptions(),
+		VPAOptions:        NewVPAOptions(),
+		KCCOptions:        NewKCCOptions(),
+		SPDOptions:        NewSPDOptions(),
+		LifeCycleOptions:  NewLifeCycleOptions(),
+		MonitorOptions:    NewMonitorOptions(),
+		OvercommitOptions: NewOvercommitOptions(),
 	}
 }
 
@@ -47,6 +49,7 @@ func (o *ControllersOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	o.SPDOptions.AddFlags(fss)
 	o.LifeCycleOptions.AddFlags(fss)
 	o.MonitorOptions.AddFlags(fss)
+	o.OvercommitOptions.AddFlags(fss)
 }
 
 // ApplyTo fills up config with options
@@ -58,6 +61,7 @@ func (o *ControllersOptions) ApplyTo(c *controllerconfig.ControllersConfiguratio
 	errList = append(errList, o.SPDOptions.ApplyTo(c.SPDConfig))
 	errList = append(errList, o.LifeCycleOptions.ApplyTo(c.LifeCycleConfig))
 	errList = append(errList, o.MonitorOptions.ApplyTo(c.MonitorConfig))
+	errList = append(errList, o.OvercommitOptions.ApplyTo(c.OvercommitConfig))
 	return errors.NewAggregate(errList)
 }
 

--- a/cmd/katalyst-controller/app/options/overcommit.go
+++ b/cmd/katalyst-controller/app/options/overcommit.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"time"
+
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/controller"
+)
+
+const (
+	defaultNodeOvercommitSyncWorkers     = 1
+	defaultNodeOvercommitReconcilePeriod = 30 * time.Minute
+)
+
+// OvercommitOptions holds the configurations for overcommit.
+type OvercommitOptions struct {
+	NodeOvercommitOptions
+}
+
+// NodeOvercommitOptions holds the configurations for nodeOvercommitConfig controller.
+type NodeOvercommitOptions struct {
+	// numer of workers to sync overcommit config
+	SyncWorkers int
+
+	// time interval of reconcile overcommit config
+	ConfigReconcilePeriod time.Duration
+}
+
+// NewOvercommitOptions creates a new Options with a default config.
+func NewOvercommitOptions() *OvercommitOptions {
+	return &OvercommitOptions{}
+}
+
+// AddFlags adds flags to the specified FlagSet
+func (o *OvercommitOptions) AddFlags(fss *cliflag.NamedFlagSets) {
+	fs := fss.FlagSet("noc")
+
+	fs.IntVar(&o.SyncWorkers, "nodeovercommit-sync-workers", defaultNodeOvercommitSyncWorkers, "num of goroutines to sync nodeovercommitconfig")
+	fs.DurationVar(&o.ConfigReconcilePeriod, "nodeovercommit-reconcile-period", defaultNodeOvercommitReconcilePeriod, "Period for nodeovercommit controller to sync configs")
+}
+
+func (o *OvercommitOptions) ApplyTo(c *controller.OvercommitConfig) error {
+	c.Node.SyncWorkers = o.SyncWorkers
+	c.Node.ConfigReconcilePeriod = o.ConfigReconcilePeriod
+	return nil
+}
+
+func (o *OvercommitOptions) Config() (*controller.OvercommitConfig, error) {
+	c := &controller.OvercommitConfig{}
+	if err := o.ApplyTo(c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/pkg/client/control/noc.go
+++ b/pkg/client/control/noc.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+
+	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+	clientset "github.com/kubewharf/katalyst-api/pkg/client/clientset/versioned"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+type NocUpdater interface {
+	PatchNocStatus(ctx context.Context, oldNoc, newNoc *v1alpha1.NodeOvercommitConfig) (*v1alpha1.NodeOvercommitConfig, error)
+}
+
+type DummyNocUpdater struct{}
+
+func (d *DummyNocUpdater) PatchNocStatus(_ context.Context, _, newNoc *v1alpha1.NodeOvercommitConfig) (*v1alpha1.NodeOvercommitConfig, error) {
+	return newNoc, nil
+}
+
+func NewRealNocUpdater(client clientset.Interface) NocUpdater {
+	return &RealNocUpdater{
+		client: client,
+	}
+}
+
+type RealNocUpdater struct {
+	client clientset.Interface
+}
+
+func (r *RealNocUpdater) PatchNocStatus(ctx context.Context, oldNoc, newNoc *v1alpha1.NodeOvercommitConfig) (*v1alpha1.NodeOvercommitConfig, error) {
+	if oldNoc == nil || newNoc == nil {
+		return nil, fmt.Errorf("can't patch a nil noc")
+	}
+
+	oldData, err := json.Marshal(v1alpha1.NodeOvercommitConfig{Status: oldNoc.Status})
+	if err != nil {
+		return nil, err
+	}
+	newData, err := json.Marshal(v1alpha1.NodeOvercommitConfig{Status: newNoc.Status})
+	if err != nil {
+		return nil, err
+	}
+
+	patchBytes, err := jsonmergepatch.CreateThreeWayJSONMergePatch(oldData, newData, oldData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create merge patch for nodeOvercommitConfig %s: %v",
+			oldNoc.Name, err)
+	}
+	if general.JsonPathEmpty(patchBytes) {
+		return newNoc, nil
+	}
+
+	return r.client.OvercommitV1alpha1().NodeOvercommitConfigs().Patch(ctx, oldNoc.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+}

--- a/pkg/client/control/node.go
+++ b/pkg/client/control/node.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+// NodeUpdater is used to update Node
+type NodeUpdater interface {
+	PatchNode(ctx context.Context, oldNode, newNode *core.Node) error
+	UpdateNode(ctx context.Context, node *core.Node, opts metav1.UpdateOptions) (*core.Node, error)
+}
+
+type DummyNodeUpdater struct{}
+
+func (d *DummyNodeUpdater) UpdateNode(_ context.Context, _ *core.Node, _ metav1.UpdateOptions) (*core.Node, error) {
+	return nil, nil
+}
+
+func (d *DummyNodeUpdater) PatchNode(_ context.Context, _, _ *core.Node) error {
+	return nil
+}
+
+type RealNodeUpdater struct {
+	client kubernetes.Interface
+}
+
+func NewRealNodeUpdater(client kubernetes.Interface) *RealNodeUpdater {
+	return &RealNodeUpdater{
+		client: client,
+	}
+}
+
+func (r *RealNodeUpdater) UpdateNode(ctx context.Context, node *core.Node, opts metav1.UpdateOptions) (*core.Node, error) {
+	if node == nil {
+		return nil, fmt.Errorf("can't update a nil node")
+	}
+
+	return r.client.CoreV1().Nodes().Update(ctx, node, opts)
+}
+
+func (r *RealNodeUpdater) PatchNode(ctx context.Context, oldNode, newNode *core.Node) error {
+	if oldNode == nil || newNode == nil {
+		return fmt.Errorf("can't update a nil node")
+	}
+
+	oldData, err := json.Marshal(oldNode)
+	if err != nil {
+		return err
+	}
+
+	newData, err := json.Marshal(newNode)
+	if err != nil {
+		return err
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, &core.Node{})
+	if err != nil {
+		return fmt.Errorf("failed to create merge patch for node%q: %v", oldNode.Name, err)
+	}
+	if general.JsonPathEmpty(patchBytes) {
+		return nil
+	}
+
+	_, err = r.client.CoreV1().Nodes().Patch(ctx, oldNode.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
+}

--- a/pkg/config/controller/controller_base.go
+++ b/pkg/config/controller/controller_base.go
@@ -47,6 +47,7 @@ type ControllersConfiguration struct {
 	*SPDConfig
 	*LifeCycleConfig
 	*MonitorConfig
+	*OvercommitConfig
 }
 
 func NewGenericControllerConfiguration() *GenericControllerConfiguration {
@@ -55,10 +56,11 @@ func NewGenericControllerConfiguration() *GenericControllerConfiguration {
 
 func NewControllersConfiguration() *ControllersConfiguration {
 	return &ControllersConfiguration{
-		VPAConfig:       NewVPAConfig(),
-		KCCConfig:       NewKCCConfig(),
-		SPDConfig:       NewSPDConfig(),
-		LifeCycleConfig: NewLifeCycleConfig(),
-		MonitorConfig:   NewMonitorConfig(),
+		VPAConfig:        NewVPAConfig(),
+		KCCConfig:        NewKCCConfig(),
+		SPDConfig:        NewSPDConfig(),
+		LifeCycleConfig:  NewLifeCycleConfig(),
+		MonitorConfig:    NewMonitorConfig(),
+		OvercommitConfig: NewOvercommitConfig(),
 	}
 }

--- a/pkg/config/controller/overcommit.go
+++ b/pkg/config/controller/overcommit.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "time"
+
+type OvercommitConfig struct {
+	Node NodeOvercommitConfig
+}
+
+type NodeOvercommitConfig struct {
+	// numer of workers to sync overcommit config
+	SyncWorkers int
+
+	// time interval of reconcile overcommit config
+	ConfigReconcilePeriod time.Duration
+}
+
+func NewOvercommitConfig() *OvercommitConfig {
+	return &OvercommitConfig{
+		Node: NodeOvercommitConfig{},
+	}
+}

--- a/pkg/controller/overcommit/node/handler.go
+++ b/pkg/controller/overcommit/node/handler.go
@@ -114,17 +114,6 @@ func (nc *NodeOvercommitController) updateNode(old, new interface{}) {
 	nc.enqueueNode(newNode)
 }
 
-func (nc *NodeOvercommitController) deleteNode(obj interface{}) {
-	node, ok := obj.(*v1.Node)
-	if !ok {
-		klog.Errorf("cannot convert obj to *v1.Node: %v", obj)
-		return
-	}
-
-	klog.V(4).Infof("[noc] notice deletion of Node %s", node.Name)
-	nc.enqueueNode(node)
-}
-
 func (nc *NodeOvercommitController) enqueueNodeOvercommitConfig(noc *v1alpha1.NodeOvercommitConfig, eventType eventType) {
 	if noc == nil {
 		klog.Warning("[noc] trying to enqueue a nil config")

--- a/pkg/controller/overcommit/node/handler.go
+++ b/pkg/controller/overcommit/node/handler.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+type nodeOvercommitEvent struct {
+	nodeKey   string
+	configKey string
+	eventType
+}
+
+type eventType string
+
+const (
+	nodeEvent   eventType = "node"
+	configEvent eventType = "config"
+)
+
+func (nc *NodeOvercommitController) addNodeOvercommitConfig(obj interface{}) {
+	noc, ok := obj.(*v1alpha1.NodeOvercommitConfig)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1alpha1.NodeOvercommitConfig: %v", obj)
+		return
+	}
+
+	klog.V(4).Infof("[noc] notice addition of NodeOvercommitConfig %s", native.GenerateUniqObjectNameKey(noc))
+	nc.enqueueNodeOvercommitConfig(noc, configEvent)
+}
+
+func (nc *NodeOvercommitController) updateNodeOvercommitConfig(old, new interface{}) {
+	noc, ok := new.(*v1alpha1.NodeOvercommitConfig)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1alpha1.NodeOvercommitConfig: %v", noc)
+		return
+	}
+
+	klog.V(4).Infof("[noc] notice update of NodeOvercommitConfig %s", native.GenerateUniqObjectNameKey(noc))
+	nc.enqueueNodeOvercommitConfig(noc, configEvent)
+}
+
+func (nc *NodeOvercommitController) deleteNodeOvercommitConfig(obj interface{}) {
+	noc, ok := obj.(*v1alpha1.NodeOvercommitConfig)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1alpha1.NodeOvercommitConfig: %v", obj)
+		return
+	}
+	klog.V(4).Infof("[noc] notice deletion of NodeOvercommitConfig %s", native.GenerateUniqObjectNameKey(noc))
+
+	nc.enqueueNodeOvercommitConfig(noc, configEvent)
+}
+
+func (nc *NodeOvercommitController) addNode(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1.Node: %v", obj)
+		return
+	}
+
+	klog.V(4).Infof("[noc] notice addition of Node %s", node.Name)
+	nc.enqueueNode(node)
+}
+
+func (nc *NodeOvercommitController) updateNode(old, new interface{}) {
+	oldNode, ok := old.(*v1.Node)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1.Node: %v", old)
+		return
+	}
+	newNode, ok := new.(*v1.Node)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1.Node: %v", new)
+		return
+	}
+	var (
+		oldLabel, newLabel string
+	)
+	if len(oldNode.Labels) != 0 {
+		oldLabel = oldNode.Labels[consts.NodeOvercommitSelectorKey]
+	}
+	if len(newNode.Labels) != 0 {
+		newLabel = newNode.Labels[consts.NodeOvercommitSelectorKey]
+	}
+	if oldLabel == newLabel {
+		return
+	}
+
+	klog.V(4).Infof("[noc] notice update of Node %s", newNode.Name)
+	nc.enqueueNode(newNode)
+}
+
+func (nc *NodeOvercommitController) deleteNode(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		klog.Errorf("cannot convert obj to *v1.Node: %v", obj)
+		return
+	}
+
+	klog.V(4).Infof("[noc] notice deletion of Node %s", node.Name)
+	nc.enqueueNode(node)
+}
+
+func (nc *NodeOvercommitController) enqueueNodeOvercommitConfig(noc *v1alpha1.NodeOvercommitConfig, eventType eventType) {
+	if noc == nil {
+		klog.Warning("[noc] trying to enqueue a nil config")
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(noc)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", noc, err))
+		return
+	}
+
+	nc.nocSyncQueue.Add(nodeOvercommitEvent{
+		configKey: key,
+		eventType: eventType,
+	})
+}
+
+func (nc *NodeOvercommitController) enqueueNode(node *v1.Node) {
+	if node == nil {
+		klog.Warning("[noc] trying to enqueue a nil node")
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(node)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", node, err))
+		return
+	}
+
+	nc.nocSyncQueue.Add(nodeOvercommitEvent{
+		nodeKey:   key,
+		eventType: nodeEvent,
+	})
+}

--- a/pkg/controller/overcommit/node/matcher/matcher.go
+++ b/pkg/controller/overcommit/node/matcher/matcher.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+)
+
+type (
+	ConfigToNodes map[string]sets.String
+	NodeToConfig  map[string][]*v1alpha1.NodeOvercommitConfig
+)
+
+type Matcher interface {
+	// Reconcile rematch all configs and nodes
+	Reconcile() error
+
+	// MatchConfig matches nodes for config, return nodeNames whose matched config maybe updated.
+	MatchConfig(configName string) ([]string, error)
+	// MatchNode matches and sorts configs for node.
+	MatchNode(nodeName string)
+	// GetConfig get valid config by nodeName
+	GetConfig(nodeName string) *v1alpha1.NodeOvercommitConfig
+	// GetNodeToConfig get matched and sorted configList by nodeName
+	GetNodeToConfig(nodeName string) []*v1alpha1.NodeOvercommitConfig
+	// ListNodeToConfig list nodes with all matched configNames
+	ListNodeToConfig() map[string][]string
+	// GetNodes get matched nodes by configName
+	GetNodes(configName string) []string
+	// DelNode delete node in matcher cache
+	DelNode(nodeName string)
+}
+
+type NodeIndexer interface {
+	GetNode(nodeName string) (*v1.Node, error)
+	ListNode(selector labels.Selector) ([]*v1.Node, error)
+}
+
+type NocIndexer interface {
+	GetNoc(name string) (*v1alpha1.NodeOvercommitConfig, error)
+	ListNoc() ([]*v1alpha1.NodeOvercommitConfig, error)
+}
+
+type NodeMatchEvent struct {
+	NodeName   string
+	NodeUpdate bool
+}
+
+type DummyMatcher struct{}
+
+func (dm *DummyMatcher) Reconcile() error {
+	return nil
+}
+
+func (dm *DummyMatcher) MatchConfig(configName string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (dm *DummyMatcher) MatchNode(nodeName string) {
+	return
+}
+
+func (dm *DummyMatcher) GetConfig(nodeName string) *v1alpha1.NodeOvercommitConfig {
+	return nil
+}
+
+func (dm *DummyMatcher) DelNode(nodeName string) {}
+
+func (dm *DummyMatcher) GetNodeToConfig(nodeName string) []*v1alpha1.NodeOvercommitConfig {
+	return nil
+}
+
+func (dm *DummyMatcher) ListNodeToConfig() map[string][]string {
+	return nil
+}
+
+func (dm *DummyMatcher) GetNodes(configName string) []string {
+	return nil
+}
+
+func NewMatcher(nodeIndexer NodeIndexer, nocIndexer NocIndexer) *MatcherImpl {
+	return &MatcherImpl{
+		RWMutex:       sync.RWMutex{},
+		nodeIndexer:   nodeIndexer,
+		nocIndexer:    nocIndexer,
+		configToNodes: make(map[string]sets.String),
+		nodeToConfig:  make(map[string][]*v1alpha1.NodeOvercommitConfig),
+	}
+}
+
+type MatcherImpl struct {
+	ctx context.Context
+	sync.RWMutex
+
+	nodeIndexer NodeIndexer
+	nocIndexer  NocIndexer
+
+	configToNodes ConfigToNodes
+	nodeToConfig  NodeToConfig
+}
+
+func (i *MatcherImpl) Reconcile() error {
+	err := i.reconcileConfig()
+	if err != nil {
+		return err
+	}
+
+	return i.reconcoleNode()
+}
+
+func (i *MatcherImpl) reconcileConfig() error {
+	nodeOvercommitConfigs, err := i.nocIndexer.ListNoc()
+	if err != nil {
+		klog.Errorf("list nodeOvercommitConfig fail: %v", err)
+		return err
+	}
+
+	i.Lock()
+	defer i.Unlock()
+	i.configToNodes = make(map[string]sets.String)
+	for _, config := range nodeOvercommitConfigs {
+		nodeNames, err := i.matchConfigToNodes(config)
+		if err != nil {
+			return err
+		}
+
+		i.configToNodes[config.Name] = sets.NewString(nodeNames...)
+	}
+	return nil
+}
+
+func (i *MatcherImpl) reconcoleNode() error {
+	nodeList, err := i.nodeIndexer.ListNode(labels.Everything())
+	if err != nil {
+		klog.Errorf("list node fail: %v", err)
+		return err
+	}
+	nodeOvercommitConfigs, err := i.nocIndexer.ListNoc()
+	if err != nil {
+		klog.Errorf("list nodeOvercommitConfig fail: %v", err)
+		return err
+	}
+
+	i.Lock()
+	defer i.Unlock()
+
+	for _, node := range nodeList {
+		configList := NocList{}
+		for _, config := range nodeOvercommitConfigs {
+			if i.configToNodes[config.Name].Has(node.Name) {
+				configList = append(configList, config)
+			}
+		}
+
+		if configList.Len() <= 0 {
+			delete(i.nodeToConfig, node.Name)
+		} else {
+			sort.Sort(configList)
+			i.nodeToConfig[node.Name] = configList
+		}
+	}
+
+	return nil
+}
+
+func (i *MatcherImpl) GetConfig(nodeName string) *v1alpha1.NodeOvercommitConfig {
+	i.RLock()
+	defer i.RUnlock()
+	configs := i.nodeToConfig[nodeName]
+	if len(configs) == 0 {
+		return nil
+	}
+	return configs[0]
+}
+
+func (i *MatcherImpl) MatchConfig(configName string) ([]string, error) {
+	var nodeUnionSets sets.String
+	nodeNames, err := i.matchConfigNameToNodes(configName)
+	if err != nil && errors.IsNotFound(err) {
+		i.Lock()
+		nodeUnionSets = i.configToNodes[configName]
+		delete(i.configToNodes, configName)
+		i.Unlock()
+		return nodeUnionSets.UnsortedList(), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	i.Lock()
+	nodeUnionSets = i.configNodeUnion(configName, nodeNames)
+	i.configToNodes[configName] = sets.NewString(nodeNames...)
+	i.Unlock()
+	return nodeUnionSets.UnsortedList(), nil
+}
+
+func (i *MatcherImpl) MatchNode(nodeName string) {
+	var (
+		configList = NocList{}
+		err        error
+		config     *v1alpha1.NodeOvercommitConfig
+	)
+
+	i.RLock()
+	for configName, nodeSet := range i.configToNodes {
+		if nodeSet.Has(nodeName) {
+			config, err = i.nocIndexer.GetNoc(configName)
+			if err != nil {
+				klog.Errorf("get nodeOvercommitConfig %s fail: %v", configName, err)
+				continue
+			}
+			configList = append(configList, config)
+		}
+	}
+	i.RUnlock()
+
+	sort.Sort(configList)
+
+	i.Lock()
+	defer i.Unlock()
+	if configList.Len() <= 0 {
+		delete(i.nodeToConfig, nodeName)
+		return
+	}
+
+	i.nodeToConfig[nodeName] = configList
+	return
+}
+
+func (i *MatcherImpl) DelNode(nodeName string) {
+	i.Lock()
+	defer i.Unlock()
+
+	delete(i.nodeToConfig, nodeName)
+	for key := range i.configToNodes {
+		i.configToNodes[key].Delete(nodeName)
+	}
+}
+
+func (i *MatcherImpl) GetNodeToConfig(nodeName string) []*v1alpha1.NodeOvercommitConfig {
+	i.RLock()
+	defer i.RUnlock()
+	return i.nodeToConfig[nodeName]
+}
+
+func (i *MatcherImpl) ListNodeToConfig() map[string][]string {
+	ret := make(map[string][]string)
+	i.RLock()
+	defer i.RUnlock()
+
+	for nodeName, configs := range i.nodeToConfig {
+		ret[nodeName] = make([]string, 0)
+		for i := range configs {
+			ret[nodeName] = append(ret[nodeName], configs[i].Name)
+		}
+	}
+	return ret
+}
+
+func (i *MatcherImpl) GetNodes(configName string) []string {
+	i.RLock()
+	defer i.RUnlock()
+	return i.configToNodes[configName].UnsortedList()
+}
+
+func (i *MatcherImpl) matchConfigNameToNodes(configName string) ([]string, error) {
+	overcommitConfig, err := i.nocIndexer.GetNoc(configName)
+	if err != nil {
+		return nil, err
+	}
+
+	if overcommitConfig == nil {
+		return nil, fmt.Errorf("config %s is nil", configName)
+	}
+
+	return i.matchConfigToNodes(overcommitConfig)
+}
+
+func (i *MatcherImpl) matchConfigToNodes(overcommitConfig *v1alpha1.NodeOvercommitConfig) ([]string, error) {
+	var (
+		nodeNames  = make([]string, 0)
+		configType = NodeOvercommitConfigType(overcommitConfig)
+	)
+
+	switch configType {
+	case ConfigNodeList:
+		for _, nodeName := range overcommitConfig.Spec.NodeList {
+			nodeNames = append(nodeNames, nodeName)
+		}
+		return nodeNames, nil
+	case ConfigSelector:
+		selector, err := metav1.LabelSelectorAsSelector(overcommitConfig.Spec.Selector)
+		if err != nil {
+			klog.Errorf("config %s LabelSelectorAsSelector fail: %v", overcommitConfig.Name, err)
+			return nil, err
+		}
+		nodeList, err := i.nodeIndexer.ListNode(selector)
+		if err != nil {
+			klog.Errorf("list node by %s fail: %v", selector.String(), err)
+			return nil, err
+		}
+		for _, node := range nodeList {
+			nodeNames = append(nodeNames, node.Name)
+		}
+		return nodeNames, nil
+	case ConfigDefault:
+		fallthrough
+	default:
+		nodeList, err := i.nodeIndexer.ListNode(labels.Everything())
+		if err != nil {
+			klog.Errorf("list all node fail: %v", err)
+			return nil, err
+		}
+		for _, node := range nodeList {
+			nodeNames = append(nodeNames, node.Name)
+		}
+		return nodeNames, nil
+	}
+}
+
+func (i *MatcherImpl) configNodeUnion(configName string, nodeNames []string) sets.String {
+	var (
+		newNodes = sets.NewString(nodeNames...)
+	)
+
+	originalNodes, ok := i.configToNodes[configName]
+	if !ok {
+		return newNodes
+	}
+
+	return originalNodes.Union(newNodes)
+}

--- a/pkg/controller/overcommit/node/matcher/matcher_test.go
+++ b/pkg/controller/overcommit/node/matcher/matcher_test.go
@@ -1,0 +1,625 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+)
+
+type FakeNodeIndexer struct {
+	nodeMap map[string]*v1.Node
+}
+
+func newFakeNodeIndexer() *FakeNodeIndexer {
+	return &FakeNodeIndexer{
+		nodeMap: make(map[string]*v1.Node),
+	}
+}
+
+func (fn *FakeNodeIndexer) GetNode(nodeName string) (*v1.Node, error) {
+	if _, ok := fn.nodeMap[nodeName]; !ok {
+		return nil, errors.NewNotFound(v1.Resource("Node"), nodeName)
+	}
+	return fn.nodeMap[nodeName], nil
+}
+
+func (fn *FakeNodeIndexer) ListNode(selector labels.Selector) ([]*v1.Node, error) {
+	nodeList := make([]*v1.Node, 0)
+	for _, node := range fn.nodeMap {
+		if selector.Matches(labels.Set(node.Labels)) {
+			nodeList = append(nodeList, node)
+		}
+	}
+	return nodeList, nil
+}
+
+func (fn *FakeNodeIndexer) add(node *v1.Node) {
+	fn.nodeMap[node.Name] = node
+}
+
+type FakeNocIndexer struct {
+	configMap map[string]*v1alpha1.NodeOvercommitConfig
+}
+
+func newFakeNocIndexer() *FakeNocIndexer {
+	return &FakeNocIndexer{
+		configMap: make(map[string]*v1alpha1.NodeOvercommitConfig),
+	}
+}
+
+func (fn *FakeNocIndexer) GetNoc(name string) (*v1alpha1.NodeOvercommitConfig, error) {
+	if _, ok := fn.configMap[name]; !ok {
+		return nil, errors.NewNotFound(v1.Resource("NodeOvercommitConfig"), name)
+	}
+	return fn.configMap[name], nil
+}
+
+func (fn *FakeNocIndexer) ListNoc() ([]*v1alpha1.NodeOvercommitConfig, error) {
+	configList := make([]*v1alpha1.NodeOvercommitConfig, 0)
+	for _, c := range fn.configMap {
+		configList = append(configList, c)
+	}
+	return configList, nil
+}
+
+func (fn *FakeNocIndexer) add(config *v1alpha1.NodeOvercommitConfig) {
+	fn.configMap[config.Name] = config
+}
+
+func makeTestMatcher() *MatcherImpl {
+	nodeIndexer := makeTestNodeIndexer()
+	nocIndexer := makeTestNocIndexer()
+
+	return NewMatcher(nodeIndexer, nocIndexer)
+}
+
+func makeInitedMatcher() (*MatcherImpl, error) {
+	m := makeTestMatcher()
+	err := m.Reconcile()
+	return m, err
+}
+
+func makeTestNodeIndexer() *FakeNodeIndexer {
+	nodeIndexer := newFakeNodeIndexer()
+
+	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", UID: "01", Labels: map[string]string{"pool": "pool1"}}})
+	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", UID: "02", Labels: map[string]string{"pool": "pool2"}}})
+	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3", UID: "03", Labels: map[string]string{"pool": "pool1"}}})
+	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node4", UID: "04", Labels: map[string]string{"pool": "pool3"}}})
+	return nodeIndexer
+}
+
+func makeTestNocIndexer() *FakeNocIndexer {
+	nocIndexer := newFakeNocIndexer()
+
+	nocIndexer.add(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config1-nodeList",
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			NodeList: []string{
+				"node1",
+				"node2",
+			},
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU:    "1.5",
+				v1.ResourceMemory: "1",
+			},
+		},
+	})
+
+	nocIndexer.add(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config2-default",
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU:    "1",
+				v1.ResourceMemory: "1",
+			},
+		},
+	})
+
+	nocIndexer.add(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config3-selector",
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pool": "pool1",
+				},
+			},
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU: "2",
+			},
+		},
+	})
+
+	return nocIndexer
+}
+
+func makeMatcherByIndexer(nodeIndexer *FakeNodeIndexer, nocIndexer *FakeNocIndexer) *MatcherImpl {
+	matcher := NewMatcher(nodeIndexer, nocIndexer)
+	_ = matcher.Reconcile()
+	return matcher
+}
+
+func TestMatchConfigNameToNodes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		configName string
+		result     []string
+	}{
+		{
+			name:       "nodeList",
+			configName: "config1-nodeList",
+			result:     []string{"node1", "node2"},
+		},
+		{
+			name:       "selector",
+			configName: "config3-selector",
+			result:     []string{"node1", "node3"},
+		},
+		{
+			name:       "default matches all nodes",
+			configName: "config2-default",
+			result:     []string{"node1", "node2", "node3", "node4"},
+		},
+	}
+
+	matcher := makeTestMatcher()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := matcher.matchConfigNameToNodes(tc.configName)
+			assert.Nil(t, err)
+			assert.Equal(t, len(tc.result), len(out))
+		})
+	}
+}
+
+func TestMatchConfig(t *testing.T) {
+	t.Parallel()
+	nodeIndexer1 := makeTestNodeIndexer()
+	nocIndexer1 := makeTestNocIndexer()
+	matcher1 := makeMatcherByIndexer(nodeIndexer1, nocIndexer1)
+	nocIndexer1.configMap["config3-selector"].Spec.Selector.MatchLabels["pool"] = "pool2"
+
+	nodeIndexer2 := makeTestNodeIndexer()
+	nocIndexer2 := makeTestNocIndexer()
+	matcher2 := makeMatcherByIndexer(nodeIndexer2, nocIndexer2)
+	nocIndexer2.add(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config4-selector",
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pool": "pool2",
+				},
+			},
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU: "3",
+			},
+		},
+	})
+
+	nodeIndexer3 := makeTestNodeIndexer()
+	nocIndexer3 := makeTestNocIndexer()
+	matcher3 := makeMatcherByIndexer(nodeIndexer3, nocIndexer3)
+	delete(nocIndexer3.configMap, "config3-selector")
+
+	nodeIndexer4 := makeTestNodeIndexer()
+	nocIndexer4 := makeTestNocIndexer()
+	matcher4 := makeMatcherByIndexer(nodeIndexer4, nocIndexer4)
+	nocIndexer4.configMap["config1-nodeList"].Spec.NodeList = nil
+	nocIndexer4.configMap["config1-nodeList"].Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"pool": "pool2",
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		matcher    Matcher
+		configName string
+		result     []string
+	}{
+		{
+			name:       "update selector",
+			matcher:    matcher1,
+			configName: "config3-selector",
+			result:     []string{"node1", "node2", "node3"},
+		},
+		{
+			name:       "add config",
+			matcher:    matcher2,
+			configName: "config4-selector",
+			result:     []string{"node2"},
+		},
+		{
+			name:       "delete config",
+			matcher:    matcher3,
+			configName: "config3-selector",
+			result:     []string{"node1", "node3"},
+		},
+		{
+			name:       "update config type",
+			matcher:    matcher4,
+			configName: "config1-nodeList",
+			result:     []string{"node1", "node2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.matcher.MatchConfig(tc.configName)
+			assert.Nil(t, err)
+			assert.Equal(t, len(out), len(tc.result))
+		})
+	}
+}
+
+func TestMatchNode(t *testing.T) {
+	t.Parallel()
+	// node1 -> config1-nodeList, node2 -> config1-nodeList, node3 -> config3-selector, node4 -> config2-selector
+
+	nodeIndexer1 := makeTestNodeIndexer()
+	nocIndexer1 := makeTestNocIndexer()
+	matcher1 := makeMatcherByIndexer(nodeIndexer1, nocIndexer1)
+	nocIndexer1.configMap["config3-selector"].Spec.Selector.MatchLabels["pool"] = "pool2"
+
+	nodeIndexer2 := makeTestNodeIndexer()
+	nocIndexer2 := makeTestNocIndexer()
+	matcher2 := makeMatcherByIndexer(nodeIndexer2, nocIndexer2)
+	nocIndexer2.add(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config4-selector",
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"pool": "pool3",
+				},
+			},
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU: "3",
+			},
+		},
+	})
+
+	nodeIndexer3 := makeTestNodeIndexer()
+	nocIndexer3 := makeTestNocIndexer()
+	matcher3 := makeMatcherByIndexer(nodeIndexer3, nocIndexer3)
+	delete(nocIndexer3.configMap, "config3-selector")
+
+	nodeIndexer4 := makeTestNodeIndexer()
+	nocIndexer4 := makeTestNocIndexer()
+	matcher4 := makeMatcherByIndexer(nodeIndexer4, nocIndexer4)
+	nocIndexer4.configMap["config1-nodeList"].Spec.NodeList = nil
+	nocIndexer4.configMap["config1-nodeList"].Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"pool": "pool2",
+		},
+	}
+
+	nodeIndexer5 := makeTestNodeIndexer()
+	nocIndexer5 := makeTestNocIndexer()
+	matcher5 := makeMatcherByIndexer(nodeIndexer5, nocIndexer5)
+	nodeIndexer5.nodeMap["node4"].Labels["pool"] = "pool1"
+
+	nodeIndexer6 := makeTestNodeIndexer()
+	nocIndexer6 := makeTestNocIndexer()
+	matcher6 := makeMatcherByIndexer(nodeIndexer6, nocIndexer6)
+	nodeIndexer6.nodeMap["node1"].Labels = nil
+
+	nodeIndexer7 := makeTestNodeIndexer()
+	nocIndexer7 := makeTestNocIndexer()
+	matcher7 := makeMatcherByIndexer(nodeIndexer7, nocIndexer7)
+	nodeIndexer7.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node5", UID: "05", Labels: map[string]string{"pool": "pool1"}}})
+
+	testCases := []struct {
+		name       string
+		matcher    Matcher
+		configName string
+		nodeName   string
+		oldNodeMap map[string]string
+		newNodeMap map[string]string
+	}{
+		{
+			name:       "update selector",
+			matcher:    matcher1,
+			configName: "config3-selector",
+			nodeName:   "",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config2-default",
+				"node4": "config2-default",
+			},
+		},
+		{
+			name:       "add config",
+			matcher:    matcher2,
+			configName: "config4-selector",
+			nodeName:   "",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config4-selector",
+			},
+		},
+		{
+			name:       "delete config",
+			matcher:    matcher3,
+			configName: "config3-selector",
+			nodeName:   "",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config2-default",
+				"node4": "config2-default",
+			},
+		},
+		{
+			name:       "update config type",
+			matcher:    matcher4,
+			configName: "config1-nodeList",
+			nodeName:   "",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config3-selector",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+		},
+		{
+			name:       "update node label",
+			matcher:    matcher5,
+			configName: "",
+			nodeName:   "node4",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config3-selector",
+			},
+		},
+		{
+			name:       "update node label2",
+			matcher:    matcher6,
+			configName: "",
+			nodeName:   "node1",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+		},
+		{
+			name:       "add node",
+			matcher:    matcher7,
+			configName: "",
+			nodeName:   "node5",
+			oldNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+			},
+			newNodeMap: map[string]string{
+				"node1": "config1-nodeList",
+				"node2": "config1-nodeList",
+				"node3": "config3-selector",
+				"node4": "config2-default",
+				"node5": "config3-selector",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.configName == "" {
+				for _, c := range []string{"config1-nodeList", "config2-default", "config3-selector"} {
+					_, _ = tc.matcher.MatchConfig(c)
+				}
+				tc.matcher.MatchNode(tc.nodeName)
+			} else {
+				nodes, _ := tc.matcher.MatchConfig(tc.configName)
+				for _, node := range nodes {
+					tc.matcher.MatchNode(node)
+				}
+			}
+
+			for k, v := range tc.newNodeMap {
+				config := tc.matcher.GetConfig(k)
+				assert.Equal(t, config.Name, v)
+			}
+		})
+	}
+}
+
+func TestDelNode(t *testing.T) {
+	t.Parallel()
+
+	matcher1, _ := makeInitedMatcher()
+	matcher2, _ := makeInitedMatcher()
+
+	testCases := []struct {
+		name     string
+		nodeName string
+		matcher  *MatcherImpl
+		result   int
+	}{
+		{
+			name:     "exist node",
+			nodeName: "node1",
+			matcher:  matcher1,
+			result:   3,
+		},
+		{
+			name:     "non-existing node",
+			nodeName: "node99",
+			matcher:  matcher2,
+			result:   4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.matcher.DelNode(tc.nodeName)
+			fmt.Printf("testCase: %v", tc)
+			assert.Equal(t, tc.result, len(tc.matcher.nodeToConfig))
+		})
+	}
+}
+
+func TestSort(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		nocList NocList
+		result  string
+	}{
+		{
+			name: "default and selector",
+			nocList: NocList{
+				&v1alpha1.NodeOvercommitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+					Spec: v1alpha1.NodeOvercommitConfigSpec{},
+				},
+				&v1alpha1.NodeOvercommitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "selector",
+					},
+					Spec: v1alpha1.NodeOvercommitConfigSpec{
+						Selector: &metav1.LabelSelector{},
+					},
+				},
+			},
+			result: "selector",
+		},
+		{
+			name: "selector and nodelist",
+			nocList: NocList{
+				&v1alpha1.NodeOvercommitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nodelist",
+					},
+					Spec: v1alpha1.NodeOvercommitConfigSpec{
+						NodeList: []string{},
+					},
+				},
+				&v1alpha1.NodeOvercommitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "selector",
+					},
+					Spec: v1alpha1.NodeOvercommitConfigSpec{
+						Selector: &metav1.LabelSelector{},
+					},
+				},
+			},
+			result: "nodelist",
+		},
+		{
+			name: "creationTimestamp",
+			nocList: NocList{
+				&v1alpha1.NodeOvercommitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "nodelist1",
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+					},
+					Spec: v1alpha1.NodeOvercommitConfigSpec{
+						NodeList: []string{},
+					},
+				},
+				&v1alpha1.NodeOvercommitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "nodelist2",
+						CreationTimestamp: metav1.NewTime(time.Now()),
+					},
+					Spec: v1alpha1.NodeOvercommitConfigSpec{
+						NodeList: []string{},
+					},
+				},
+			},
+			result: "nodelist2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sort.Sort(tc.nocList)
+			assert.Equal(t, tc.result, tc.nocList[0].Name)
+		})
+	}
+}

--- a/pkg/controller/overcommit/node/matcher/matcher_test.go
+++ b/pkg/controller/overcommit/node/matcher/matcher_test.go
@@ -24,78 +24,54 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	v12 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+	v1alpha12 "github.com/kubewharf/katalyst-api/pkg/client/listers/overcommit/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/consts"
 )
 
-type FakeNodeIndexer struct {
-	nodeMap map[string]*v1.Node
-}
-
-func newFakeNodeIndexer() *FakeNodeIndexer {
-	return &FakeNodeIndexer{
-		nodeMap: make(map[string]*v1.Node),
-	}
-}
-
-func (fn *FakeNodeIndexer) GetNode(nodeName string) (*v1.Node, error) {
-	if _, ok := fn.nodeMap[nodeName]; !ok {
-		return nil, errors.NewNotFound(v1.Resource("Node"), nodeName)
-	}
-	return fn.nodeMap[nodeName], nil
-}
-
-func (fn *FakeNodeIndexer) ListNode(selector labels.Selector) ([]*v1.Node, error) {
-	nodeList := make([]*v1.Node, 0)
-	for _, node := range fn.nodeMap {
-		if selector.Matches(labels.Set(node.Labels)) {
-			nodeList = append(nodeList, node)
+func fakeIndexer() cache.Indexer {
+	return cache.NewIndexer(func(obj interface{}) (string, error) {
+		noc, ok := obj.(*v1alpha1.NodeOvercommitConfig)
+		if !ok {
+			return "", nil
 		}
-	}
-	return nodeList, nil
+		return noc.Name, nil
+	}, cache.Indexers{
+		LabelSelectorValIndex: func(obj interface{}) ([]string, error) {
+			noc, ok := obj.(*v1alpha1.NodeOvercommitConfig)
+			if !ok {
+				return []string{}, nil
+			}
+			return []string{noc.Spec.NodeOvercommitSelectorVal}, nil
+		},
+	})
 }
 
-func (fn *FakeNodeIndexer) add(node *v1.Node) {
-	fn.nodeMap[node.Name] = node
-}
-
-type FakeNocIndexer struct {
-	configMap map[string]*v1alpha1.NodeOvercommitConfig
-}
-
-func newFakeNocIndexer() *FakeNocIndexer {
-	return &FakeNocIndexer{
-		configMap: make(map[string]*v1alpha1.NodeOvercommitConfig),
-	}
-}
-
-func (fn *FakeNocIndexer) GetNoc(name string) (*v1alpha1.NodeOvercommitConfig, error) {
-	if _, ok := fn.configMap[name]; !ok {
-		return nil, errors.NewNotFound(v1.Resource("NodeOvercommitConfig"), name)
-	}
-	return fn.configMap[name], nil
-}
-
-func (fn *FakeNocIndexer) ListNoc() ([]*v1alpha1.NodeOvercommitConfig, error) {
-	configList := make([]*v1alpha1.NodeOvercommitConfig, 0)
-	for _, c := range fn.configMap {
-		configList = append(configList, c)
-	}
-	return configList, nil
-}
-
-func (fn *FakeNocIndexer) add(config *v1alpha1.NodeOvercommitConfig) {
-	fn.configMap[config.Name] = config
+func fakeNodeIndexer() cache.Indexer {
+	return cache.NewIndexer(func(obj interface{}) (string, error) {
+		node, ok := obj.(*v1.Node)
+		if !ok {
+			return "", nil
+		}
+		return node.Name, nil
+	}, cache.Indexers{
+		"test": func(obj interface{}) ([]string, error) {
+			return []string{}, nil
+		},
+	})
 }
 
 func makeTestMatcher() *MatcherImpl {
-	nodeIndexer := makeTestNodeIndexer()
-	nocIndexer := makeTestNocIndexer()
+	nodeIndexer := testNodeIndexer()
+	indexer := testNocIndexer()
+	nocLister := v1alpha12.NewNodeOvercommitConfigLister(indexer)
+	nodeLister := v12.NewNodeLister(nodeIndexer)
 
-	return NewMatcher(nodeIndexer, nocIndexer)
+	return NewMatcher(nodeLister, nocLister, indexer)
 }
 
 func makeInitedMatcher() (*MatcherImpl, error) {
@@ -104,28 +80,27 @@ func makeInitedMatcher() (*MatcherImpl, error) {
 	return m, err
 }
 
-func makeTestNodeIndexer() *FakeNodeIndexer {
-	nodeIndexer := newFakeNodeIndexer()
+func testNodeIndexer() cache.Indexer {
+	indexer := fakeNodeIndexer()
 
-	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", UID: "01", Labels: map[string]string{"pool": "pool1"}}})
-	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", UID: "02", Labels: map[string]string{"pool": "pool2"}}})
-	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3", UID: "03", Labels: map[string]string{"pool": "pool1"}}})
-	nodeIndexer.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node4", UID: "04", Labels: map[string]string{"pool": "pool3"}}})
-	return nodeIndexer
+	indexer.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", UID: "01", Labels: map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}}})
+	indexer.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", UID: "02", Labels: map[string]string{consts.NodeOvercommitSelectorKey: "pool2"}}})
+	indexer.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node3", UID: "03", Labels: map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}}})
+	indexer.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node4", UID: "04", Labels: map[string]string{consts.NodeOvercommitSelectorKey: "pool3"}}})
+	indexer.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node5", UID: "05"}})
+	indexer.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node6", UID: "06", Labels: map[string]string{"pool": "pool1"}}})
+	return indexer
 }
 
-func makeTestNocIndexer() *FakeNocIndexer {
-	nocIndexer := newFakeNocIndexer()
+func testNocIndexer() cache.Indexer {
+	indexer := fakeIndexer()
 
-	nocIndexer.add(&v1alpha1.NodeOvercommitConfig{
+	indexer.Add(&v1alpha1.NodeOvercommitConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "config1-nodeList",
+			Name: "config1",
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
-			NodeList: []string{
-				"node1",
-				"node2",
-			},
+			NodeOvercommitSelectorVal: "pool1",
 			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
 				v1.ResourceCPU:    "1.5",
 				v1.ResourceMemory: "1",
@@ -133,39 +108,27 @@ func makeTestNocIndexer() *FakeNocIndexer {
 		},
 	})
 
-	nocIndexer.add(&v1alpha1.NodeOvercommitConfig{
+	indexer.Add(&v1alpha1.NodeOvercommitConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "config2-default",
+			Name: "config2",
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			NodeOvercommitSelectorVal: "pool2",
 			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
-				v1.ResourceCPU:    "1",
+				v1.ResourceCPU:    "2",
 				v1.ResourceMemory: "1",
 			},
 		},
 	})
 
-	nocIndexer.add(&v1alpha1.NodeOvercommitConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "config3-selector",
-		},
-		Spec: v1alpha1.NodeOvercommitConfigSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"pool": "pool1",
-				},
-			},
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
-				v1.ResourceCPU: "2",
-			},
-		},
-	})
-
-	return nocIndexer
+	return indexer
 }
 
-func makeMatcherByIndexer(nodeIndexer *FakeNodeIndexer, nocIndexer *FakeNocIndexer) *MatcherImpl {
-	matcher := NewMatcher(nodeIndexer, nocIndexer)
+func makeMatcherByIndexer(nodeIndexer, nocIndexer cache.Indexer) *MatcherImpl {
+	nodeLister := v12.NewNodeLister(nodeIndexer)
+	nocLister := v1alpha12.NewNodeOvercommitConfigLister(nocIndexer)
+
+	matcher := NewMatcher(nodeLister, nocLister, nocIndexer)
 	_ = matcher.Reconcile()
 	return matcher
 }
@@ -180,18 +143,13 @@ func TestMatchConfigNameToNodes(t *testing.T) {
 	}{
 		{
 			name:       "nodeList",
-			configName: "config1-nodeList",
-			result:     []string{"node1", "node2"},
-		},
-		{
-			name:       "selector",
-			configName: "config3-selector",
+			configName: "config1",
 			result:     []string{"node1", "node3"},
 		},
 		{
 			name:       "default matches all nodes",
-			configName: "config2-default",
-			result:     []string{"node1", "node2", "node3", "node4"},
+			configName: "config2",
+			result:     []string{"node2"},
 		},
 	}
 
@@ -208,44 +166,52 @@ func TestMatchConfigNameToNodes(t *testing.T) {
 
 func TestMatchConfig(t *testing.T) {
 	t.Parallel()
-	nodeIndexer1 := makeTestNodeIndexer()
-	nocIndexer1 := makeTestNocIndexer()
+	nodeIndexer1 := testNodeIndexer()
+	nocIndexer1 := testNocIndexer()
 	matcher1 := makeMatcherByIndexer(nodeIndexer1, nocIndexer1)
-	nocIndexer1.configMap["config3-selector"].Spec.Selector.MatchLabels["pool"] = "pool2"
+	nocIndexer1.Update(
+		&v1alpha1.NodeOvercommitConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "config2",
+			},
+			Spec: v1alpha1.NodeOvercommitConfigSpec{
+				NodeOvercommitSelectorVal: "pool3",
+				ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+					v1.ResourceCPU:    "2",
+					v1.ResourceMemory: "1",
+				},
+			}})
 
-	nodeIndexer2 := makeTestNodeIndexer()
-	nocIndexer2 := makeTestNocIndexer()
+	nodeIndexer2 := testNodeIndexer()
+	nocIndexer2 := testNocIndexer()
 	matcher2 := makeMatcherByIndexer(nodeIndexer2, nocIndexer2)
-	nocIndexer2.add(&v1alpha1.NodeOvercommitConfig{
+	nocIndexer2.Add(&v1alpha1.NodeOvercommitConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "config4-selector",
+			Name: "config3",
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"pool": "pool2",
-				},
-			},
+			NodeOvercommitSelectorVal: "pool3",
 			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
 				v1.ResourceCPU: "3",
 			},
 		},
 	})
 
-	nodeIndexer3 := makeTestNodeIndexer()
-	nocIndexer3 := makeTestNocIndexer()
+	nodeIndexer3 := testNodeIndexer()
+	nocIndexer3 := testNocIndexer()
 	matcher3 := makeMatcherByIndexer(nodeIndexer3, nocIndexer3)
-	delete(nocIndexer3.configMap, "config3-selector")
-
-	nodeIndexer4 := makeTestNodeIndexer()
-	nocIndexer4 := makeTestNocIndexer()
-	matcher4 := makeMatcherByIndexer(nodeIndexer4, nocIndexer4)
-	nocIndexer4.configMap["config1-nodeList"].Spec.NodeList = nil
-	nocIndexer4.configMap["config1-nodeList"].Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"pool": "pool2",
+	nocIndexer3.Delete(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config1",
 		},
-	}
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			NodeOvercommitSelectorVal: "pool1",
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU:    "1.5",
+				v1.ResourceMemory: "1",
+			},
+		},
+	})
 
 	testCases := []struct {
 		name       string
@@ -256,26 +222,20 @@ func TestMatchConfig(t *testing.T) {
 		{
 			name:       "update selector",
 			matcher:    matcher1,
-			configName: "config3-selector",
-			result:     []string{"node1", "node2", "node3"},
+			configName: "config2",
+			result:     []string{"node2", "node4"},
 		},
 		{
 			name:       "add config",
 			matcher:    matcher2,
-			configName: "config4-selector",
-			result:     []string{"node2"},
+			configName: "config3",
+			result:     []string{"node4"},
 		},
 		{
 			name:       "delete config",
 			matcher:    matcher3,
-			configName: "config3-selector",
+			configName: "config1",
 			result:     []string{"node1", "node3"},
-		},
-		{
-			name:       "update config type",
-			matcher:    matcher4,
-			configName: "config1-nodeList",
-			result:     []string{"node1", "node2"},
 		},
 	}
 
@@ -283,68 +243,89 @@ func TestMatchConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := tc.matcher.MatchConfig(tc.configName)
 			assert.Nil(t, err)
-			assert.Equal(t, len(out), len(tc.result))
+			sort.Strings(out)
+			assert.Equal(t, tc.result, out)
 		})
 	}
 }
 
 func TestMatchNode(t *testing.T) {
 	t.Parallel()
-	// node1 -> config1-nodeList, node2 -> config1-nodeList, node3 -> config3-selector, node4 -> config2-selector
 
-	nodeIndexer1 := makeTestNodeIndexer()
-	nocIndexer1 := makeTestNocIndexer()
+	nodeIndexer1 := testNodeIndexer()
+	nocIndexer1 := testNocIndexer()
 	matcher1 := makeMatcherByIndexer(nodeIndexer1, nocIndexer1)
-	nocIndexer1.configMap["config3-selector"].Spec.Selector.MatchLabels["pool"] = "pool2"
-
-	nodeIndexer2 := makeTestNodeIndexer()
-	nocIndexer2 := makeTestNocIndexer()
-	matcher2 := makeMatcherByIndexer(nodeIndexer2, nocIndexer2)
-	nocIndexer2.add(&v1alpha1.NodeOvercommitConfig{
+	nocIndexer1.Update(&v1alpha1.NodeOvercommitConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "config4-selector",
+			Name: "config2",
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"pool": "pool3",
-				},
+			NodeOvercommitSelectorVal: "pool3",
+			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				v1.ResourceCPU:    "2",
+				v1.ResourceMemory: "1",
 			},
+		}})
+
+	nodeIndexer2 := testNodeIndexer()
+	nocIndexer2 := testNocIndexer()
+	matcher2 := makeMatcherByIndexer(nodeIndexer2, nocIndexer2)
+	nocIndexer2.Add(&v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config3",
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			NodeOvercommitSelectorVal: "pool3",
 			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
 				v1.ResourceCPU: "3",
 			},
 		},
 	})
 
-	nodeIndexer3 := makeTestNodeIndexer()
-	nocIndexer3 := makeTestNocIndexer()
+	nodeIndexer3 := testNodeIndexer()
+	nocIndexer3 := testNocIndexer()
 	matcher3 := makeMatcherByIndexer(nodeIndexer3, nocIndexer3)
-	delete(nocIndexer3.configMap, "config3-selector")
+	nocIndexer3.Delete(
+		&v1alpha1.NodeOvercommitConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "config1",
+			}},
+	)
 
-	nodeIndexer4 := makeTestNodeIndexer()
-	nocIndexer4 := makeTestNocIndexer()
-	matcher4 := makeMatcherByIndexer(nodeIndexer4, nocIndexer4)
-	nocIndexer4.configMap["config1-nodeList"].Spec.NodeList = nil
-	nocIndexer4.configMap["config1-nodeList"].Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"pool": "pool2",
-		},
-	}
-
-	nodeIndexer5 := makeTestNodeIndexer()
-	nocIndexer5 := makeTestNocIndexer()
+	nodeIndexer5 := testNodeIndexer()
+	nocIndexer5 := testNocIndexer()
 	matcher5 := makeMatcherByIndexer(nodeIndexer5, nocIndexer5)
-	nodeIndexer5.nodeMap["node4"].Labels["pool"] = "pool1"
+	nodeIndexer5.Update(
+		&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node4",
+				Labels: map[string]string{
+					consts.NodeOvercommitSelectorKey: "pool1",
+				},
+			},
+		})
 
-	nodeIndexer6 := makeTestNodeIndexer()
-	nocIndexer6 := makeTestNocIndexer()
+	nodeIndexer6 := testNodeIndexer()
+	nocIndexer6 := testNocIndexer()
 	matcher6 := makeMatcherByIndexer(nodeIndexer6, nocIndexer6)
-	nodeIndexer6.nodeMap["node1"].Labels = nil
+	nodeIndexer5.Update(
+		&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node1",
+				Labels: nil,
+			},
+		})
 
-	nodeIndexer7 := makeTestNodeIndexer()
-	nocIndexer7 := makeTestNocIndexer()
+	nodeIndexer7 := testNodeIndexer()
+	nocIndexer7 := testNocIndexer()
 	matcher7 := makeMatcherByIndexer(nodeIndexer7, nocIndexer7)
-	nodeIndexer7.add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node5", UID: "05", Labels: map[string]string{"pool": "pool1"}}})
+	nodeIndexer7.Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node7", UID: "07", Labels: map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}}})
+
+	oldNodeMap := map[string]string{
+		"node1": "config1",
+		"node2": "config2",
+		"node3": "config1",
+	}
 
 	testCases := []struct {
 		name       string
@@ -357,73 +338,36 @@ func TestMatchNode(t *testing.T) {
 		{
 			name:       "update selector",
 			matcher:    matcher1,
-			configName: "config3-selector",
+			configName: "config2",
 			nodeName:   "",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
+			oldNodeMap: oldNodeMap,
 			newNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config2-default",
-				"node4": "config2-default",
+				"node1": "config1",
+				"node3": "config1",
+				"node4": "config2",
 			},
 		},
 		{
 			name:       "add config",
 			matcher:    matcher2,
-			configName: "config4-selector",
+			configName: "config3",
 			nodeName:   "",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
+			oldNodeMap: oldNodeMap,
 			newNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config4-selector",
+				"node1": "config1",
+				"node2": "config2",
+				"node3": "config1",
+				"node4": "config3",
 			},
 		},
 		{
 			name:       "delete config",
 			matcher:    matcher3,
-			configName: "config3-selector",
+			configName: "config1",
 			nodeName:   "",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
+			oldNodeMap: oldNodeMap,
 			newNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config2-default",
-				"node4": "config2-default",
-			},
-		},
-		{
-			name:       "update config type",
-			matcher:    matcher4,
-			configName: "config1-nodeList",
-			nodeName:   "",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
-			newNodeMap: map[string]string{
-				"node1": "config3-selector",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
+				"node2": "config2",
 			},
 		},
 		{
@@ -431,17 +375,12 @@ func TestMatchNode(t *testing.T) {
 			matcher:    matcher5,
 			configName: "",
 			nodeName:   "node4",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
+			oldNodeMap: oldNodeMap,
 			newNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config3-selector",
+				"node1": "config1",
+				"node2": "config2",
+				"node3": "config1",
+				"node4": "config1",
 			},
 		},
 		{
@@ -449,36 +388,23 @@ func TestMatchNode(t *testing.T) {
 			matcher:    matcher6,
 			configName: "",
 			nodeName:   "node1",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
+			oldNodeMap: oldNodeMap,
 			newNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
+				"node2": "config2",
+				"node3": "config1",
 			},
 		},
 		{
 			name:       "add node",
 			matcher:    matcher7,
 			configName: "",
-			nodeName:   "node5",
-			oldNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-			},
+			nodeName:   "node7",
+			oldNodeMap: oldNodeMap,
 			newNodeMap: map[string]string{
-				"node1": "config1-nodeList",
-				"node2": "config1-nodeList",
-				"node3": "config3-selector",
-				"node4": "config2-default",
-				"node5": "config3-selector",
+				"node1": "config1",
+				"node2": "config2",
+				"node3": "config1",
+				"node7": "config1",
 			},
 		},
 	}
@@ -486,7 +412,7 @@ func TestMatchNode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.configName == "" {
-				for _, c := range []string{"config1-nodeList", "config2-default", "config3-selector"} {
+				for _, c := range []string{"config1", "config2"} {
 					_, _ = tc.matcher.MatchConfig(c)
 				}
 				tc.matcher.MatchNode(tc.nodeName)
@@ -521,13 +447,13 @@ func TestDelNode(t *testing.T) {
 			name:     "exist node",
 			nodeName: "node1",
 			matcher:  matcher1,
-			result:   3,
+			result:   2,
 		},
 		{
 			name:     "non-existing node",
 			nodeName: "node99",
 			matcher:  matcher2,
-			result:   4,
+			result:   3,
 		},
 	}
 
@@ -549,70 +475,22 @@ func TestSort(t *testing.T) {
 		result  string
 	}{
 		{
-			name: "default and selector",
-			nocList: NocList{
-				&v1alpha1.NodeOvercommitConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "default",
-					},
-					Spec: v1alpha1.NodeOvercommitConfigSpec{},
-				},
-				&v1alpha1.NodeOvercommitConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "selector",
-					},
-					Spec: v1alpha1.NodeOvercommitConfigSpec{
-						Selector: &metav1.LabelSelector{},
-					},
-				},
-			},
-			result: "selector",
-		},
-		{
-			name: "selector and nodelist",
-			nocList: NocList{
-				&v1alpha1.NodeOvercommitConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "nodelist",
-					},
-					Spec: v1alpha1.NodeOvercommitConfigSpec{
-						NodeList: []string{},
-					},
-				},
-				&v1alpha1.NodeOvercommitConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "selector",
-					},
-					Spec: v1alpha1.NodeOvercommitConfigSpec{
-						Selector: &metav1.LabelSelector{},
-					},
-				},
-			},
-			result: "nodelist",
-		},
-		{
 			name: "creationTimestamp",
 			nocList: NocList{
 				&v1alpha1.NodeOvercommitConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:              "nodelist1",
+						Name:              "noclist1",
 						CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
-					},
-					Spec: v1alpha1.NodeOvercommitConfigSpec{
-						NodeList: []string{},
 					},
 				},
 				&v1alpha1.NodeOvercommitConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:              "nodelist2",
+						Name:              "noclist2",
 						CreationTimestamp: metav1.NewTime(time.Now()),
-					},
-					Spec: v1alpha1.NodeOvercommitConfigSpec{
-						NodeList: []string{},
 					},
 				},
 			},
-			result: "nodelist2",
+			result: "noclist2",
 		},
 	}
 

--- a/pkg/controller/overcommit/node/matcher/matcher_test.go
+++ b/pkg/controller/overcommit/node/matcher/matcher_test.go
@@ -101,7 +101,7 @@ func testNocIndexer() cache.Indexer {
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
 			NodeOvercommitSelectorVal: "pool1",
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+			ResourceOvercommitRatio: map[v1.ResourceName]string{
 				v1.ResourceCPU:    "1.5",
 				v1.ResourceMemory: "1",
 			},
@@ -114,7 +114,7 @@ func testNocIndexer() cache.Indexer {
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
 			NodeOvercommitSelectorVal: "pool2",
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+			ResourceOvercommitRatio: map[v1.ResourceName]string{
 				v1.ResourceCPU:    "2",
 				v1.ResourceMemory: "1",
 			},
@@ -176,7 +176,7 @@ func TestMatchConfig(t *testing.T) {
 			},
 			Spec: v1alpha1.NodeOvercommitConfigSpec{
 				NodeOvercommitSelectorVal: "pool3",
-				ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+				ResourceOvercommitRatio: map[v1.ResourceName]string{
 					v1.ResourceCPU:    "2",
 					v1.ResourceMemory: "1",
 				},
@@ -191,7 +191,7 @@ func TestMatchConfig(t *testing.T) {
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
 			NodeOvercommitSelectorVal: "pool3",
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+			ResourceOvercommitRatio: map[v1.ResourceName]string{
 				v1.ResourceCPU: "3",
 			},
 		},
@@ -206,7 +206,7 @@ func TestMatchConfig(t *testing.T) {
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
 			NodeOvercommitSelectorVal: "pool1",
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+			ResourceOvercommitRatio: map[v1.ResourceName]string{
 				v1.ResourceCPU:    "1.5",
 				v1.ResourceMemory: "1",
 			},
@@ -261,7 +261,7 @@ func TestMatchNode(t *testing.T) {
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
 			NodeOvercommitSelectorVal: "pool3",
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+			ResourceOvercommitRatio: map[v1.ResourceName]string{
 				v1.ResourceCPU:    "2",
 				v1.ResourceMemory: "1",
 			},
@@ -276,7 +276,7 @@ func TestMatchNode(t *testing.T) {
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
 			NodeOvercommitSelectorVal: "pool3",
-			ResourceOvercommitRatioConfig: map[v1.ResourceName]string{
+			ResourceOvercommitRatio: map[v1.ResourceName]string{
 				v1.ResourceCPU: "3",
 			},
 		},

--- a/pkg/controller/overcommit/node/matcher/sorter.go
+++ b/pkg/controller/overcommit/node/matcher/sorter.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+)
+
+type NocList []*v1alpha1.NodeOvercommitConfig
+
+type ConfigType int
+
+const (
+	ConfigDefault ConfigType = iota
+	ConfigSelector
+	ConfigNodeList
+)
+
+func (nl NocList) Len() int {
+	return len(nl)
+}
+
+func (nl NocList) Swap(i, j int) {
+	nl[i], nl[j] = nl[j], nl[i]
+}
+
+// ConfigNodeList > ConfigSelector > ConfigDefault
+// Config created later has a higher priority
+func (nl NocList) Less(i, j int) bool {
+	ti := NodeOvercommitConfigType(nl[i])
+	tj := NodeOvercommitConfigType(nl[j])
+
+	if ti == tj {
+		return nl[j].CreationTimestamp.Before(&nl[i].CreationTimestamp)
+	}
+
+	return ti > tj
+}
+
+func NodeOvercommitConfigType(config *v1alpha1.NodeOvercommitConfig) ConfigType {
+	if config.Spec.NodeList != nil {
+		return ConfigNodeList
+	}
+
+	if config.Spec.Selector != nil {
+		return ConfigSelector
+	}
+
+	return ConfigDefault
+}

--- a/pkg/controller/overcommit/node/node.go
+++ b/pkg/controller/overcommit/node/node.go
@@ -1,0 +1,425 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	configv1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/client/listers/overcommit/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	katalyst_base "github.com/kubewharf/katalyst-core/cmd/base"
+	"github.com/kubewharf/katalyst-core/pkg/client/control"
+	"github.com/kubewharf/katalyst-core/pkg/config/controller"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	"github.com/kubewharf/katalyst-core/pkg/controller/overcommit/node/matcher"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+const nodeOvercommitControllerName = "noc"
+
+var resourceAnnotationKey = map[corev1.ResourceName]string{
+	corev1.ResourceCPU:    consts.NodeAnnotationCPUOvercommitRatioKey,
+	corev1.ResourceMemory: consts.NodeAnnotationMemoryOvercommitRatioKey,
+}
+
+// NodeOvercommitController is responsible to update node overcommit annotation
+// according to NodeOvercommitConfig
+type NodeOvercommitController struct {
+	ctx context.Context
+
+	nodeLister           v1.NodeLister
+	nodeOvercommitLister v1alpha1.NodeOvercommitConfigLister
+	nodeUpdater          control.NodeUpdater
+	nocUpdater           control.NocUpdater
+
+	syncedFunc []cache.InformerSynced
+
+	matcher         matcher.Matcher
+	nocSyncQueue    workqueue.RateLimitingInterface
+	nodeSyncQueue   workqueue.RateLimitingInterface
+	workerCount     int
+	reconcilePeriod time.Duration
+	firstReconcile  bool
+
+	metricsEmitter metrics.MetricEmitter
+}
+
+func NewNodeOvercommitController(
+	ctx context.Context,
+	controlCtx *katalyst_base.GenericContext,
+	genericConf *generic.GenericConfiguration,
+	overcommitConf *controller.OvercommitConfig,
+) (*NodeOvercommitController, error) {
+
+	nodeInformer := controlCtx.KubeInformerFactory.Core().V1().Nodes()
+	nodeOvercommitInformer := controlCtx.InternalInformerFactory.Overcommit().V1alpha1().NodeOvercommitConfigs()
+	genericClient := controlCtx.Client
+
+	nodeOvercommitConfigController := &NodeOvercommitController{
+		ctx:                  ctx,
+		nodeLister:           nodeInformer.Lister(),
+		nodeOvercommitLister: nodeOvercommitInformer.Lister(),
+		nodeUpdater:          &control.DummyNodeUpdater{},
+		nocUpdater:           &control.DummyNocUpdater{},
+		nocSyncQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "noc"),
+		nodeSyncQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node"),
+		workerCount:          overcommitConf.Node.SyncWorkers,
+		syncedFunc: []cache.InformerSynced{
+			nodeInformer.Informer().HasSynced,
+			nodeOvercommitInformer.Informer().HasSynced,
+		},
+		matcher:         &matcher.DummyMatcher{},
+		reconcilePeriod: overcommitConf.Node.ConfigReconcilePeriod,
+	}
+
+	nodeOvercommitConfigController.metricsEmitter = controlCtx.EmitterPool.GetDefaultMetricsEmitter()
+	if nodeOvercommitConfigController.metricsEmitter == nil {
+		nodeOvercommitConfigController.metricsEmitter = metrics.DummyMetrics{}
+	}
+
+	if !genericConf.DryRun {
+		nodeOvercommitConfigController.matcher = matcher.NewMatcher(nodeOvercommitConfigController, nodeOvercommitConfigController)
+		nodeOvercommitConfigController.nodeUpdater = control.NewRealNodeUpdater(genericClient.KubeClient)
+		nodeOvercommitConfigController.nocUpdater = control.NewRealNocUpdater(genericClient.InternalClient)
+	}
+
+	// add handlers
+	nodeOvercommitInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    nodeOvercommitConfigController.addNodeOvercommitConfig,
+		UpdateFunc: nodeOvercommitConfigController.updateNodeOvercommitConfig,
+		DeleteFunc: nodeOvercommitConfigController.deleteNodeOvercommitConfig,
+	})
+
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    nodeOvercommitConfigController.addNode,
+		UpdateFunc: nodeOvercommitConfigController.updateNode,
+	})
+
+	return nodeOvercommitConfigController, nil
+}
+
+func (nc *NodeOvercommitController) Run() {
+	defer utilruntime.HandleCrash()
+	defer func() {
+		nc.nocSyncQueue.ShutDown()
+		nc.nodeSyncQueue.ShutDown()
+		klog.Infof("Shutting down %s controller", nodeOvercommitControllerName)
+	}()
+
+	if !cache.WaitForCacheSync(nc.ctx.Done(), nc.syncedFunc...) {
+		utilruntime.HandleError(fmt.Errorf("unable to sync caches for %s controller", nodeOvercommitControllerName))
+		return
+	}
+
+	klog.Infof("caches are synced for %s controller", nodeOvercommitControllerName)
+
+	err := nc.matcher.Reconcile()
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("controller %s Reconcile fail: %v", nodeOvercommitControllerName, err))
+		return
+	}
+
+	klog.Infof("%s controller start process, workerCount: %v, reconcilePeriod: %v", nodeOvercommitControllerName, nc.workerCount, nc.reconcilePeriod)
+	for i := 0; i < nc.workerCount; i++ {
+		// config matching and node configs sorting are handled asynchronously in different worker
+		go wait.Until(nc.nodeWorker, time.Second, nc.ctx.Done())
+
+		go wait.Until(nc.worker, time.Second, nc.ctx.Done())
+	}
+
+	nc.reconcile()
+
+	<-nc.ctx.Done()
+}
+
+func (nc *NodeOvercommitController) reconcile() {
+	go wait.Until(func() {
+		if nc.firstReconcile {
+			nc.firstReconcile = false
+			return
+		}
+		err := nc.matcher.Reconcile()
+		if err != nil {
+			klog.Error(err)
+			return
+		}
+
+		nodeList, err := nc.nodeLister.List(labels.Everything())
+		if err != nil {
+			klog.Error(err)
+			return
+		}
+		for _, node := range nodeList {
+			err = nc.setNodeOvercommitAnnotations(node.Name)
+			if err != nil {
+				klog.Errorf("%s controller reconcile set node annotation fail: %v", nodeOvercommitControllerName, err)
+				continue
+			}
+		}
+
+		configList, err := nc.nodeOvercommitLister.List(labels.Everything())
+		if err != nil {
+			klog.Error(err)
+			return
+		}
+		for _, config := range configList {
+			err = nc.patchNodeOvercommitConfigStatus(config.Name)
+			if err != nil {
+				klog.Errorf("%s controller reconcile patch noc status fail: %v")
+				continue
+			}
+		}
+	}, nc.reconcilePeriod, nc.ctx.Done())
+}
+
+func (nc *NodeOvercommitController) worker() {
+	for nc.processNextEvent() {
+	}
+}
+
+func (nc *NodeOvercommitController) nodeWorker() {
+	for nc.processNextNode() {
+	}
+}
+
+func (nc *NodeOvercommitController) processNextEvent() bool {
+	key, quit := nc.nocSyncQueue.Get()
+	if quit {
+		return false
+	}
+	defer nc.nocSyncQueue.Done(key)
+
+	var (
+		event = key.(nodeOvercommitEvent)
+		err   error
+	)
+	// both config change and node label change may cause the matching relationship to change,
+	// but they are handled in different ways
+	switch event.eventType {
+	case nodeEvent:
+		err = nc.syncNodeEvent(event.nodeKey)
+	case configEvent:
+		//
+		err = nc.syncConfigEvent(event.configKey)
+	default:
+		nc.nocSyncQueue.Forget(key)
+		klog.Errorf("unkonw event type: %s", event.eventType)
+		return true
+	}
+	if err == nil {
+		nc.nocSyncQueue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("sync %q failed with %v", key, err))
+	nc.nocSyncQueue.AddRateLimited(key)
+
+	return true
+}
+
+func (nc *NodeOvercommitController) processNextNode() bool {
+	key, quit := nc.nodeSyncQueue.Get()
+	if quit {
+		return false
+	}
+	defer nc.nodeSyncQueue.Done(key)
+
+	err := nc.syncNode(key.(string))
+	if err == nil {
+		nc.nodeSyncQueue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("sync %q failed with %v", key, err))
+	nc.nodeSyncQueue.AddRateLimited(key)
+
+	return true
+}
+
+func (nc *NodeOvercommitController) syncConfigEvent(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("failed to split namespace and name from key %s", key)
+		return err
+	}
+
+	nodeNames, err := nc.matcher.MatchConfig(name)
+	if err != nil {
+		klog.Errorf("failed to update config, configName: %v, err: %v", name, err)
+		return err
+	}
+
+	for _, nodeName := range nodeNames {
+		nc.nodeSyncQueue.Add(nodeName)
+	}
+
+	return nc.patchNodeOvercommitConfigStatus(name)
+}
+
+func (nc *NodeOvercommitController) syncNodeEvent(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("failed to split namespace and name from key %s", key)
+		return err
+	}
+	_, err = nc.nodeLister.Get(name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			nc.matcher.DelNode(name)
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	nodeOverCommitConfigList, err := nc.nodeOvercommitLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("failed to list nodeOverCommitConfig: %v", err)
+		return err
+	}
+	for _, config := range nodeOverCommitConfigList {
+		_, err := nc.matcher.MatchConfig(config.Name)
+		if err != nil {
+			klog.Errorf("failed to match config %s: %v", config.Name, err)
+			return err
+		}
+		err = nc.patchNodeOvercommitConfigStatus(config.Name)
+		if err != nil {
+			// fail of patching nodeOvercommitConfigStatus will not affect node overcommit ratio
+			// can be fixed by reconcile
+			klog.Warning("failed to patch %s nodeOvercommitConfigStatus: %v", config.Name, err)
+			continue
+		}
+	}
+
+	nc.nodeSyncQueue.Add(name)
+	return nil
+}
+
+func (nc *NodeOvercommitController) syncNode(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("failed to split namespace and name from key %s", key)
+		return err
+	}
+
+	nc.matcher.MatchNode(name)
+
+	return nc.setNodeOvercommitAnnotations(name)
+}
+
+func (nc *NodeOvercommitController) patchNodeOvercommitConfigStatus(configName string) error {
+	oldConfig, err := nc.nodeOvercommitLister.Get(configName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Warning("nodeOvercommitConfig %v has been deleted.")
+			return nil
+		}
+		klog.Errorf("get nodeOvercommitConfig %v fail: %v", configName, err)
+		return err
+	}
+
+	nodeNames := nc.matcher.GetNodes(configName)
+	newConfig := oldConfig.DeepCopy()
+	newConfig.Status.MatchedNodeList = nodeNames
+
+	_, err = nc.nocUpdater.PatchNocStatus(nc.ctx, oldConfig, newConfig)
+	if err != nil {
+		klog.Error(err)
+		return err
+	}
+	return nil
+}
+
+func (nc *NodeOvercommitController) setNodeOvercommitAnnotations(nodeName string) error {
+	node, err := nc.nodeLister.Get(nodeName)
+	if err != nil {
+		klog.Errorf("get node %s fail: %v", nodeName, err)
+		return err
+	}
+
+	nodeCopy := node.DeepCopy()
+	nodeAnnotations := nodeCopy.GetAnnotations()
+	if nodeAnnotations == nil {
+		nodeAnnotations = make(map[string]string)
+	}
+
+	var (
+		nodeOvercommitConfig = emptyOvercommitConfig()
+	)
+	config := nc.matcher.GetConfig(nodeName)
+	if config != nil {
+		nodeOvercommitConfig, err = nc.nodeOvercommitLister.Get(config.Name)
+		if err != nil {
+			klog.Errorf("get nodeOvercommitConfig %s fail: %v", config.Name, err)
+			return err
+		}
+	}
+	for resourceName, annotationKey := range resourceAnnotationKey {
+		c, ok := nodeOvercommitConfig.Spec.ResourceOvercommitRatioConfig[resourceName]
+		if !ok {
+			switch resourceName {
+			case corev1.ResourceCPU:
+				nodeAnnotations[annotationKey] = consts.DefaultNodeCPUOvercommitRatio
+			case corev1.ResourceMemory:
+				nodeAnnotations[annotationKey] = consts.DefaultNodeMemoryOvercommitRatio
+			}
+		} else {
+			nodeAnnotations[annotationKey] = c
+		}
+	}
+	nodeCopy.Annotations = nodeAnnotations
+
+	return nc.nodeUpdater.PatchNode(nc.ctx, node, nodeCopy)
+}
+
+func (nc *NodeOvercommitController) GetNode(nodeName string) (*corev1.Node, error) {
+	return nc.nodeLister.Get(nodeName)
+}
+
+func (nc *NodeOvercommitController) ListNode(selector labels.Selector) ([]*corev1.Node, error) {
+	return nc.nodeLister.List(selector)
+}
+
+func (nc *NodeOvercommitController) GetNoc(name string) (*configv1alpha1.NodeOvercommitConfig, error) {
+	return nc.nodeOvercommitLister.Get(name)
+}
+
+func (nc *NodeOvercommitController) ListNoc() ([]*configv1alpha1.NodeOvercommitConfig, error) {
+	return nc.nodeOvercommitLister.List(labels.Everything())
+}
+
+func emptyOvercommitConfig() *configv1alpha1.NodeOvercommitConfig {
+	return &configv1alpha1.NodeOvercommitConfig{
+		Spec: configv1alpha1.NodeOvercommitConfigSpec{
+			ResourceOvercommitRatioConfig: map[corev1.ResourceName]string{},
+		},
+	}
+}

--- a/pkg/controller/overcommit/node/node.go
+++ b/pkg/controller/overcommit/node/node.go
@@ -398,7 +398,7 @@ func (nc *NodeOvercommitController) setNodeOvercommitAnnotationsWithConfig(nodeN
 		nodeOvercommitConfig = config
 	}
 	for resourceName, annotationKey := range resourceAnnotationKey {
-		c, ok := nodeOvercommitConfig.Spec.ResourceOvercommitRatioConfig[resourceName]
+		c, ok := nodeOvercommitConfig.Spec.ResourceOvercommitRatio[resourceName]
 		if !ok {
 			switch resourceName {
 			case corev1.ResourceCPU:
@@ -418,7 +418,7 @@ func (nc *NodeOvercommitController) setNodeOvercommitAnnotationsWithConfig(nodeN
 func emptyOvercommitConfig() *configv1alpha1.NodeOvercommitConfig {
 	return &configv1alpha1.NodeOvercommitConfig{
 		Spec: configv1alpha1.NodeOvercommitConfigSpec{
-			ResourceOvercommitRatioConfig: map[corev1.ResourceName]string{},
+			ResourceOvercommitRatio: map[corev1.ResourceName]string{},
 		},
 	}
 }

--- a/pkg/controller/overcommit/node/node_test.go
+++ b/pkg/controller/overcommit/node/node_test.go
@@ -1,0 +1,396 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	katalyst_base "github.com/kubewharf/katalyst-core/cmd/base"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-controller/app/options"
+	"github.com/kubewharf/katalyst-core/pkg/config/controller"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+)
+
+func makeNoc(name string, cpuOvercommitRatio, memoryOvercommitRatio string) *v1alpha1.NodeOvercommitConfig {
+	return &v1alpha1.NodeOvercommitConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.NodeOvercommitConfigSpec{
+			ResourceOvercommitRatioConfig: map[corev1.ResourceName]string{
+				corev1.ResourceCPU:    cpuOvercommitRatio,
+				corev1.ResourceMemory: memoryOvercommitRatio,
+			},
+		},
+	}
+}
+
+func makeSelectorNoc(name string, cpuOvercommitRatio, memoryOvercommitRatio string, labels map[string]string) *v1alpha1.NodeOvercommitConfig {
+	c := makeNoc(name, cpuOvercommitRatio, memoryOvercommitRatio)
+	c.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: labels,
+	}
+	return c
+}
+
+func makeNodeListNoc(name string, cpuOvercommitRatio, memoryOvercommitRatio string, nodeList []string) *v1alpha1.NodeOvercommitConfig {
+	c := makeNoc(name, cpuOvercommitRatio, memoryOvercommitRatio)
+	c.Spec.NodeList = nodeList
+	return c
+}
+
+func makeNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+type testCase struct {
+	name          string
+	initNodes     []*corev1.Node
+	initConfigs   []*v1alpha1.NodeOvercommitConfig
+	updateNodes   []*corev1.Node
+	updateConfigs []*v1alpha1.NodeOvercommitConfig
+	addNodes      []*corev1.Node
+	addConfigs    []*v1alpha1.NodeOvercommitConfig
+	deleteNodes   []string
+	deleteConfigs []string
+	result        map[string]map[string]string
+}
+
+var defaultInitNodes = func() []*corev1.Node {
+	return []*corev1.Node{
+		makeNode("node1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+		makeNode("node2", map[string]string{consts.NodeOvercommitSelectorKey: "pool2"}),
+		makeNode("node3", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+		makeNode("node4", map[string]string{consts.NodeOvercommitSelectorKey: "pool3"}),
+	}
+}()
+
+var testCases = []testCase{
+	{
+		name:      "init: null config, add: default config",
+		initNodes: defaultInitNodes,
+		addConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "init: null config, add: default / selector / nodelist config",
+		initNodes: defaultInitNodes,
+		addConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "update selector / nodelist config",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		updateConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool2"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node4"}),
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+		},
+	},
+	{
+		name:      "only update config resource",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		updateConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeSelectorNoc("config2-selector", "3", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "3", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "update node label",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		updateNodes: []*corev1.Node{
+			makeNode("node3", map[string]string{consts.NodeOvercommitSelectorKey: "pool2"}),
+			makeNode("node4", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "delete config",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		deleteConfigs: []string{"config3-nodelist"},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "delete node",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1", "1"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		deleteNodes: []string{"node1"},
+		result: map[string]map[string]string{
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "delete default config",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeNoc("config1-default", "1.5", "1.5"),
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		deleteConfigs: []string{"config1-default"},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "4", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "delete selector / nodelist without default config",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeSelectorNoc("config2-selector", "2", "1", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
+			makeNodeListNoc("config3-nodelist", "4", "2", []string{"node1", "node2"}),
+		},
+		deleteConfigs: []string{"config2-selector", "config3-nodelist"},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+}
+
+func TestReconcile(t *testing.T) {
+	// test noc and node add/update/delete by reconcile
+	t.Parallel()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fss := &cliflag.NamedFlagSets{}
+			nocOptions := options.NewOvercommitOptions()
+			nocOptions.AddFlags(fss)
+			nocOptions.ConfigReconcilePeriod = 5 * time.Second
+			nocConf := controller.NewOvercommitConfig()
+			_ = nocOptions.ApplyTo(nocConf)
+
+			genericConf := &generic.GenericConfiguration{}
+
+			controlCtx, err := katalyst_base.GenerateFakeGenericContext()
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			nocController, err := NewNodeOvercommitController(ctx, controlCtx, genericConf, nocConf)
+			assert.NoError(t, err)
+
+			for _, node := range tc.initNodes {
+				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.initConfigs {
+				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			controlCtx.StartInformer(nocController.ctx)
+			syncd := cache.WaitForCacheSync(nocController.ctx.Done(), nocController.syncedFunc...)
+			assert.True(t, syncd)
+			assert.Equal(t, 5*time.Second, nocController.reconcilePeriod)
+			err = nocController.matcher.Reconcile()
+			assert.NoError(t, err)
+
+			nocController.reconcile()
+
+			for _, node := range tc.addNodes {
+				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.addConfigs {
+				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, node := range tc.updateNodes {
+				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.updateConfigs {
+				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Update(ctx, config, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, node := range tc.deleteNodes {
+				err = controlCtx.Client.KubeClient.CoreV1().Nodes().Delete(ctx, node, metav1.DeleteOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.deleteConfigs {
+				err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Delete(ctx, config, metav1.DeleteOptions{})
+				assert.NoError(t, err)
+			}
+			time.Sleep(6 * time.Second)
+
+			for nodeName, annotations := range tc.result {
+				for k, v := range annotations {
+					node, err := nocController.nodeLister.Get(nodeName)
+					assert.NoError(t, err)
+					assert.Equal(t, v, node.Annotations[k], fmt.Sprintf("node: %v, k: %v, v: %v, actual: %v", nodeName, k, v, node.Annotations[k]))
+				}
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fss := &cliflag.NamedFlagSets{}
+			nocOptions := options.NewOvercommitOptions()
+			nocOptions.AddFlags(fss)
+			nocConf := controller.NewOvercommitConfig()
+			_ = nocOptions.ApplyTo(nocConf)
+
+			genericConf := &generic.GenericConfiguration{}
+
+			controlCtx, err := katalyst_base.GenerateFakeGenericContext()
+			assert.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			nocController, err := NewNodeOvercommitController(ctx, controlCtx, genericConf, nocConf)
+			assert.NoError(t, err)
+
+			for _, node := range tc.initNodes {
+				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.initConfigs {
+				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			controlCtx.StartInformer(nocController.ctx)
+
+			go nocController.Run()
+			time.Sleep(1 * time.Second)
+			for _, node := range tc.addNodes {
+				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.addConfigs {
+				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, node := range tc.updateNodes {
+				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.updateConfigs {
+				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Update(ctx, config, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, node := range tc.deleteNodes {
+				err = controlCtx.Client.KubeClient.CoreV1().Nodes().Delete(ctx, node, metav1.DeleteOptions{})
+				assert.NoError(t, err)
+			}
+			for _, config := range tc.deleteConfigs {
+				err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Delete(ctx, config, metav1.DeleteOptions{})
+				assert.NoError(t, err)
+			}
+
+			time.Sleep(2 * time.Second)
+
+			for nodeName, annotations := range tc.result {
+				for k, v := range annotations {
+					node, err := nocController.nodeLister.Get(nodeName)
+					assert.NoError(t, err)
+					assert.Equal(t, v, node.Annotations[k], fmt.Sprintf("node: %v, k: %v, v: %v, actual: %v", nodeName, k, v, node.Annotations[k]))
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/overcommit/node/node_test.go
+++ b/pkg/controller/overcommit/node/node_test.go
@@ -43,7 +43,7 @@ func makeNoc(name string, cpuOvercommitRatio, memoryOvercommitRatio string) *v1a
 			CreationTimestamp: metav1.NewTime(time.Now()),
 		},
 		Spec: v1alpha1.NodeOvercommitConfigSpec{
-			ResourceOvercommitRatioConfig: map[corev1.ResourceName]string{
+			ResourceOvercommitRatio: map[corev1.ResourceName]string{
 				corev1.ResourceCPU:    cpuOvercommitRatio,
 				corev1.ResourceMemory: memoryOvercommitRatio,
 			},


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
add nodeOvercommit controller
nodeOvercommit controller watches nodeOvercommitConfigs and nodes, matches node and configs by rules in nodeOvercommitConfigs, and then update node overcommit annotations.

#### Which issue(s) this PR fixes:
https://github.com/kubewharf/katalyst-core/issues/214
katalyst-api pr: https://github.com/kubewharf/katalyst-api/pull/34
