### PR TITLE
Fix calculation of rate metrics

### DIFF
--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -114,7 +114,7 @@ const (
 	MetricStoreAllInsContainer  = "cpu.store.allins.container"
 	MetricStoreInsContainer     = "cpu.store.ins.container"
 
-	MetricUpdateTimeContainer = "cpu.updatetime.container"
+	MetricCPUUpdateTimeContainer = "cpu.updatetime.container"
 )
 
 // container memory metrics
@@ -147,6 +147,8 @@ const (
 	MetricBlkioWriteIopsContainer = "blkio.write.iops.container"
 	MetricBlkioReadBpsContainer   = "blkio.read.bps.container"
 	MetricBlkioWriteBpsContainer  = "blkio.write.bps.container"
+
+	MetricBlkioUpdateTimeContainer = "blkio.updatetime.container"
 )
 
 // container net metrics


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Due to the sampling lag between katalyst(once per 5s) and malachite-core(once per 10s), there will be lots of "zero" value produced(70% for mem_read/write_bandwidth).

This work tries to fix the problem by setting rate metric only when the metric is updated.

#### Special notes for your reviewer:
For the previous version:
(Many "zero" cases could be seen in the three following moments.)

<img width="1843" alt="截屏2023-10-09 14 57 01" src="https://github.com/kubewharf/katalyst-core/assets/38838049/6b073c43-f5d6-4a62-9677-3ce15ae59b42">



<img width="1851" alt="截屏2023-10-09 14 57 14" src="https://github.com/kubewharf/katalyst-core/assets/38838049/748dc06f-bd69-460f-808a-3233da9408c8">

<img width="1855" alt="截屏2023-10-09 14 57 29" src="https://github.com/kubewharf/katalyst-core/assets/38838049/ebd05d79-1b72-4c0e-83eb-4420d48ba54c">

After Updating:
(No more "zero" values, but at the "start" moment basically. I did't upload them all, but I had checked about it.)

<img width="1856" alt="截屏2023-10-09 14 28 39" src="https://github.com/kubewharf/katalyst-core/assets/38838049/2018a081-6b24-47f1-95a0-7c40142e2291">

