### PR TITLE
unified solution for TCP memory limitation

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -37,6 +37,8 @@ type SockMemOptions struct {
 	EnableSettingSockMem bool
 	// SetHostTCPMemLimit limit host max tcp memory usage.
 	SetHostTCPMemLimitRatio int
+	// SetCgroupTCPMemLimitRatio limit cgroup max tcp memory usage.
+	SetCgroupTCPMemLimitRatio int
 }
 
 func NewMemoryOptions() *MemoryOptions {
@@ -47,8 +49,9 @@ func NewMemoryOptions() *MemoryOptions {
 		EnableSettingMemoryMigrate: false,
 		EnableMemoryAdvisor:        false,
 		SockMemOptions: SockMemOptions{
-			EnableSettingSockMem:    false,
-			SetHostTCPMemLimitRatio: 20, // default: 20% * {host total memory}
+			EnableSettingSockMem:      false,
+			SetHostTCPMemLimitRatio:   20,  // default: 20% * {host total memory}
+			SetCgroupTCPMemLimitRatio: 100, // default: 100% * {cgroup memory}
 		},
 	}
 }
@@ -72,6 +75,8 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.EnableSettingSockMem, "if set true, we will limit tcpmem usage in cgroup and host level")
 	fs.IntVar(&o.SetHostTCPMemLimitRatio, "qrm-memory-host-tcpmem-limit-ratio",
 		o.SetHostTCPMemLimitRatio, "limit host max tcp memory usage")
+	fs.IntVar(&o.SetCgroupTCPMemLimitRatio, "qrm-memory-cgroup-tcpmem-limit-ratio",
+		o.SetCgroupTCPMemLimitRatio, "limit cgroup max tcp memory usage")
 }
 
 func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
@@ -83,5 +88,6 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.ExtraControlKnobConfigFile = o.ExtraControlKnobConfigFile
 	conf.EnableSettingSockMem = o.EnableSettingSockMem
 	conf.SetHostTCPMemLimitRatio = o.SetHostTCPMemLimitRatio
+	conf.SetCgroupTCPMemLimitRatio = o.SetCgroupTCPMemLimitRatio
 	return nil
 }

--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -29,6 +29,14 @@ type MemoryOptions struct {
 	EnableSettingMemoryMigrate bool
 	EnableMemoryAdvisor        bool
 	ExtraControlKnobConfigFile string
+
+	SockMemOptions
+}
+
+type SockMemOptions struct {
+	EnableSettingSockMem bool
+	// SetHostTCPMemLimit limit host max tcp memory usage.
+	SetHostTCPMemLimitRatio int
 }
 
 func NewMemoryOptions() *MemoryOptions {
@@ -38,6 +46,10 @@ func NewMemoryOptions() *MemoryOptions {
 		SkipMemoryStateCorruption:  false,
 		EnableSettingMemoryMigrate: false,
 		EnableMemoryAdvisor:        false,
+		SockMemOptions: SockMemOptions{
+			EnableSettingSockMem:    false,
+			SetHostTCPMemLimitRatio: 20, // default: 20% * {host total memory}
+		},
 	}
 }
 
@@ -56,7 +68,12 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.EnableMemoryAdvisor, "Whether memory resource plugin should enable sys-advisor")
 	fs.StringVar(&o.ExtraControlKnobConfigFile, "memory-extra-control-knob-config-file",
 		o.ExtraControlKnobConfigFile, "the absolute path of extra control knob config file")
+	fs.BoolVar(&o.EnableSettingSockMem, "enable-setting-sockmem",
+		o.EnableSettingSockMem, "if set true, we will limit tcpmem usage in cgroup and host level")
+	fs.IntVar(&o.SetHostTCPMemLimitRatio, "qrm-memory-host-tcpmem-limit-ratio",
+		o.SetHostTCPMemLimitRatio, "limit host max tcp memory usage")
 }
+
 func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.PolicyName = o.PolicyName
 	conf.ReservedMemoryGB = o.ReservedMemoryGB
@@ -64,5 +81,7 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.EnableSettingMemoryMigrate = o.EnableSettingMemoryMigrate
 	conf.EnableMemoryAdvisor = o.EnableMemoryAdvisor
 	conf.ExtraControlKnobConfigFile = o.ExtraControlKnobConfigFile
+	conf.EnableSettingSockMem = o.EnableSettingSockMem
+	conf.SetHostTCPMemLimitRatio = o.SetHostTCPMemLimitRatio
 	return nil
 }

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -213,6 +213,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		memoryadvisor.ControlKnobHandlerWithChecker(policyImplement.handleAdvisorDropCache))
 
 	sockmem.UpdateHostTCPMemRatio(conf.SetHostTCPMemLimitRatio)
+	sockmem.UpdateCgroupTCPMemRatio(conf.SetCgroupTCPMemLimitRatio)
 
 	return true, &agent.PluginWrapper{GenericPlugin: pluginWrapper}, nil
 }

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/advisorsvc"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/memoryadvisor"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/state"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	"github.com/kubewharf/katalyst-core/pkg/agent/utilcomponent/periodicalhandler"
@@ -67,6 +68,7 @@ const (
 	stateCheckPeriod           = 30 * time.Second
 	maxResidualTime            = 5 * time.Minute
 	setMemoryMigratePeriod     = 5 * time.Second
+	setSockMemPeriod           = 1 * time.Minute
 	applyCgroupPeriod          = 5 * time.Second
 	setExtraControlKnobsPeriod = 5 * time.Second
 )
@@ -123,6 +125,7 @@ type DynamicPolicy struct {
 	asyncWorkers *asyncworker.AsyncWorkers
 
 	enableSettingMemoryMigrate bool
+	enableSettingSockMem       bool
 	enableMemoryAdvisor        bool
 	memoryAdvisorSocketAbsPath string
 	memoryPluginSocketAbsPath  string
@@ -177,6 +180,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		podDebugAnnoKeys:           conf.PodDebugAnnoKeys,
 		asyncWorkers:               asyncworker.NewAsyncWorkers(memoryPluginAsyncWorkersName),
 		enableSettingMemoryMigrate: conf.EnableSettingMemoryMigrate,
+		enableSettingSockMem:       conf.EnableSettingSockMem,
 		enableMemoryAdvisor:        conf.EnableMemoryAdvisor,
 		memoryAdvisorSocketAbsPath: conf.MemoryAdvisorSocketAbsPath,
 		memoryPluginSocketAbsPath:  conf.MemoryPluginSocketAbsPath,
@@ -207,6 +211,8 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		memoryadvisor.ControlKnobHandlerWithChecker(handleAdvisorCPUSetMems))
 	memoryadvisor.RegisterControlKnobHandler(memoryadvisor.ControlKnobKeyDropCache,
 		memoryadvisor.ControlKnobHandlerWithChecker(policyImplement.handleAdvisorDropCache))
+
+	sockmem.UpdateHostTCPMemRatio(conf.SetHostTCPMemLimitRatio)
 
 	return true, &agent.PluginWrapper{GenericPlugin: pluginWrapper}, nil
 }
@@ -243,6 +249,11 @@ func (p *DynamicPolicy) Start() (err error) {
 	if p.enableSettingMemoryMigrate {
 		general.Infof("setMemoryMigrate enabled")
 		go wait.Until(p.setMemoryMigrate, setMemoryMigratePeriod, p.stopCh)
+	}
+
+	if p.enableSettingSockMem {
+		general.Infof("setSockMem enabled")
+		go wait.Until(p.setSockMemLimit, setSockMemPeriod, p.stopCh)
 	}
 
 	periodicalhandler.ReadyToStartHandlersByGroup(qrm.QRMMemoryPluginPeriodicalHandlerGroupName)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/const.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/const.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+const (
+	// Constants for host tcp mem ratio
+	hostTCPMemRatioMin = 20 // min ratio for host tcp mem: 20%
+	hostTCPMemRatioMax = 80 // max ratio for host tcp mem: 80%
+	hostTCPMemFile     = "/proc/sys/net/ipv4/tcp_mem"
+)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/const.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/const.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Katalyst Authors.
+Copyright 2022 The Katalyst Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,4 +21,13 @@ const (
 	hostTCPMemRatioMin = 20 // min ratio for host tcp mem: 20%
 	hostTCPMemRatioMax = 80 // max ratio for host tcp mem: 80%
 	hostTCPMemFile     = "/proc/sys/net/ipv4/tcp_mem"
+
+	// Constants for cgroupv1 sock memory statistics
+	kernSockMemOff     = 9223372036854771712 // max value
+	kernSockMemEnabled = 9223372036854767616
+
+	// Constants for cgroupv1 sock memory ratio
+	cgroupTCPMemMin2G    = 2147483648 // static min value for pod's sockmem: 2G
+	cgroupTCPMemRatioMin = 20         // min ratio for pod's sockmem: 20%
+	cgroupTCPMemRatioMax = 200        // max ratio for pod's sockmem: 200%
 )

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/sockmem_linux.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/sockmem_linux.go
@@ -1,0 +1,120 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2023 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	info "github.com/google/cadvisor/info/v1"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+type SockMemConfig struct {
+	hostTCPMemRatio   int
+	cgroupTCPMemRatio int
+}
+
+var sockMemConfig = SockMemConfig{
+	hostTCPMemRatio:   20,  // default: 20% * {host total memory}
+	cgroupTCPMemRatio: 100, // default: 100% * {cgroup memory limit}
+}
+
+func UpdateHostTCPMemRatio(ratio int) {
+	if ratio < hostTCPMemRatioMin {
+		ratio = hostTCPMemRatioMin
+	} else if ratio > hostTCPMemRatioMax {
+		ratio = hostTCPMemRatioMax
+	}
+	sockMemConfig.hostTCPMemRatio = ratio
+}
+
+func alignToPageSize(number int) int {
+	pageSize := int(syscall.Getpagesize())
+	alignedNumber := (number + pageSize - 1) &^ (pageSize - 1)
+	return alignedNumber
+}
+
+func getHostTCPMemFile(TCPMemFile string) ([]uint64, error) {
+	data, err := os.ReadFile(TCPMemFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s, err %v", TCPMemFile, err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("empty content in %s", TCPMemFile)
+	}
+
+	line := lines[0]
+	fields := strings.Fields(line)
+	if len(fields) != 3 {
+		return nil, fmt.Errorf("unexpected number of fields in %s", TCPMemFile)
+	}
+
+	var tcpMem []uint64
+	for _, field := range fields {
+		value, err := strconv.ParseUint(field, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		tcpMem = append(tcpMem, value)
+	}
+
+	return tcpMem, nil
+}
+
+func setHostTCPMemFile(TCPMemFile string, tcpMem []uint64) error {
+	if len(tcpMem) != 3 {
+		return fmt.Errorf("tcpMem array must have exactly three elements")
+	}
+
+	content := fmt.Sprintf("%d\t%d\t%d\n", tcpMem[0], tcpMem[1], tcpMem[2])
+	err := os.WriteFile(TCPMemFile, []byte(content), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to %s, err %v", TCPMemFile, err)
+	}
+
+	return nil
+}
+
+func SetHostTCPMem(machineInfo *info.MachineInfo) {
+	tcpMemRatio := sockMemConfig.hostTCPMemRatio
+	tcpMem, err := getHostTCPMemFile(hostTCPMemFile)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	pageSize := uint64(unix.Getpagesize())
+	memTotal := machineInfo.MemoryCapacity
+
+	newUpperLimit := memTotal / pageSize / 100 * uint64(tcpMemRatio)
+
+	if (newUpperLimit != tcpMem[2]) && (newUpperLimit > tcpMem[1]) {
+		klog.Infof("write to host tcp_mem, newLimit=%d, oldLimit=%d", newUpperLimit, tcpMem[2])
+		tcpMem[2] = newUpperLimit
+		setHostTCPMemFile(hostTCPMemFile, tcpMem)
+	}
+}

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/sockmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/sockmem/sockmem_linux_test.go
@@ -1,0 +1,174 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLimitFromTCPMemFile(t *testing.T) {
+	// case1, normal input/outout
+	tmpFile, err := ioutil.TempFile("", "tcp_mem")
+	if err != nil {
+		t.Fatalf("Error creating temporary file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	testData := []byte("187365\t249822\t999999\n")
+	_, err = tmpFile.Write(testData)
+	if err != nil {
+		t.Fatalf("Error writing test data to temporary file: %v", err)
+	}
+	tmpFile.Close()
+
+	tcpMem, err := getHostTCPMemFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf("Expected no error, but got error: %v", err)
+	}
+	expectedUpperLimit := uint64(999999)
+	if expectedUpperLimit != tcpMem[2] {
+		t.Errorf("Expected upper limit to be %d, but got %d", expectedUpperLimit, tcpMem[2])
+	}
+
+	expectedUpperLimit = uint64(249822)
+	if expectedUpperLimit != tcpMem[1] {
+		t.Errorf("Expected pressure limit to be %d, but got %d", expectedUpperLimit, tcpMem[1])
+	}
+
+	// case2, null file
+	_, err = getHostTCPMemFile("nullfile")
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+
+	// case3, file with invalid data
+	testData = []byte("invalid_data\n")
+	err = ioutil.WriteFile(tmpFile.Name(), testData, 0644)
+	if err != nil {
+		t.Fatalf("Error writing invalid test data to temporary file: %v", err)
+	}
+	_, err = getHostTCPMemFile(tmpFile.Name())
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+}
+
+func TestSetLimitToTCPMemFile(t *testing.T) {
+	// case1, normal logic
+	tmpFile, err := ioutil.TempFile("", "tcp_mem")
+	if err != nil {
+		t.Fatalf("Error creating temporary file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	testData := []byte("187365\t249822\t999999\n")
+	_, err = tmpFile.Write(testData)
+	if err != nil {
+		t.Fatalf("Error writing test data to temporary file: %v", err)
+	}
+	tmpFile.Close()
+
+	tcpMem := []uint64{1, 2, 123456}
+	setHostTCPMemFile(tmpFile.Name(), tcpMem)
+	data, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading modified file: %v", err)
+	}
+	newValues := strings.Fields(string(data))
+	if len(newValues) < 3 {
+		t.Errorf("Expected at least 3 values in the file, but got %d", len(newValues))
+	}
+	newUpper, _ := strconv.Atoi(newValues[2])
+	if newUpper != 123456 {
+		t.Errorf("Expected upper limit to be 123456, but got %d", newUpper)
+	}
+
+	// case2, null file
+	err = setHostTCPMemFile("nonexistentfile", tcpMem)
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("Expected 'file not found' error, but got: %v", err)
+	}
+	// case3, file with invalid data
+	wrongTcpMem := []uint64{1, 2, 3, 4}
+	err = setHostTCPMemFile(tmpFile.Name(), wrongTcpMem)
+	if err == nil {
+		t.Error("tcp_mem is wrong, need return err")
+	}
+}
+
+func TestAlignToPageSize(t *testing.T) {
+	pageSize := int64(syscall.Getpagesize())
+
+	// Test case 1: Number already aligned to page size
+	result := alignToPageSize(pageSize * 2)
+	assert.Equal(t, pageSize*2, result, "Unexpected result for aligned number")
+
+	// Test case 2: Number smaller than page size
+	result = alignToPageSize(pageSize - 1)
+	assert.Equal(t, pageSize, result, "Unexpected result for number smaller than page size")
+}
+
+func TestUpdateHostTCPMemRatio(t *testing.T) {
+	// Test case 1: Valid ratio within the range
+	UpdateHostTCPMemRatio(30)
+	assert.Equal(t, 30, sockMemConfig.hostTCPMemRatio, "Unexpected hostTCPMemRatio value")
+
+	// Test case 2: Ratio below the minimum
+	UpdateHostTCPMemRatio(hostTCPMemRatioMin - 1)
+	assert.Equal(t, hostTCPMemRatioMin, sockMemConfig.hostTCPMemRatio, "Unexpected hostTCPMemRatio value")
+
+	// Test case 3: Ratio above the maximum
+	UpdateHostTCPMemRatio(hostTCPMemRatioMax + 1)
+	assert.Equal(t, hostTCPMemRatioMax, sockMemConfig.hostTCPMemRatio, "Unexpected hostTCPMemRatio value")
+}
+
+func TestUpdateCgroupTCPMemRatio(t *testing.T) {
+	// Test case 1: Valid ratio within the range
+	UpdateCgroupTCPMemRatio(50)
+	assert.Equal(t, 50, sockMemConfig.cgroupTCPMemRatio, "Unexpected cgroupTCPMemRatio value")
+
+	// Test case 2: Ratio below the minimum
+	UpdateCgroupTCPMemRatio(cgroupTCPMemRatioMin - 1)
+	assert.Equal(t, cgroupTCPMemRatioMin, sockMemConfig.cgroupTCPMemRatio, "Unexpected cgroupTCPMemRatio value")
+
+	// Test case 3: Ratio above the maximum
+	UpdateCgroupTCPMemRatio(cgroupTCPMemRatioMax + 1)
+	assert.Equal(t, cgroupTCPMemRatioMax, sockMemConfig.cgroupTCPMemRatio, "Unexpected cgroupTCPMemRatio value")
+}
+
+func TestSetCg1TCPMem(t *testing.T) {
+	podUID := "pod123"
+	containerID := "container456"
+	memLimit := int64(1024)
+	memTCPLimit := int64(512)
+	err := SetCg1TCPMem(podUID, containerID, memLimit, memTCPLimit)
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+}

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -39,6 +39,8 @@ type SockMemQRMPluginConfig struct {
 	EnableSettingSockMem bool
 	// SetHostTCPMemLimit limit host max tcp memory usage.
 	SetHostTCPMemLimitRatio int
+	// SetCgroupTCPMemLimit limit cgroup max tcp memory usage.
+	SetCgroupTCPMemLimitRatio int
 }
 
 func NewMemoryQRMPluginConfig() *MemoryQRMPluginConfig {

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -29,6 +29,16 @@ type MemoryQRMPluginConfig struct {
 	EnableMemoryAdvisor bool
 	// ExtraControlKnobConfigFile: the absolute path of extra control knob config file
 	ExtraControlKnobConfigFile string
+
+	// SockMemQRMPluginConfig: the configuration for sockmem limitation in cgroup and host level
+	SockMemQRMPluginConfig
+}
+
+type SockMemQRMPluginConfig struct {
+	// EnableSettingSockMemLimit is used to limit tcpmem usage in cgroup and host level
+	EnableSettingSockMem bool
+	// SetHostTCPMemLimit limit host max tcp memory usage.
+	SetHostTCPMemLimitRatio int
 }
 
 func NewMemoryQRMPluginConfig() *MemoryQRMPluginConfig {

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -120,6 +120,7 @@ const (
 // container memory metrics
 const (
 	MetricMemLimitContainer     = "mem.limit.container"
+	MetricMemTCPLimitContainer  = "mem.tcp.limit.container"
 	MetricMemUsageContainer     = "mem.usage.container"
 	MetricMemUsageUserContainer = "mem.usage.user.container"
 	MetricMemUsageSysContainer  = "mem.usage.sys.container"

--- a/pkg/metaserver/agent/metric/malachite/fetcher.go
+++ b/pkg/metaserver/agent/metric/malachite/fetcher.go
@@ -816,6 +816,8 @@ func (m *MalachiteMetricsFetcher) processContainerMemoryData(podUID, containerNa
 
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemLimitContainer,
 			utilmetric.MetricData{Value: float64(mem.MemoryLimitInBytes), Time: &updateTime})
+		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemTCPLimitContainer,
+			utilmetric.MetricData{Value: float64(mem.KernTCPMemLimitInBytes), Time: &updateTime})
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemUsageContainer,
 			utilmetric.MetricData{Value: float64(mem.MemoryUsageInBytes), Time: &updateTime})
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemUsageUserContainer,

--- a/pkg/metaserver/agent/metric/malachite/types/cgroup.go
+++ b/pkg/metaserver/agent/metric/malachite/types/cgroup.go
@@ -104,6 +104,7 @@ type MemoryCgDataV1 struct {
 	MemoryLimitInBytes     uint64        `json:"memory_limit_in_bytes"`
 	MemoryUsageInBytes     uint64        `json:"memory_usage_in_bytes"`
 	KernMemoryUsageInBytes uint64        `json:"kern_memory_usage_in_bytes"`
+	KernTCPMemLimitInBytes uint64        `json:"kern_tcp_memory_limit_in_bytes"`
 	Cache                  uint64        `json:"cache"`
 	Rss                    uint64        `json:"rss"`
 	Shmem                  uint64        `json:"shmem"`

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -56,8 +56,9 @@ const (
 
 // MemoryData set cgroup memory data
 type MemoryData struct {
-	LimitInBytes int64
-	WmarkRatio   int32
+	LimitInBytes       int64
+	TCPMemLimitInBytes int64
+	WmarkRatio         int32
 }
 
 // CPUData set cgroup cpu data

--- a/pkg/util/cgroup/manager/v1/fs_linux.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux.go
@@ -52,6 +52,14 @@ func (m *manager) ApplyMemory(absCgroupPath string, data *common.MemoryData) err
 		}
 	}
 
+	if data.TCPMemLimitInBytes > 0 {
+		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.kmem.tcp.limit_in_bytes", strconv.FormatInt(data.TCPMemLimitInBytes, 10)); err != nil {
+			return err
+		} else if applied {
+			klog.Infof("[CgroupV1] apply memory kmem.tcp.limit_in_bytes successfully, cgroupPath: %s, data: %v, old data: %v\n", absCgroupPath, data.TCPMemLimitInBytes, oldData)
+		}
+	}
+
 	if data.WmarkRatio != 0 {
 		newRatio := fmt.Sprintf("%d", data.WmarkRatio)
 		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.wmark_ratio", newRatio); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
Features
#### What this PR does / why we need it:
The feature provides the unified solution for TCP memory limitation in cgroup and host level.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
The feature includes 3 parts:
1, Set the limit value for host net.ipv4.tcp_mem. 
The default value is 20% of host toal memory.
2, Do nothing for cgroupv2.
3, Set pod tcp_mem accounting for cgroupv1. 
The default value is same with memory.limit_in_bytes.
