### PR TITLE
Add device io stat metrics

### DIFF
--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -55,6 +55,10 @@ const (
 	MetricIOReadSystem  = "io.read.system"
 	MetricIOWriteSystem = "io.write.system"
 	MetricIOBusySystem  = "io.busy.system"
+
+	MetricIOReadOpsSystem  = "io.read.ops.system"
+	MetricIOWriteOpsSystem = "io.write.ops.system"
+	MetricIOBusyRateSystem = "io.busy.rate.system"
 )
 
 // System numa metrics

--- a/pkg/util/metric/store.go
+++ b/pkg/util/metric/store.go
@@ -33,8 +33,9 @@ type MetricData struct {
 	Time *time.Time
 }
 
-// MetricStore stores those raw metric data items collected from
-// agent.MetricsFetcher
+// MetricStore stores those metric data. Including:
+// 1. raw data collected from agent.MetricsFetcher.
+// 2. data calculated based on raw data.
 type MetricStore struct {
 	mutex sync.RWMutex
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:
There are some metrics like iobusy/ioread/iowrite. They are  originated from [/proc/diskstats](https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats) (their filed numbers are 13, 4, 8 respectively).

These metrics are like `counter type` in prom. Thus they need to be rated over time.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
