### PR TITLE
feat(advisor): borwein fix & enhancement

### DIFF
--- a/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/borwein_test.go
+++ b/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/borwein_test.go
@@ -359,6 +359,13 @@ func TestBorweinModelResultFetcher_parseInferenceRespForPods(t *testing.T) {
 		})
 	})
 	metaServer.MetricsFetcher.Run(context.Background())
+	containers := []*advisortypes.ContainerInfo{
+		{
+			PodUID:        podUID,
+			PodName:       podName,
+			ContainerName: containerName,
+		},
+	}
 	pods := []*v1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -405,8 +412,8 @@ func TestBorweinModelResultFetcher_parseInferenceRespForPods(t *testing.T) {
 		infSvcClient          borweininfsvc.InferenceServiceClient
 	}
 	type args struct {
-		pods []*v1.Pod
-		resp *borweininfsvc.InferenceResponse
+		containers []*advisortypes.ContainerInfo
+		resp       *borweininfsvc.InferenceResponse
 	}
 	tests := []struct {
 		name    string
@@ -425,7 +432,7 @@ func TestBorweinModelResultFetcher_parseInferenceRespForPods(t *testing.T) {
 				infSvcClient:          infSvcClient,
 			},
 			args: args{
-				pods: pods,
+				containers: containers,
 				resp: &borweininfsvc.InferenceResponse{
 					PodResponseEntries: map[string]*borweininfsvc.ContainerResponseEntries{
 						podUID: {
@@ -456,7 +463,7 @@ func TestBorweinModelResultFetcher_parseInferenceRespForPods(t *testing.T) {
 				containerFeatureNames: tt.fields.containerFeatureNames,
 				infSvcClient:          tt.fields.infSvcClient,
 			}
-			got, err := bmrf.parseInferenceRespForPods(tt.args.pods, tt.args.resp)
+			got, err := bmrf.parseInferenceRespForPods(tt.args.containers, tt.args.resp)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BorweinModelResultFetcher.parseInferenceRespForPods() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -500,6 +507,13 @@ func TestBorweinModelResultFetcher_getInferenceRequestForPods(t *testing.T) {
 		})
 	})
 	metaServer.MetricsFetcher.Run(context.Background())
+	containers := []*advisortypes.ContainerInfo{
+		{
+			PodUID:        podUID,
+			PodName:       podName,
+			ContainerName: containerName,
+		},
+	}
 	pods := []*v1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -546,7 +560,7 @@ func TestBorweinModelResultFetcher_getInferenceRequestForPods(t *testing.T) {
 		infSvcClient          borweininfsvc.InferenceServiceClient
 	}
 	type args struct {
-		pods       []*v1.Pod
+		containers []*advisortypes.ContainerInfo
 		metaServer *metaserver.MetaServer
 		metaWriter metacache.MetaWriter
 		metaReader metacache.MetaReader
@@ -568,7 +582,7 @@ func TestBorweinModelResultFetcher_getInferenceRequestForPods(t *testing.T) {
 				infSvcClient:          infSvcClient,
 			},
 			args: args{
-				pods:       pods,
+				containers: containers,
 				metaReader: mc,
 				metaWriter: mc,
 				metaServer: metaServer,
@@ -596,7 +610,7 @@ func TestBorweinModelResultFetcher_getInferenceRequestForPods(t *testing.T) {
 				containerFeatureNames: tt.fields.containerFeatureNames,
 				infSvcClient:          tt.fields.infSvcClient,
 			}
-			got, err := bmrf.getInferenceRequestForPods(tt.args.pods, tt.args.metaReader, tt.args.metaWriter, tt.args.metaServer)
+			got, err := bmrf.getInferenceRequestForPods(tt.args.containers, tt.args.metaReader, tt.args.metaWriter, tt.args.metaServer)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BorweinModelResultFetcher.getInferenceRequestForPods() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein.go
@@ -242,3 +242,12 @@ func (bc *BorweinController) GetUpdatedIndicators(indicators types.Indicator, po
 	bc.updateIndicatorOffsets(podSet)
 	return bc.getUpdatedIndicators(indicators)
 }
+
+func (bc *BorweinController) ResetIndicatorOffsets() {
+	for indicatorName, currentIndicatorOffset := range bc.indicatorOffsets {
+		general.Infof("reset indicator: %s offset from %.2f to 0",
+			indicatorName, currentIndicatorOffset)
+
+		bc.indicatorOffsets[indicatorName] = 0
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
@@ -698,3 +698,40 @@ func TestBorweinController_GetUpdatedIndicators(t *testing.T) {
 		})
 	}
 }
+
+func TestBorweinController_ResetIndicatorOffsets(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		indicatorOffsets map[string]float64
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		results map[string]float64
+	}{
+		{
+			name: "test with nil indicatorOffsets",
+		},
+		{
+			name: "test with non-nil indicatorOffsets",
+			fields: fields{
+				indicatorOffsets: map[string]float64{
+					string(workloadv1alpha1.TargetIndicatorNameCPUSchedWait): 460,
+				},
+			},
+			results: map[string]float64{
+				string(workloadv1alpha1.TargetIndicatorNameCPUSchedWait): 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bc := &BorweinController{
+				indicatorOffsets: tt.fields.indicatorOffsets,
+			}
+			bc.ResetIndicatorOffsets()
+			require.True(t, reflect.DeepEqual(bc.indicatorOffsets, tt.results))
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/types/helper.go
+++ b/pkg/agent/sysadvisor/types/helper.go
@@ -35,7 +35,7 @@ func (ci *ContainerInfo) IsNumaBinding() bool {
 }
 
 func (ci *ContainerInfo) IsNumaExclusive() bool {
-	return ci.QoSLevel == consts.PodAnnotationQoSLevelDedicatedCores && qosutil.AnnotationsIndicateNUMAExclusive(ci.Annotations)
+	return ci.IsNumaBinding() && qosutil.AnnotationsIndicateNUMAExclusive(ci.Annotations)
 }
 
 func (ci *ContainerInfo) Clone() *ContainerInfo {


### PR DESCRIPTION
1. only update indicators when enbale borwein and rama in use 
2. support resetting indicator offset
3. use matacache instead of metaserver to get request containers to inference for 