### PR TITLE
resource eviction ThresholdGetter support threshold not set

### DIFF
--- a/pkg/agent/evictionmanager/plugin/reclaimed_resources.go
+++ b/pkg/agent/evictionmanager/plugin/reclaimed_resources.go
@@ -52,11 +52,11 @@ func NewReclaimedResourcesEvictionPlugin(_ *client.GenericClientSet, _ events.Ev
 		return allocatable, nil
 	}
 
-	reclaimedThresholdGetter := func(resourceName v1.ResourceName) float64 {
+	reclaimedThresholdGetter := func(resourceName v1.ResourceName) *float64 {
 		if threshold, ok := conf.GetDynamicConfiguration().EvictionThreshold[resourceName]; !ok {
-			return 1.
+			return nil
 		} else {
-			return threshold
+			return &threshold
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
ThresholdGetter of resource eviction support threshold not set
