### PR TITLE
doc: some fixes to examples and proposals for the reclaimed core pod cannot be scheduled

### DIFF
--- a/docs/proposals/scheduling/20220913-katalyst-scheduler-design.md
+++ b/docs/proposals/scheduling/20220913-katalyst-scheduler-design.md
@@ -555,6 +555,8 @@ Compatibility matrix:
           filter:
             enabled:
             - name: QoSAwareNodeResourcesFit
+            disabled:
+            - name: NodeResourcesFit
           score:
             enabled:
             - name: QoSAwareNodeResourcesFit
@@ -619,6 +621,8 @@ Compatibility matrix:
           filter:
             enabled:
             - name: QoSAwareNodeResourcesFit
+            disabled:
+            - name: NodeResourcesFit
           score:
             enabled:
             - name: QoSAwareNodeResourcesFit
@@ -761,6 +765,8 @@ Compatibility matrix:
           filter:
             enabled:
             - name: QoSAwareNodeResourcesFit
+            disabled:
+            - name: NodeResourcesFit
           score:
             enabled:
             - name: QoSAwareNodeResourcesFit
@@ -825,6 +831,8 @@ Compatibility matrix:
           filter:
             enabled:
             - name: QoSAwareNodeResourcesFit
+            disabled:
+            - name: NodeResourcesFit
           score:
             enabled:
             - name: QoSAwareNodeResourcesFit

--- a/examples/scheduler-policy-binpack.yaml
+++ b/examples/scheduler-policy-binpack.yaml
@@ -35,6 +35,8 @@ data:
           filter:
             enabled:
               - name: QoSAwareNodeResourcesFit
+            disabled:
+              - name: NodeResourcesFit
           score:
             enabled:
               - name: QoSAwareNodeResourcesFit

--- a/examples/scheduler-policy-custom.yaml
+++ b/examples/scheduler-policy-custom.yaml
@@ -35,6 +35,8 @@ data:
           filter:
             enabled:
               - name: QoSAwareNodeResourcesFit
+            disabled:
+              - name: NodeResourcesFit
           score:
             enabled:
               - name: QoSAwareNodeResourcesFit

--- a/examples/scheduler-policy-spread.yaml
+++ b/examples/scheduler-policy-spread.yaml
@@ -35,6 +35,8 @@ data:
           filter:
             enabled:
               - name: QoSAwareNodeResourcesFit
+            disabled:
+              - name: NodeResourcesFit
           score:
             enabled:
               - name: QoSAwareNodeResourcesFit


### PR DESCRIPTION


#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:
![img_v2_e6100dea-7afe-4278-a0f8-cd440e2fa5dg](https://github.com/kubewharf/katalyst-core/assets/53330071/760b750e-4791-480d-b7b6-239db21fbba3)

If  do not close the NodeResourcesFit, it will cause the katalyst-scheduler to schedule the reclaimed core pod in the Filter stage.

#### Which issue(s) this PR fixes:
#331 
#### Special notes for your reviewer:
