### PR TITLE
fix(controller): fix cnr residue when node deletion

### DIFF
--- a/cmd/katalyst-agent/app/options/reporter/reporter_base.go
+++ b/cmd/katalyst-agent/app/options/reporter/reporter_base.go
@@ -36,6 +36,7 @@ type GenericReporterOptions struct {
 	CollectInterval        time.Duration
 	InnerPlugins           []string
 	RefreshLatestCNRPeriod time.Duration
+	DefaultCNRLabels       map[string]string
 }
 
 // NewGenericReporterOptions creates a new Options with a default config.
@@ -44,6 +45,7 @@ func NewGenericReporterOptions() *GenericReporterOptions {
 		InnerPlugins:           []string{"*"},
 		CollectInterval:        defaultCollectInterval,
 		RefreshLatestCNRPeriod: defaultRefreshLatestCNRPeriod,
+		DefaultCNRLabels:       make(map[string]string),
 	}
 }
 
@@ -59,6 +61,8 @@ func (o *GenericReporterOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringSliceVar(&o.InnerPlugins, "reporter-plugins", o.InnerPlugins, fmt.Sprintf(""+
 		"A list of reporter plugins to enable. '*' enables all on-by-default reporter plugins, 'foo' enables the reporter plugin "+
 		"named 'foo', '-foo' disables the reporter plugin named 'foo'"))
+	fs.StringToStringVar(&o.DefaultCNRLabels, "default-cnr-labels", o.DefaultCNRLabels,
+		"the default labels of cnr created by agent, this config must be consistent with the label-selector in katalyst-controller.")
 }
 
 // ApplyTo fills up config with options
@@ -66,6 +70,7 @@ func (o *GenericReporterOptions) ApplyTo(c *reporterconfig.GenericReporterConfig
 	c.CollectInterval = o.CollectInterval
 	c.InnerPlugins = o.InnerPlugins
 	c.RefreshLatestCNRPeriod = o.RefreshLatestCNRPeriod
+	c.DefaultCNRLabels = o.DefaultCNRLabels
 	return nil
 }
 

--- a/pkg/agent/resourcemanager/reporter/cnr/cnrreporter.go
+++ b/pkg/agent/resourcemanager/reporter/cnr/cnrreporter.go
@@ -61,6 +61,8 @@ const (
 type cnrReporterImpl struct {
 	cnrName string
 
+	// defaultLabels contains the default config for CNR created by reporter
+	defaultLabels map[string]string
 	// latestUpdatedCNR is used as an in-memory cache for CNR;
 	// whenever CNR info is needed, get from this cache firstly
 	latestUpdatedCNR *nodev1alpha1.CustomNodeResource
@@ -83,6 +85,7 @@ func NewCNRReporter(genericClient *client.GenericClientSet, metaServer *metaserv
 	c := &cnrReporterImpl{
 		cnrName:                conf.NodeName,
 		refreshLatestCNRPeriod: conf.RefreshLatestCNRPeriod,
+		defaultLabels:          conf.DefaultCNRLabels,
 		notifiers:              make(map[string]metaservercnr.CNRNotifier),
 		emitter:                emitter,
 		client:                 genericClient.InternalClient,
@@ -337,7 +340,8 @@ func (c *cnrReporterImpl) resetCNRIfNeeded(err error) bool {
 func (c *cnrReporterImpl) defaultCNR() *nodev1alpha1.CustomNodeResource {
 	return &nodev1alpha1.CustomNodeResource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: c.cnrName,
+			Name:   c.cnrName,
+			Labels: c.defaultLabels,
 		},
 	}
 }

--- a/pkg/config/agent/reporter/reporter_base.go
+++ b/pkg/config/agent/reporter/reporter_base.go
@@ -31,6 +31,9 @@ type GenericReporterConfiguration struct {
 	InnerPlugins []string
 
 	RefreshLatestCNRPeriod time.Duration
+
+	// DefaultCNRLabels is the labels for CNR created by reporter
+	DefaultCNRLabels map[string]string
 }
 
 type ReporterPluginsConfiguration struct {

--- a/pkg/controller/lifecycle/cnr.go
+++ b/pkg/controller/lifecycle/cnr.go
@@ -320,7 +320,7 @@ func (cl *CNRLifecycle) updateOrCreateCNR(node *corev1.Node) error {
 	}
 
 	newCNR := cnr.DeepCopy()
-	newCNR.Labels = node.Labels
+	newCNR.Labels = general.MergeMap(newCNR.Labels, node.Labels)
 	setCNROwnerReference(newCNR, node)
 	if apiequality.Semantic.DeepEqual(newCNR, cnr) {
 		return nil


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:

When a Node is deleted, there may be remaining CNR (CustomNodeResource) objects without labels in cluster. This is because when a node is deleted, katalyst-agent creates a new CNR without labels, and the katalyst-controller is unable to GET the deleted node for patching labels. 
Additionally, during the periodic cleaning process in katalyst-controller, it lists CNRs with labels based on the NodeSelector from Informer initialization, excluding the CNR without labels created katalyst-agent. This causes the CNR to be unable to be cleaned up.
```
# Residual CNR without lables
apiVersion: node.katalyst.kubewharf.io/v1alpha1
kind: CustomNodeResource
metadata:
  name: 172.25.0.7
spec: {}
status: 
  topologyPolicy: SingleNUMANodeContainerLevel
  topologyZone:
     ...
  
```

This PR attempts to list all CNRs from the kube-apiserver during the periodic cleaning process, instead of using `cnrLister` with a NodeSelector.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:



