### PR TITLE
enhancement: support disk type and  io-latency cgroup operations

### DIFF
--- a/pkg/consts/common.go
+++ b/pkg/consts/common.go
@@ -68,6 +68,14 @@ const (
 	ObjectFieldNameStatus = "status"
 )
 
+// common disk types.
+const (
+	DiskTypeUnknown = 0
+	DiskTypeHDD     = 1
+	DiskTypeSSD     = 2
+	DiskTypeNVME    = 3
+)
+
 var (
 	EXP1  = 1.0 / math.Exp(5.0/60.0)
 	EXP5  = 1.0 / math.Exp(5.0/300.0)

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -68,6 +68,9 @@ const (
 	MetricIOReadOpsSystem  = "io.read.ops.system"
 	MetricIOWriteOpsSystem = "io.write.ops.system"
 	MetricIOBusyRateSystem = "io.busy.rate.system"
+
+	MetricIODiskType     = "io.disk.type"
+	MetricIODiskWBTValue = "io.disk.wbt"
 )
 
 // System rootfs metrics

--- a/pkg/metaserver/agent/metric/helper/consts.go
+++ b/pkg/metaserver/agent/metric/helper/consts.go
@@ -22,12 +22,14 @@ const (
 	metricsNameContainerMetric = "container_metric_raw"
 	metricsNamePodMetric       = "pod_metric_raw"
 	metricsNamePodVolumeMetric = "pod_volume_metric_raw"
+	metricsNameDeviceMetric    = "device_metric_raw"
 
 	metricsTagKeyNumaID        = "numa_id"
 	metricsTagKeyMetricName    = "metric_name"
 	metricsTagKeyPodUID        = "pod_uid"
 	metricsTagKeyContainerName = "container_name"
 	metricsTagKeyPodVolumeName = "pod_volume_name"
+	metricsTagKeyDeviceName    = "device_name"
 )
 
 const (
@@ -36,4 +38,5 @@ const (
 	errMsgGetContainerNumaMetrics   = "failed to get container numa metric, metric name: %s, pod uid: %s, container name: %s, numa id: %d, err: %v"
 	errMsgGetContainerSystemMetrics = "failed to get container system metric, metric name: %s, pod uid: %s, container name: %s, err: %v"
 	errMsgGetPodVolumeMetrics       = "failed to get pod volume metric, pod uid: %s, volume name: %s, metric name: %s, err: %v"
+	errMsgGetDeviceMetrics          = "failed to get device metric, metric name: %s, device: %s, err: %v"
 )

--- a/pkg/metaserver/agent/metric/helper/device.go
+++ b/pkg/metaserver/agent/metric/helper/device.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	metricutil "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+func GetDeviceMetricWithTime(metricsFetcher types.MetricsFetcher, emitter metrics.MetricEmitter, metricName string, devName string) (metricutil.MetricData, error) {
+	metricData, err := metricsFetcher.GetDeviceMetric(devName, metricName)
+	if err != nil {
+		general.Errorf(errMsgGetDeviceMetrics, metricName, devName, err)
+		return metricutil.MetricData{}, err
+	}
+	_ = emitter.StoreFloat64(metricsNameDeviceMetric, metricData.Value, metrics.MetricTypeNameRaw,
+		metrics.ConvertMapToTags(map[string]string{
+			metricsTagKeyDeviceName: devName,
+			metricsTagKeyMetricName: metricName,
+		})...)
+	return metricData, nil
+}
+
+func GetDeviceMetric(metricsFetcher types.MetricsFetcher, emitter metrics.MetricEmitter, metricName string, devName string) (float64, error) {
+	metricWithTime, err := GetDeviceMetricWithTime(metricsFetcher, emitter, metricName, devName)
+	if err != nil {
+		return 0, err
+	}
+	return metricWithTime.Value, err
+}

--- a/pkg/metaserver/agent/metric/helper/device_test.go
+++ b/pkg/metaserver/agent/metric/helper/device_test.go
@@ -1,0 +1,37 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+func TestGetDeviceMetric(t *testing.T) {
+	t.Parallel()
+	_, err := GetDeviceMetricWithTime(metric.NewFakeMetricsFetcher(metrics.DummyMetrics{}), metrics.DummyMetrics{}, "not-exist", "sdb")
+	assert.NotNil(t, err)
+	_, err = GetDeviceMetric(metric.NewFakeMetricsFetcher(metrics.DummyMetrics{}), metrics.DummyMetrics{}, "not-exist", "sdb")
+	assert.NotNil(t, err)
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -300,6 +300,19 @@ func (m *MalachiteMetricsProvisioner) processSystemIOData(systemIOData *malachit
 			utilmetric.MetricData{Value: float64(device.IoWrite), Time: &updateTime})
 		m.metricStore.SetDeviceMetric(device.DeviceName, consts.MetricIOBusySystem,
 			utilmetric.MetricData{Value: float64(device.IoBusy), Time: &updateTime})
+
+		diskType := consts.DiskTypeUnknown
+		if device.DiskType == "HDD" {
+			diskType = consts.DiskTypeHDD
+		} else if device.DiskType == "SSD" {
+			diskType = consts.DiskTypeSSD
+		} else if device.DiskType == "NVME" {
+			diskType = consts.DiskTypeNVME
+		}
+		m.metricStore.SetDeviceMetric(device.DeviceName, consts.MetricIODiskType,
+			utilmetric.MetricData{Value: float64(diskType), Time: &updateTime})
+		m.metricStore.SetDeviceMetric(device.DeviceName, consts.MetricIODiskWBTValue,
+			utilmetric.MetricData{Value: float64(device.WBTValue), Time: &updateTime})
 	}
 }
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -47,7 +47,27 @@ func Test_noneExistMetricsProvisioner(t *testing.T) {
 	}
 	fakeSystemIO := &malachitetypes.SystemDiskIoData{
 		DiskIo: []malachitetypes.DiskIo{
-			{},
+			{
+				PrimaryDeviceID:   8,
+				SecondaryDeviceID: 16,
+				DeviceName:        "sdb",
+				DiskType:          "HDD",
+				WBTValue:          1234,
+			},
+			{
+				PrimaryDeviceID:   8,
+				SecondaryDeviceID: 24,
+				DeviceName:        "sdc",
+				DiskType:          "SSD",
+				WBTValue:          2234,
+			},
+			{
+				PrimaryDeviceID:   8,
+				SecondaryDeviceID: 32,
+				DeviceName:        "nvme01",
+				DiskType:          "NVME",
+				WBTValue:          3234,
+			},
 		},
 	}
 	fakeCgroupInfoV1 := &malachitetypes.MalachiteCgroupInfo{

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/system.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/system.go
@@ -28,6 +28,8 @@ type DiskIo struct {
 	IoRead            uint64 `json:"io_read"`
 	IoWrite           uint64 `json:"io_write"`
 	IoBusy            uint64 `json:"io_busy"`
+	DiskType          string `json:"disk_type"`
+	WBTValue          int64  `json:"wbt_lat_usec"`
 }
 
 type SystemDiskIoData struct {

--- a/pkg/util/cgroup/manager/cgroup.go
+++ b/pkg/util/cgroup/manager/cgroup.go
@@ -151,6 +151,15 @@ func ApplyIOWeightWithAbsolutePath(absCgroupPath string, devID string, weight ui
 	return GetManager().ApplyIOWeight(absCgroupPath, devID, weight)
 }
 
+func ApplyIOLatencyWithRelativePath(relCgroupPath string, devID string, latency uint64) error {
+	absCgroupPath := common.GetAbsCgroupPath(common.CgroupSubsysIO, relCgroupPath)
+	return ApplyIOLatencyWithAbsolutePath(absCgroupPath, devID, latency)
+}
+
+func ApplyIOLatencyWithAbsolutePath(absCgroupPath string, devID string, latency uint64) error {
+	return GetManager().ApplyIOLatency(absCgroupPath, devID, latency)
+}
+
 func ApplyUnifiedDataWithAbsolutePath(absCgroupPath, cgroupFileName, data string) error {
 	return GetManager().ApplyUnifiedData(absCgroupPath, cgroupFileName, data)
 }

--- a/pkg/util/cgroup/manager/cgroup_test.go
+++ b/pkg/util/cgroup/manager/cgroup_test.go
@@ -70,6 +70,10 @@ func testManager(t *testing.T, version string) {
 	assert.NotNil(t, err)
 	err = ApplyUnifiedDataForContainer("fake-pod", "fake-container", common.CgroupSubsysMemory, "memory.high", "max")
 	assert.NotNil(t, err)
+	err = ApplyIOLatencyWithRelativePath("/test", "default", 10000)
+	assert.NotNil(t, err)
+	err = ApplyIOLatencyWithRelativePath("/test", "default", 0)
+	assert.NotNil(t, err)
 
 	_, _ = GetMemoryWithRelativePath("/")
 	_, _ = GetMemoryWithAbsolutePath("/")

--- a/pkg/util/cgroup/manager/fake_manager.go
+++ b/pkg/util/cgroup/manager/fake_manager.go
@@ -48,6 +48,10 @@ func (f *FakeCgroupManager) ApplyIOWeight(absCgroupPath string, devID string, we
 	return nil
 }
 
+func (f *FakeCgroupManager) ApplyIOLatency(absCgroupPath string, devID string, latency uint64) error {
+	return nil
+}
+
 func (f *FakeCgroupManager) ApplyUnifiedData(absCgroupPath, cgroupFileName, data string) error {
 	return nil
 }

--- a/pkg/util/cgroup/manager/manager.go
+++ b/pkg/util/cgroup/manager/manager.go
@@ -41,6 +41,7 @@ type Manager interface {
 	ApplyIOCostQoS(absCgroupPath string, devID string, data *common.IOCostQoSData) error
 	ApplyIOCostModel(absCgroupPath string, devID string, data *common.IOCostModelData) error
 	ApplyIOWeight(absCgroupPath string, devID string, weight uint64) error
+	ApplyIOLatency(absCgroupPath string, devID string, latency uint64) error
 	ApplyUnifiedData(absCgroupPath, cgroupFileName, data string) error
 
 	GetMemory(absCgroupPath string) (*common.MemoryStats, error)

--- a/pkg/util/cgroup/manager/v1/fs_linux.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux.go
@@ -199,6 +199,10 @@ func (m *manager) ApplyIOWeight(absCgroupPath string, devID string, weight uint6
 	return errors.New("cgroups v1 does not support io.weight")
 }
 
+func (m *manager) ApplyIOLatency(absCgroupPath string, devID string, latency uint64) error {
+	return errors.New("cgroups v1 does not support io.latency")
+}
+
 func (m *manager) ApplyUnifiedData(absCgroupPath, cgroupFileName, data string) error {
 	if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, cgroupFileName, data); err != nil {
 		return err

--- a/pkg/util/cgroup/manager/v1/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v1/fs_unsupported.go
@@ -60,6 +60,10 @@ func (m *unsupportedManager) ApplyIOWeight(absCgroupPath string, devID string, w
 	return fmt.Errorf("unsupported manager v1")
 }
 
+func (m *unsupportedManager) ApplyIOLatency(absCgroupPath string, devID string, latency uint64) error {
+	return fmt.Errorf("unsupported manager v1")
+}
+
 func (m *unsupportedManager) ApplyUnifiedData(absCgroupPath, cgroupFileName, data string) error {
 	return fmt.Errorf("unsupported manager v1")
 }

--- a/pkg/util/cgroup/manager/v2/fs_linux_test.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux_test.go
@@ -315,6 +315,41 @@ func Test_manager_ApplyIOWeight(t *testing.T) {
 	}
 }
 
+func Test_manager_ApplyIOLatency(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		absCgroupPath string
+		devID         string
+		latency       uint64
+	}
+	tests := []struct {
+		name    string
+		m       *manager
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test apply io latency",
+			m:    NewManager(),
+			args: args{
+				absCgroupPath: "test-fake-path",
+				devID:         "8:16",
+				latency:       100000,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &manager{}
+			if err := m.ApplyIOLatency(tt.args.absCgroupPath, tt.args.devID, tt.args.latency); (err != nil) != tt.wantErr {
+				t.Errorf("manager.ApplyIOLatency() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_manager_ApplyUnifiedData(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/util/cgroup/manager/v2/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v2/fs_unsupported.go
@@ -60,8 +60,12 @@ func (m *unsupportedManager) ApplyIOWeight(absCgroupPath string, devID string, w
 	return fmt.Errorf("unsupported manager v2")
 }
 
+func (m *unsupportedManager) ApplyIOLatency(absCgroupPath string, devID string, latency uint64) error {
+	return fmt.Errorf("unsupported manager v2")
+}
+
 func (m *unsupportedManager) ApplyUnifiedData(absCgroupPath, cgroupFileName, data string) error {
-	return fmt.Errorf("unsupported manager v1")
+	return fmt.Errorf("unsupported manager v2")
 }
 
 func (m *unsupportedManager) GetMemory(_ string) (*common.MemoryStats, error) {


### PR DESCRIPTION
#### What type of PR is this?
Enhancements


#### What this PR does / why we need it:
For io qos features, when we deal with dirtymemory, we need to know the disk type. 
When we set io.latency, we need io.latency related cgroup operations.

#### Which issue(s) this PR fixes:
None.

#### Special notes for your reviewer:
None.
