### PR TITLE
fix(sysadvisor): avoid gc living containers' original owner pools

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server.go
@@ -176,6 +176,13 @@ func (cs *cpuServer) getCheckpoint() {
 		return false
 	})
 
+	// complement living containers' original owner pools for pool gc
+	// todo: deprecate original owner pool and generate owner pool by realtime container status
+	cs.metaCache.RangeContainer(func(podUID string, containerName string, containerInfo *types.ContainerInfo) bool {
+		livingPoolNameSet.Insert(containerInfo.OriginOwnerPoolName)
+		return true
+	})
+
 	// gc pool entries
 	_ = cs.metaCache.GCPoolEntries(livingPoolNameSet)
 


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
Avoid gc living containers' original owner pools.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
