### PR TITLE
Print out NIC info upon qrm network plugin initialization

### DIFF
--- a/pkg/agent/qrm-plugins/network/state/util.go
+++ b/pkg/agent/qrm-plugins/network/state/util.go
@@ -32,6 +32,10 @@ func GenerateMachineState(conf *qrm.QRMPluginsConfiguration, nics []machine.Inte
 		reservedBandwidth := reservation[iface.Iface]
 		egressCapacity := uint32(float32(iface.Speed) * conf.EgressCapacityRate)
 		ingressCapacity := uint32(float32(iface.Speed) * conf.IngressCapacityRate)
+
+		generalLog := general.LoggerWithPrefix("GenerateMachineState", general.LoggingPKGFull)
+		generalLog.Infof("NIC %s's speed: %d, capacity: [%d/%d], reservation: %d", iface.Iface, iface.Speed, egressCapacity, ingressCapacity, reservedBandwidth)
+
 		// we do not differentiate egress reservation and ingress reservation for now. That is, they are supposed to be the same.
 		if reservedBandwidth > 0 && (reservedBandwidth >= egressCapacity || reservedBandwidth >= ingressCapacity) {
 			return nil, fmt.Errorf("invalid bandwidth reservation: %d on NIC: %s with capacity: [%d/%d]", reservedBandwidth, iface.Iface, egressCapacity, ingressCapacity)


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
Print out NIC info when initializing qrm network plugin
