### PR TITLE
fix KatalystCustomConfigTargetHandler to avoid cnc being cleared when cache no synced in restart

### DIFF
--- a/pkg/controller/kcc/cnc.go
+++ b/pkg/controller/kcc/cnc.go
@@ -98,6 +98,7 @@ func NewCustomNodeConfigController(
 		customNodeConfigSyncQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), cncControllerName),
 		syncedFunc: []cache.InformerSynced{
 			customNodeConfigInformer.Informer().HasSynced,
+			targetHandler.HasSynced,
 		},
 	}
 

--- a/pkg/controller/kcc/kcc.go
+++ b/pkg/controller/kcc/kcc.go
@@ -111,6 +111,7 @@ func NewKatalystCustomConfigController(
 		katalystCustomConfigSyncQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), kccControllerName),
 		syncedFunc: []cache.InformerSynced{
 			katalystCustomConfigInformer.Informer().HasSynced,
+			targetHandler.HasSynced,
 		},
 	}
 

--- a/pkg/controller/kcc/kcct.go
+++ b/pkg/controller/kcc/kcct.go
@@ -101,6 +101,7 @@ func NewKatalystCustomConfigTargetController(
 		targetHandler:              targetHandler,
 		syncedFunc: []cache.InformerSynced{
 			katalystCustomConfigInformer.Informer().HasSynced,
+			targetHandler.HasSynced,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
cnc/kcc/kcct controller should wait KatalystCustomConfigTargetHandler cache synced to aviod unexpectly behavior when cache no synced in restart.
