### PR TITLE
fix unit test race in sockmem plugin

### DIFF
--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go
@@ -294,11 +294,16 @@ func TestSetCg1TCPMem(t *testing.T) {
 	containerID := "container45"
 	memLimit := int64(1024)
 	memTCPLimit := int64(512)
-	err := setCg1TCPMem(podUID, containerID, memLimit, memTCPLimit)
+	sockMemConfig := SockMemConfig{
+		globalTCPMemRatio: 20.0,
+		cgroupTCPMemRatio: 100.0,
+	}
+
+	err := setCg1TCPMem(podUID, containerID, memLimit, memTCPLimit, &sockMemConfig)
 	if err == nil {
 		t.Error("Expected an error, but got none")
 	}
-	err = setCg1TCPMem(podUID, containerID, 9223372036854771712, memTCPLimit)
+	err = setCg1TCPMem(podUID, containerID, 9223372036854771712, memTCPLimit, &sockMemConfig)
 	if err == nil {
 		t.Error("Expected an error, but got none")
 	}


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What this PR does / why we need it:
bug fix: fix unit test race in sockmem plugin

#### Which issue(s) this PR fixes:
unit test race in sockmem plugin, plz see following as reference:
WARNING: DATA RACE
Read at 0x000004feb178 by goroutine 84:
  github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem.setCg1TCPMem()
      /runner/_work/katalyst-core/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go:71 +0x84
  github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem.TestSetCg1TCPMem()
      /runner/_work/katalyst-core/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go:301 +0xc4
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1486 +0x47

Previous write at 0x000004feb178 by goroutine 18:
  github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem.SetSockMemLimit()
      /runner/_work/katalyst-core/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go:118 +0x346
  github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem.TestSetSockMemLimit()
      /runner/_work/katalyst-core/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go:167 +0xd64
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.10/x64/src/testing/testing.go:1486 +0x47


#### Special notes for your reviewer:
