### PR TITLE
increase the log level of getting object failed when check internal metric

### DIFF
--- a/pkg/custom-metric/store/local/local_store.go
+++ b/pkg/custom-metric/store/local/local_store.go
@@ -299,7 +299,8 @@ func (l *LocalMemoryMetricStore) checkInternalMetricMatchedWithObjectList(intern
 
 	obj, err := l.getObject(internal.GetObjectKind(), namespace, internal.GetObjectName())
 	if err != nil {
-		return false, err
+		klog.V(5).Infof("get object %v/%v kind %s failed, %v", namespace, internal.GetName(), internal.GetObjectKind(), err)
+		return false, nil
 	}
 
 	workload, ok := obj.(*v1.PartialObjectMetadata)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
To minimize the volume of logs generated when object retrieval fails during internal metric checks, particularly in instances where pods are created or deleted too frequently
