### PR TITLE
feat(sockmem-plugin): unified solution for TCP memory limitation #365

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -29,6 +29,14 @@ type MemoryOptions struct {
 	EnableSettingMemoryMigrate bool
 	EnableMemoryAdvisor        bool
 	ExtraControlKnobConfigFile string
+
+	SockMemOptions
+}
+
+type SockMemOptions struct {
+	EnableSettingSockMem bool
+	// SetGlobalTCPMemRatio limits global max tcp memory usage.
+	SetGlobalTCPMemRatio int
 }
 
 func NewMemoryOptions() *MemoryOptions {
@@ -38,6 +46,10 @@ func NewMemoryOptions() *MemoryOptions {
 		SkipMemoryStateCorruption:  false,
 		EnableSettingMemoryMigrate: false,
 		EnableMemoryAdvisor:        false,
+		SockMemOptions: SockMemOptions{
+			EnableSettingSockMem: false,
+			SetGlobalTCPMemRatio: 20, // default: 20% * {host total memory}
+		},
 	}
 }
 
@@ -56,7 +68,12 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.EnableMemoryAdvisor, "Whether memory resource plugin should enable sys-advisor")
 	fs.StringVar(&o.ExtraControlKnobConfigFile, "memory-extra-control-knob-config-file",
 		o.ExtraControlKnobConfigFile, "the absolute path of extra control knob config file")
+	fs.BoolVar(&o.EnableSettingSockMem, "enable-setting-sockmem",
+		o.EnableSettingSockMem, "if set true, we will limit tcpmem usage in cgroup and host level")
+	fs.IntVar(&o.SetGlobalTCPMemRatio, "qrm-memory-global-tcpmem-ratio",
+		o.SetGlobalTCPMemRatio, "limit global max tcp memory usage")
 }
+
 func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.PolicyName = o.PolicyName
 	conf.ReservedMemoryGB = o.ReservedMemoryGB
@@ -64,5 +81,7 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.EnableSettingMemoryMigrate = o.EnableSettingMemoryMigrate
 	conf.EnableMemoryAdvisor = o.EnableMemoryAdvisor
 	conf.ExtraControlKnobConfigFile = o.ExtraControlKnobConfigFile
+	conf.EnableSettingSockMem = o.EnableSettingSockMem
+	conf.SetGlobalTCPMemRatio = o.SetGlobalTCPMemRatio
 	return nil
 }

--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -37,6 +37,8 @@ type SockMemOptions struct {
 	EnableSettingSockMem bool
 	// SetGlobalTCPMemRatio limits global max tcp memory usage.
 	SetGlobalTCPMemRatio int
+	// SetCgroupTCPMemLimitRatio limit cgroup max tcp memory usage.
+	SetCgroupTCPMemRatio int
 }
 
 func NewMemoryOptions() *MemoryOptions {
@@ -48,7 +50,8 @@ func NewMemoryOptions() *MemoryOptions {
 		EnableMemoryAdvisor:        false,
 		SockMemOptions: SockMemOptions{
 			EnableSettingSockMem: false,
-			SetGlobalTCPMemRatio: 20, // default: 20% * {host total memory}
+			SetGlobalTCPMemRatio: 20,  // default: 20% * {host total memory}
+			SetCgroupTCPMemRatio: 100, // default: 100% * {cgroup memory}
 		},
 	}
 }
@@ -72,6 +75,8 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.EnableSettingSockMem, "if set true, we will limit tcpmem usage in cgroup and host level")
 	fs.IntVar(&o.SetGlobalTCPMemRatio, "qrm-memory-global-tcpmem-ratio",
 		o.SetGlobalTCPMemRatio, "limit global max tcp memory usage")
+	fs.IntVar(&o.SetCgroupTCPMemRatio, "qrm-memory-cgroup-tcpmem-ratio",
+		o.SetCgroupTCPMemRatio, "limit cgroup max tcp memory usage")
 }
 
 func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
@@ -83,5 +88,6 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.ExtraControlKnobConfigFile = o.ExtraControlKnobConfigFile
 	conf.EnableSettingSockMem = o.EnableSettingSockMem
 	conf.SetGlobalTCPMemRatio = o.SetGlobalTCPMemRatio
+	conf.SetCgroupTCPMemRatio = o.SetCgroupTCPMemRatio
 	return nil
 }

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/const.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/const.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+const (
+	EnableSetSockMemPeriodicalHandlerName = "SetSockMem"
+
+	// Constants for global tcpmem ratio
+	globalTCPMemRatioMin = 20 // min ratio for host tcp mem: 20%
+	globalTCPMemRatioMax = 80 // max ratio for host tcp mem: 80%
+	hostTCPMemFile       = "/proc/sys/net/ipv4/tcp_mem"
+
+	// Constants for cgroupv1 tcpmem statistics
+	kernSockMemAccoutingOff = 9223372036854771712 // max value
+	kernSockMemAccoutingOn  = 9223372036854767616
+
+	// Constants for cgroupv1 tcpmem ratio
+	cgroupTCPMemMin2G    = 2147483648 // static min value for pod's sockmem: 2G
+	cgroupTCPMemRatioMin = 20         // min ratio for pod's sockmem: 20%
+	cgroupTCPMemRatioMax = 200        // max ratio for pod's sockmem: 200%
+)

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/const.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/const.go
@@ -20,16 +20,15 @@ const (
 	EnableSetSockMemPeriodicalHandlerName = "SetSockMem"
 
 	// Constants for global tcpmem ratio
-	globalTCPMemRatioMin = 20 // min ratio for host tcp mem: 20%
-	globalTCPMemRatioMax = 80 // max ratio for host tcp mem: 80%
-	hostTCPMemFile       = "/proc/sys/net/ipv4/tcp_mem"
+	globalTCPMemRatioMin float64 = 20.0 // min ratio for host tcp mem: 20%
+	globalTCPMemRatioMax float64 = 80.0 // max ratio for host tcp mem: 80%
+	hostTCPMemFile               = "/proc/sys/net/ipv4/tcp_mem"
 
 	// Constants for cgroupv1 tcpmem statistics
-	kernSockMemAccoutingOff = 9223372036854771712 // max value
-	kernSockMemAccoutingOn  = 9223372036854767616
+	kernSockMemAccoutingOn float64 = 9223372036854767616.0
 
 	// Constants for cgroupv1 tcpmem ratio
-	cgroupTCPMemMin2G    = 2147483648 // static min value for pod's sockmem: 2G
-	cgroupTCPMemRatioMin = 20         // min ratio for pod's sockmem: 20%
-	cgroupTCPMemRatioMax = 200        // max ratio for pod's sockmem: 200%
+	cgroupTCPMemMin2G    float64 = 2147483648.0 // static min value for pod's sockmem: 2G
+	cgroupTCPMemRatioMin float64 = 20.0         // min ratio for pod's sockmem: 20%
+	cgroupTCPMemRatioMax float64 = 200.0        // max ratio for pod's sockmem: 200%
 )

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go
@@ -1,0 +1,117 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+import (
+	"fmt"
+
+	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"golang.org/x/sys/unix"
+)
+
+type SockMemConfig struct {
+	globalTCPMemRatio int
+}
+
+var sockMemConfig = SockMemConfig{
+	globalTCPMemRatio: 20, // default: 20% * {host total memory}
+}
+
+func updateGlobalTCPMemRatio(ratio int) {
+	if ratio < globalTCPMemRatioMin {
+		ratio = globalTCPMemRatioMin
+	} else if ratio > globalTCPMemRatioMax {
+		ratio = globalTCPMemRatioMax
+	}
+	sockMemConfig.globalTCPMemRatio = ratio
+}
+
+func setHostTCPMem(memTotal uint64) error {
+	tcpMemRatio := sockMemConfig.globalTCPMemRatio
+	tcpMem, err := getHostTCPMemFile(hostTCPMemFile)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return err
+	}
+
+	pageSize := uint64(unix.Getpagesize())
+	newUpperLimit := memTotal / pageSize / 100 * uint64(tcpMemRatio)
+	if (newUpperLimit != tcpMem[2]) && (newUpperLimit > tcpMem[1]) {
+		general.Infof("write to host tcp_mem, ratio=%d, newLimit=%d, oldLimit=%d", tcpMemRatio, newUpperLimit, tcpMem[2])
+		tcpMem[2] = newUpperLimit
+		setHostTCPMemFile(hostTCPMemFile, tcpMem)
+	}
+	return nil
+}
+
+/*
+ * SetSockMemLimit is the unified solution for tcpmem limitation.
+ * it includes 3 parts:
+ * 1, set the global tcpmem limitation by changing net.ipv4.tcp_mem.
+ * 2, do nothing under cgroupv2.
+ * 3, set the cgroup tcpmem limitation under cgroupv1.
+ */
+func SetSockMemLimit(conf *coreconfig.Configuration,
+	_ interface{}, _ *dynamicconfig.DynamicAgentConfiguration,
+	_ metrics.MetricEmitter, metaServer *metaserver.MetaServer) {
+	general.Infof("called")
+
+	// SettingSockMem featuregate.
+	if !conf.EnableSettingSockMem {
+		general.Infof("SetSockMemLimit disabled")
+		return
+	} else if metaServer == nil {
+		general.Errorf("nil metaServer")
+		return
+	}
+
+	updateGlobalTCPMemRatio(conf.SetGlobalTCPMemRatio)
+
+	/*
+	 * Step1, set the [limit] value for host net.ipv4.tcp_mem.
+	 *
+	 * Description of net.ipv4.tcp_mem:
+	 * It includes 3 parts: min, pressure, limit.
+	 * The format is like the following:
+	 * net.ipv4.tcp_mem = [min] [pressure] [limit]
+	 *
+	 * Each parts means:
+	 * [min]: represents the minimum number of pages allowed in the queue.
+	 * [pressure]: represents the threshold at which the system considers memory
+	 *   to be under pressure due to TCP socket usage. When the memory usage reaches
+	 *   this value, the system may start taking actions like cleaning up or reclaiming memory.
+	 * [limit]: indicates the maximum number of pages allowed in the queue.
+	 */
+	_ = setHostTCPMem(metaServer.MemoryCapacity)
+
+	// Step2, do nothing for cg2.
+	if common.CheckCgroup2UnifiedMode() {
+		general.Infof("skip setSockMemLimit in cg2 env")
+		return
+	}
+
+	// Step3, set tcp_mem accounting for pods under cgroupv1.
+	// to-do
+}

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go
@@ -20,32 +20,32 @@ limitations under the License.
 package sockmem
 
 import (
+	"context"
 	"fmt"
+
+	"golang.org/x/sys/unix"
 
 	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
 	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+	coreconsts "github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/helper"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	cgroupcm "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	cgroupmgr "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
-	"golang.org/x/sys/unix"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
 type SockMemConfig struct {
-	globalTCPMemRatio int
+	globalTCPMemRatio float64
+	cgroupTCPMemRatio float64
 }
 
 var sockMemConfig = SockMemConfig{
-	globalTCPMemRatio: 20, // default: 20% * {host total memory}
-}
-
-func updateGlobalTCPMemRatio(ratio int) {
-	if ratio < globalTCPMemRatioMin {
-		ratio = globalTCPMemRatioMin
-	} else if ratio > globalTCPMemRatioMax {
-		ratio = globalTCPMemRatioMax
-	}
-	sockMemConfig.globalTCPMemRatio = ratio
+	globalTCPMemRatio: 20,  // default: 20% * {host total memory}
+	cgroupTCPMemRatio: 100, // default: 100% * {cgroup memory limit}
 }
 
 func setHostTCPMem(memTotal uint64) error {
@@ -59,9 +59,27 @@ func setHostTCPMem(memTotal uint64) error {
 	pageSize := uint64(unix.Getpagesize())
 	newUpperLimit := memTotal / pageSize / 100 * uint64(tcpMemRatio)
 	if (newUpperLimit != tcpMem[2]) && (newUpperLimit > tcpMem[1]) {
-		general.Infof("write to host tcp_mem, ratio=%d, newLimit=%d, oldLimit=%d", tcpMemRatio, newUpperLimit, tcpMem[2])
+		general.Infof("write to host tcp_mem, ratio=%v, newLimit=%d, oldLimit=%d", tcpMemRatio, newUpperLimit, tcpMem[2])
 		tcpMem[2] = newUpperLimit
 		setHostTCPMemFile(hostTCPMemFile, tcpMem)
+	}
+	return nil
+}
+
+func setCg1TCPMem(podUID, containerID string, memLimit, memTCPLimit int64) error {
+	newMemTCPLimit := memLimit / 100 * int64(sockMemConfig.cgroupTCPMemRatio)
+	newMemTCPLimit = alignToPageSize(newMemTCPLimit)
+	newMemTCPLimit = int64(general.Clamp(float64(newMemTCPLimit), cgroupTCPMemMin2G, kernSockMemAccoutingOn))
+
+	cgroupPath, err := cgroupcm.GetContainerRelativeCgroupPath(podUID, containerID)
+	if err != nil {
+		return err
+	}
+	if newMemTCPLimit != memTCPLimit {
+		_ = cgroupmgr.ApplyMemoryWithRelativePath(cgroupPath, &cgroupcm.MemoryData{
+			TCPMemLimitInBytes: newMemTCPLimit,
+		})
+		general.Infof("Apply TCPMemLimitInBytes: %v, old value=%d, new value=%d", cgroupPath, memTCPLimit, newMemTCPLimit)
 	}
 	return nil
 }
@@ -75,20 +93,28 @@ func setHostTCPMem(memTotal uint64) error {
  */
 func SetSockMemLimit(conf *coreconfig.Configuration,
 	_ interface{}, _ *dynamicconfig.DynamicAgentConfiguration,
-	_ metrics.MetricEmitter, metaServer *metaserver.MetaServer) {
+	emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer) {
 	general.Infof("called")
 
-	// SettingSockMem featuregate.
-	if !conf.EnableSettingSockMem {
-		general.Infof("SetSockMemLimit disabled")
+	if conf == nil {
+		general.Errorf("nil extraConf")
+		return
+	} else if emitter == nil {
+		general.Errorf("nil emitter")
 		return
 	} else if metaServer == nil {
 		general.Errorf("nil metaServer")
 		return
 	}
 
-	updateGlobalTCPMemRatio(conf.SetGlobalTCPMemRatio)
+	// SettingSockMem featuregate.
+	if !conf.EnableSettingSockMem {
+		general.Infof("SetSockMemLimit disabled")
+		return
+	}
 
+	sockMemConfig.globalTCPMemRatio = general.Clamp(float64(conf.SetGlobalTCPMemRatio), globalTCPMemRatioMin, globalTCPMemRatioMax)
+	sockMemConfig.cgroupTCPMemRatio = general.Clamp(float64(conf.SetCgroupTCPMemRatio), cgroupTCPMemRatioMin, cgroupTCPMemRatioMax)
 	/*
 	 * Step1, set the [limit] value for host net.ipv4.tcp_mem.
 	 *
@@ -104,14 +130,53 @@ func SetSockMemLimit(conf *coreconfig.Configuration,
 	 *   this value, the system may start taking actions like cleaning up or reclaiming memory.
 	 * [limit]: indicates the maximum number of pages allowed in the queue.
 	 */
-	_ = setHostTCPMem(metaServer.MemoryCapacity)
-
+	// 0 means skip this feature.
+	if conf.SetGlobalTCPMemRatio != 0 {
+		_ = setHostTCPMem(metaServer.MemoryCapacity)
+	}
 	// Step2, do nothing for cg2.
+	// In cg2, tcpmem is accounted together with other memory(anon, kernel, file...).
+	// So, we don't need to limit it.
 	if common.CheckCgroup2UnifiedMode() {
 		general.Infof("skip setSockMemLimit in cg2 env")
 		return
 	}
 
 	// Step3, set tcp_mem accounting for pods under cgroupv1.
-	// to-do
+	// In cg1, tcpmem is accounted for separately from other memory(anon, kernel, file..).
+	// So, we need to limit it by manually.
+	// 0 means skip this feature.
+	if conf.SetCgroupTCPMemRatio == 0 {
+		return
+	}
+
+	podList, err := metaServer.GetPodList(context.Background(), native.PodIsActive)
+	if err != nil {
+		general.Errorf("get pod list failed, err: %v", err)
+		return
+	}
+
+	for _, pod := range podList {
+		if pod == nil {
+			general.Errorf("get nil pod from metaServer")
+			continue
+		}
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			podUID, containerID := string(pod.UID), native.TrimContainerIDPrefix(containerStatus.ContainerID)
+
+			memLimit, found := helper.GetPodMetric(metaServer.MetricsFetcher, emitter, pod, coreconsts.MetricMemLimitContainer, -1)
+			if !found {
+				general.Infof("memory limit not found:%v..\n", podUID)
+				continue
+			}
+
+			memTCPLimit, found := helper.GetPodMetric(metaServer.MetricsFetcher, emitter, pod, coreconsts.MetricMemTCPLimitContainer, -1)
+			if !found {
+				general.Infof("memory tcp.limit not found:%v..\n", podUID)
+				continue
+			}
+
+			_ = setCg1TCPMem(podUID, containerID, int64(memLimit), int64(memTCPLimit))
+		}
+	}
 }

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go
@@ -1,0 +1,305 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent"
+	configagent "github.com/kubewharf/katalyst-core/pkg/config/agent"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	metaagent "github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+func makeMetaServer() (*metaserver.MetaServer, error) {
+	server := &metaserver.MetaServer{
+		MetaAgent: &metaagent.MetaAgent{},
+	}
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 1, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	server.KatalystMachineInfo = &machine.KatalystMachineInfo{
+		CPUTopology: cpuTopology,
+	}
+	server.MetricsFetcher = metric.NewFakeMetricsFetcher(metrics.DummyMetrics{})
+	return server, nil
+}
+
+func TestSetSockMemLimit(t *testing.T) {
+	t.Parallel()
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: false,
+						},
+					},
+				},
+			},
+		},
+	}, nil, &dynamicconfig.DynamicAgentConfiguration{}, nil, nil)
+
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: true,
+						},
+					},
+				},
+			},
+		},
+	}, nil, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, nil)
+
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: true,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, nil)
+
+	metaServer, err := makeMetaServer()
+	assert.NoError(t, err)
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{}}
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: true,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: false,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	normalPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "normalPod",
+			Name: "normalPod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c",
+				},
+			},
+		},
+	}
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{normalPod}}
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: true,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	SetSockMemLimit(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						SockMemQRMPluginConfig: qrm.SockMemQRMPluginConfig{
+							EnableSettingSockMem: true,
+							SetGlobalTCPMemRatio: 0,
+							SetCgroupTCPMemRatio: 0,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+}
+
+func TestGetLimitFromTCPMemFile(t *testing.T) {
+	t.Parallel()
+	// case1, normal input/outout
+	tmpFile, err := ioutil.TempFile("", "tcp_mem")
+	if err != nil {
+		t.Fatalf("Error creating temporary file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	testData := []byte("187365\t249822\t999999\n")
+	_, err = tmpFile.Write(testData)
+	if err != nil {
+		t.Fatalf("Error writing test data to temporary file: %v", err)
+	}
+	tmpFile.Close()
+
+	tcpMem, err := getHostTCPMemFile(tmpFile.Name())
+	if err != nil {
+		t.Errorf("Expected no error, but got error: %v", err)
+	}
+	expectedUpperLimit := uint64(999999)
+	if expectedUpperLimit != tcpMem[2] {
+		t.Errorf("Expected upper limit to be %d, but got %d", expectedUpperLimit, tcpMem[2])
+	}
+
+	expectedUpperLimit = uint64(249822)
+	if expectedUpperLimit != tcpMem[1] {
+		t.Errorf("Expected pressure limit to be %d, but got %d", expectedUpperLimit, tcpMem[1])
+	}
+
+	// case2, null file
+	_, err = getHostTCPMemFile("nullfile")
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+
+	// case3, file with invalid data
+	testData = []byte("invalid_data\n")
+	err = ioutil.WriteFile(tmpFile.Name(), testData, 0644)
+	if err != nil {
+		t.Fatalf("Error writing invalid test data to temporary file: %v", err)
+	}
+	_, err = getHostTCPMemFile(tmpFile.Name())
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+}
+
+func TestSetLimitToTCPMemFile(t *testing.T) {
+	t.Parallel()
+	// case1, normal logic
+	tmpFile, err := ioutil.TempFile("", "tcp_mem")
+	if err != nil {
+		t.Fatalf("Error creating temporary file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	testData := []byte("187365\t249822\t999999\n")
+	_, err = tmpFile.Write(testData)
+	if err != nil {
+		t.Fatalf("Error writing test data to temporary file: %v", err)
+	}
+	tmpFile.Close()
+
+	tcpMem := []uint64{1, 2, 123456}
+	setHostTCPMemFile(tmpFile.Name(), tcpMem)
+	data, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Error reading modified file: %v", err)
+	}
+	newValues := strings.Fields(string(data))
+	if len(newValues) < 3 {
+		t.Errorf("Expected at least 3 values in the file, but got %d", len(newValues))
+	}
+	newUpper, _ := strconv.Atoi(newValues[2])
+	if newUpper != 123456 {
+		t.Errorf("Expected upper limit to be 123456, but got %d", newUpper)
+	}
+
+	// case2, null file
+	err = setHostTCPMemFile("nonexistentfile", tcpMem)
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	} else if !os.IsNotExist(err) {
+		t.Errorf("Expected 'file not found' error, but got: %v", err)
+	}
+	// case3, file with invalid data
+	wrongTcpMem := []uint64{1, 2, 3, 4}
+	err = setHostTCPMemFile(tmpFile.Name(), wrongTcpMem)
+	if err == nil {
+		t.Error("tcp_mem is wrong, need return err")
+	}
+}
+
+func TestAlignToPageSize(t *testing.T) {
+	t.Parallel()
+	pageSize := int64(syscall.Getpagesize())
+
+	// Test case 1: Number already aligned to page size
+	result := alignToPageSize(pageSize * 2)
+	assert.Equal(t, pageSize*2, result, "Unexpected result for aligned number")
+
+	// Test case 2: Number smaller than page size
+	result = alignToPageSize(pageSize - 1)
+	assert.Equal(t, pageSize, result, "Unexpected result for number smaller than page size")
+}
+
+func TestSetCg1TCPMem(t *testing.T) {
+	t.Parallel()
+	podUID := "pod12"
+	containerID := "container45"
+	memLimit := int64(1024)
+	memTCPLimit := int64(512)
+	err := setCg1TCPMem(podUID, containerID, memLimit, memTCPLimit)
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+	err = setCg1TCPMem(podUID, containerID, 9223372036854771712, memTCPLimit)
+	if err == nil {
+		t.Error("Expected an error, but got none")
+	}
+}

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/utils_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/utils_linux.go
@@ -1,0 +1,82 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sockmem
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func alignToPageSize(number int64) int64 {
+	pageSize := int64(syscall.Getpagesize())
+	alignedNumber := (number + pageSize - 1) &^ (pageSize - 1)
+	return alignedNumber
+}
+
+func getHostTCPMemFile(TCPMemFile string) ([]uint64, error) {
+	data, err := os.ReadFile(TCPMemFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s, err %v", TCPMemFile, err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("empty content in %s", TCPMemFile)
+	}
+
+	line := lines[0]
+	fields := strings.Fields(line)
+	if len(fields) != 3 {
+		return nil, fmt.Errorf("unexpected number of fields in %s", TCPMemFile)
+	}
+
+	var tcpMem []uint64
+	for _, field := range fields {
+		value, err := strconv.ParseUint(field, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		tcpMem = append(tcpMem, value)
+	}
+
+	return tcpMem, nil
+}
+
+func setHostTCPMemFile(TCPMemFile string, tcpMem []uint64) error {
+	if len(tcpMem) != 3 {
+		return fmt.Errorf("tcpMem array must have exactly three elements")
+	}
+
+	_, err := os.Stat(TCPMemFile)
+	if err != nil {
+		return err
+	}
+
+	content := fmt.Sprintf("%d\t%d\t%d\n", tcpMem[0], tcpMem[1], tcpMem[2])
+	err = os.WriteFile(TCPMemFile, []byte(content), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to %s, err %v", TCPMemFile, err)
+	}
+
+	return nil
+}

--- a/pkg/agent/qrm-plugins/memory/memory.go
+++ b/pkg/agent/qrm-plugins/memory/memory.go
@@ -17,10 +17,29 @@ limitations under the License.
 package memory
 
 import (
+	"fmt"
+	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent/qrm"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem"
+	"github.com/kubewharf/katalyst-core/pkg/agent/utilcomponent/periodicalhandler"
 )
 
 func init() {
 	qrm.RegisterMemoryPolicyInitializer(dynamicpolicy.MemoryResourcePluginPolicyNameDynamic, dynamicpolicy.NewDynamicPolicy)
+}
+
+// register qrm memory-handlers registered in adapter
+func init() {
+	var errList []error
+	errList = append(errList, periodicalhandler.RegisterPeriodicalHandler(qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
+		sockmem.EnableSetSockMemPeriodicalHandlerName, sockmem.SetSockMemLimit, 60*time.Second))
+
+	aggregatedErr := utilerrors.NewAggregate(errList)
+	if aggregatedErr != nil {
+		panic(fmt.Errorf("initialize adapter memory qrm plugin failed with error: %v", aggregatedErr.Error()))
+	}
 }

--- a/pkg/agent/qrm-plugins/memory/memory.go
+++ b/pkg/agent/qrm-plugins/memory/memory.go
@@ -17,29 +17,10 @@ limitations under the License.
 package memory
 
 import (
-	"fmt"
-	"time"
-
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent/qrm"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy"
-	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem"
-	"github.com/kubewharf/katalyst-core/pkg/agent/utilcomponent/periodicalhandler"
 )
 
 func init() {
 	qrm.RegisterMemoryPolicyInitializer(dynamicpolicy.MemoryResourcePluginPolicyNameDynamic, dynamicpolicy.NewDynamicPolicy)
-}
-
-// register qrm memory-handlers registered in adapter
-func init() {
-	var errList []error
-	errList = append(errList, periodicalhandler.RegisterPeriodicalHandler(qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
-		sockmem.EnableSetSockMemPeriodicalHandlerName, sockmem.SetSockMemLimit, 60*time.Second))
-
-	aggregatedErr := utilerrors.NewAggregate(errList)
-	if aggregatedErr != nil {
-		panic(fmt.Errorf("initialize adapter memory qrm plugin failed with error: %v", aggregatedErr.Error()))
-	}
 }

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -29,6 +29,16 @@ type MemoryQRMPluginConfig struct {
 	EnableMemoryAdvisor bool
 	// ExtraControlKnobConfigFile: the absolute path of extra control knob config file
 	ExtraControlKnobConfigFile string
+
+	// SockMemQRMPluginConfig: the configuration for sockmem limitation in cgroup and host level
+	SockMemQRMPluginConfig
+}
+
+type SockMemQRMPluginConfig struct {
+	// EnableSettingSockMemLimit is used to limit tcpmem usage in cgroup and host level
+	EnableSettingSockMem bool
+	// SetGlobalTCPMemRatio limits host max global tcp memory usage.
+	SetGlobalTCPMemRatio int
 }
 
 func NewMemoryQRMPluginConfig() *MemoryQRMPluginConfig {

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -39,6 +39,8 @@ type SockMemQRMPluginConfig struct {
 	EnableSettingSockMem bool
 	// SetGlobalTCPMemRatio limits host max global tcp memory usage.
 	SetGlobalTCPMemRatio int
+	// SetCgroupTCPMemRatio limit cgroup max tcp memory usage.
+	SetCgroupTCPMemRatio int
 }
 
 func NewMemoryQRMPluginConfig() *MemoryQRMPluginConfig {

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -120,6 +120,7 @@ const (
 // container memory metrics
 const (
 	MetricMemLimitContainer     = "mem.limit.container"
+	MetricMemTCPLimitContainer  = "mem.tcp.limit.container"
 	MetricMemUsageContainer     = "mem.usage.container"
 	MetricMemUsageUserContainer = "mem.usage.user.container"
 	MetricMemUsageSysContainer  = "mem.usage.sys.container"

--- a/pkg/metaserver/agent/metric/malachite/fetcher.go
+++ b/pkg/metaserver/agent/metric/malachite/fetcher.go
@@ -816,6 +816,8 @@ func (m *MalachiteMetricsFetcher) processContainerMemoryData(podUID, containerNa
 
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemLimitContainer,
 			utilmetric.MetricData{Value: float64(mem.MemoryLimitInBytes), Time: &updateTime})
+		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemTCPLimitContainer,
+			utilmetric.MetricData{Value: float64(mem.KernTCPMemLimitInBytes), Time: &updateTime})
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemUsageContainer,
 			utilmetric.MetricData{Value: float64(mem.MemoryUsageInBytes), Time: &updateTime})
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricMemUsageUserContainer,

--- a/pkg/metaserver/agent/metric/malachite/types/cgroup.go
+++ b/pkg/metaserver/agent/metric/malachite/types/cgroup.go
@@ -104,6 +104,7 @@ type MemoryCgDataV1 struct {
 	MemoryLimitInBytes     uint64        `json:"memory_limit_in_bytes"`
 	MemoryUsageInBytes     uint64        `json:"memory_usage_in_bytes"`
 	KernMemoryUsageInBytes uint64        `json:"kern_memory_usage_in_bytes"`
+	KernTCPMemLimitInBytes uint64        `json:"kern_tcp_memory_limit_in_bytes"`
 	Cache                  uint64        `json:"cache"`
 	Rss                    uint64        `json:"rss"`
 	Shmem                  uint64        `json:"shmem"`

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -56,8 +56,9 @@ const (
 
 // MemoryData set cgroup memory data
 type MemoryData struct {
-	LimitInBytes int64
-	WmarkRatio   int32
+	LimitInBytes       int64
+	TCPMemLimitInBytes int64
+	WmarkRatio         int32
 }
 
 // CPUData set cgroup cpu data

--- a/pkg/util/cgroup/manager/v1/fs_linux.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux.go
@@ -52,6 +52,14 @@ func (m *manager) ApplyMemory(absCgroupPath string, data *common.MemoryData) err
 		}
 	}
 
+	if data.TCPMemLimitInBytes > 0 {
+		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.kmem.tcp.limit_in_bytes", strconv.FormatInt(data.TCPMemLimitInBytes, 10)); err != nil {
+			return err
+		} else if applied {
+			klog.Infof("[CgroupV1] apply memory kmem.tcp.limit_in_bytes successfully, cgroupPath: %s, data: %v, old data: %v\n", absCgroupPath, data.TCPMemLimitInBytes, oldData)
+		}
+	}
+
 	if data.WmarkRatio != 0 {
 		newRatio := fmt.Sprintf("%d", data.WmarkRatio)
 		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.wmark_ratio", newRatio); err != nil {


### PR DESCRIPTION
What type of PR is this?
Features

What this PR does / why we need it:
The feature provides the unified solution for TCP memory limitation in cgroup and global level.

Which issue(s) this PR fixes:
In our production environment, there is a critical case where certain services heavily consumed tcpmem(cgroupv1 pods with default setting have unlimited tcpmem), causing the global tcpmem to reach the limitation. As a result, the network performance of the entire machine was crash.

Special notes for your reviewer:
The feature includes 3 parts:
1, Set global tcpmem limit by changing net.ipv4.tcp_mem.
The default value is 20% of host toal memory.
2, Do nothing under cgroupv2.
3, Set pod tcpmem limit under cgroupv1.
The default value is same with memory.limit_in_bytes.