### PR TITLE
fix container metrics

### DIFF
--- a/cmd/katalyst-agent/app/options/sysadvisor/inference/inference_plugin.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/inference/inference_plugin.go
@@ -25,6 +25,9 @@ import (
 )
 
 const (
+	// System Metrics Collector samples a time per 10s
+	// So it may produce two same inference result within per 10s.
+	// TODO So it's better to retrieve inference results and use them per 10s.
 	defaultInferenceSyncPeriod = 5 * time.Second
 )
 

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -125,7 +125,7 @@ const (
 	MetricStoreInsContainer     = "cpu.store.ins.container"
 
 	MetricCPUNrThrottledRateContainer   = MetricCPUNrThrottledContainer + Rate
-	MetricCPUNRdPeriodRateContainer     = MetricCPUNrPeriodContainer + Rate
+	MetricCPUNrPeriodRateContainer      = MetricCPUNrPeriodContainer + Rate
 	MetricCPUThrottledTimeRateContainer = MetricCPUThrottledTimeContainer + Rate
 
 	MetricCPUUpdateTimeContainer = "cpu.updatetime.container"
@@ -174,6 +174,11 @@ const (
 
 // container net metrics
 const (
+	MetricNetTcpSendBytesContainer   = "net.tcp.send.bytes.container"
+	MetricNetTcpSendPacketsContainer = "net.tcp.send.packets.container"
+	MetricNetTcpRecvBytesContainer   = "net.tcp.recv.bytes.container"
+	MetricNetTcpRecvPacketsContainer = "net.tcp.recv.packets.container"
+
 	MetricNetTcpSendBPSContainer = "net.tcp.send.bps.container"
 	MetricNetTcpSendPpsContainer = "net.tcp.send.pps.container"
 	MetricNetTcpRecvBPSContainer = "net.tcp.recv.bps.container"


### PR DESCRIPTION
There are some metrics have been calculating incorrectly. Try to fix them in the pr.
1. Rename MetricCPUNR`d`PeriodRateContainer to MetricCPUNRPeriodRateContainer.
2. Try to assign l3_misses with OcrReadDrams when L3Misses is 0.
3. Fill the lost metrics like MetricCPUThrottledTimeContainer/MetricCPUNrThrottledContainer/MetricCPUNrPeriodContainer in the case of v2 cgroups.
4. Optimizing the calculation for MetricNetTcpRecvPacketsContainer/MetricNetTcpSendPacketsContainer/MetricNetTcpRecvBytesContainer/MetricNetTcpSendBytesContainer.
