### PR TITLE
feat(overcommit): add realtime overcommit advisor plugin

### DIFF
--- a/cmd/katalyst-agent/app/options/sysadvisor/overcommit/overcommit_aware_plugin.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/overcommit/overcommit_aware_plugin.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overcommit
+
+import (
+	"k8s.io/apimachinery/pkg/util/errors"
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/sysadvisor/overcommit/realtime"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/overcommit"
+)
+
+type OvercommitAwarePluginOptions struct {
+	*realtime.RealtimeOvercommitOptions
+}
+
+// NewOvercommitAwarePluginOptions creates a new Options with a default config.
+func NewOvercommitAwarePluginOptions() *OvercommitAwarePluginOptions {
+	return &OvercommitAwarePluginOptions{
+		RealtimeOvercommitOptions: realtime.NewRealtimeOvercommitOptions(),
+	}
+}
+
+func (o *OvercommitAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
+	fs := fss.FlagSet("overcommit_aware_plugin")
+
+	o.RealtimeOvercommitOptions.AddFlags(fs)
+}
+
+func (o *OvercommitAwarePluginOptions) ApplyTo(c *overcommit.OvercommitAwarePluginConfiguration) error {
+	var errList []error
+
+	errList = append(errList, o.RealtimeOvercommitOptions.ApplyTo(c.RealtimeOvercommitConfiguration))
+
+	return errors.NewAggregate(errList)
+}

--- a/cmd/katalyst-agent/app/options/sysadvisor/overcommit/realtime/realtime.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/overcommit/realtime/realtime.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package realtime
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/overcommit/realtime"
+)
+
+type RealtimeOvercommitOptions struct {
+	SyncPeriod     time.Duration
+	SyncPodTimeout time.Duration
+
+	TargetCPULoad          float64
+	TargetMemoryLoad       float64
+	EstimatedPodCPULoad    float64
+	EstimatedPodMemoryLoad float64
+
+	CPUMetricsToGather    []string
+	MemoryMetricsToGather []string
+}
+
+func NewRealtimeOvercommitOptions() *RealtimeOvercommitOptions {
+	return &RealtimeOvercommitOptions{
+		SyncPeriod:             10 * time.Second,
+		SyncPodTimeout:         2 * time.Second,
+		TargetCPULoad:          0.6,
+		TargetMemoryLoad:       0.8,
+		EstimatedPodCPULoad:    0.4,
+		EstimatedPodMemoryLoad: 0.8,
+
+		CPUMetricsToGather:    []string{},
+		MemoryMetricsToGather: []string{},
+	}
+}
+
+func (r *RealtimeOvercommitOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.DurationVar(&r.SyncPeriod, "realtime-overcommit-sync-period", r.SyncPeriod,
+		"period for realtime overcommit advisor to calculate node resource overcommit ratio")
+	fs.DurationVar(&r.SyncPodTimeout, "realtime-overcommit-sync-pod-timeout", r.SyncPodTimeout,
+		"timeout for realtime overcommit advisor to list pod")
+	fs.Float64Var(&r.TargetCPULoad, "realtime-overcommit-CPU-targetload", r.TargetCPULoad,
+		"target node load for realtime overcommit advisor to calculate node CPU overcommit ratio")
+	fs.Float64Var(&r.TargetMemoryLoad, "realtime-overcommit-mem-targetload", r.TargetMemoryLoad,
+		"target node load for realtime overcommit advisor to calculate node memory overcommit ratio")
+	fs.Float64Var(&r.EstimatedPodCPULoad, "realtime-overcommit-estimated-cpuload", r.EstimatedPodCPULoad,
+		"estimated pod load for realtime overcommit advisor to calculate node CPU overcommit ratio")
+	fs.Float64Var(&r.EstimatedPodMemoryLoad, "realtime-overcommit-estimated-memload", r.EstimatedPodMemoryLoad,
+		"estimated pod load for realtime overcommit advisor to calculate node memory overcommit ratio")
+	fs.StringSliceVar(&r.CPUMetricsToGather, "CPU-metrics-to-gather", r.CPUMetricsToGather,
+		"metrics list used to calculate node cpu overcommitment ratio")
+	fs.StringSliceVar(&r.MemoryMetricsToGather, "memory-metrics-to-gather", r.MemoryMetricsToGather,
+		"metrics list used to calculate node memory overcommitment ratio")
+}
+
+func (r *RealtimeOvercommitOptions) ApplyTo(o *realtime.RealtimeOvercommitConfiguration) error {
+	o.SyncPeriod = r.SyncPeriod
+	o.SyncPodTimeout = r.SyncPodTimeout
+
+	if r.TargetCPULoad > 0.0 && r.TargetMemoryLoad < 1.0 {
+		o.TargetCPULoad = r.TargetCPULoad
+	}
+	if r.TargetMemoryLoad > 0.0 && r.TargetMemoryLoad < 1.0 {
+		o.TargetMemoryLoad = r.TargetMemoryLoad
+	}
+	if r.EstimatedPodCPULoad > 0.0 && r.EstimatedPodCPULoad < 1.0 {
+		o.EstimatedPodCPULoad = r.EstimatedPodCPULoad
+	}
+	if r.EstimatedPodMemoryLoad > 0.0 && r.EstimatedPodMemoryLoad < 1.0 {
+		o.EstimatedPodMemoryLoad = r.EstimatedPodMemoryLoad
+	}
+
+	o.CPUMetricsToGather = r.CPUMetricsToGather
+	o.MemoryMetricsToGather = r.MemoryMetricsToGather
+
+	return nil
+}

--- a/cmd/katalyst-agent/app/options/sysadvisor/sysadvisor_base.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/sysadvisor_base.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/sysadvisor/inference"
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/sysadvisor/metacache"
 	metricemitter "github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/sysadvisor/metric-emitter"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/sysadvisor/overcommit"
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/sysadvisor/qosaware"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor"
 )
@@ -75,15 +76,17 @@ type SysAdvisorPluginsOptions struct {
 	*metacache.MetaCachePluginOptions
 	*metricemitter.MetricEmitterPluginOptions
 	*inference.InferencePluginOptions
+	*overcommit.OvercommitAwarePluginOptions
 }
 
 // NewSysAdvisorPluginsOptions creates a new Options with a default config.
 func NewSysAdvisorPluginsOptions() *SysAdvisorPluginsOptions {
 	return &SysAdvisorPluginsOptions{
-		QoSAwarePluginOptions:      qosaware.NewQoSAwarePluginOptions(),
-		MetaCachePluginOptions:     metacache.NewMetaCachePluginOptions(),
-		MetricEmitterPluginOptions: metricemitter.NewMetricEmitterPluginOptions(),
-		InferencePluginOptions:     inference.NewInferencePluginOptions(),
+		QoSAwarePluginOptions:        qosaware.NewQoSAwarePluginOptions(),
+		MetaCachePluginOptions:       metacache.NewMetaCachePluginOptions(),
+		MetricEmitterPluginOptions:   metricemitter.NewMetricEmitterPluginOptions(),
+		InferencePluginOptions:       inference.NewInferencePluginOptions(),
+		OvercommitAwarePluginOptions: overcommit.NewOvercommitAwarePluginOptions(),
 	}
 }
 
@@ -93,6 +96,7 @@ func (o *SysAdvisorPluginsOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	o.MetaCachePluginOptions.AddFlags(fss)
 	o.MetricEmitterPluginOptions.AddFlags(fss)
 	o.InferencePluginOptions.AddFlags(fss)
+	o.OvercommitAwarePluginOptions.AddFlags(fss)
 }
 
 // ApplyTo fills up config with options
@@ -102,6 +106,7 @@ func (o *SysAdvisorPluginsOptions) ApplyTo(c *sysadvisor.SysAdvisorPluginsConfig
 	errList = append(errList, o.MetaCachePluginOptions.ApplyTo(c.MetaCachePluginConfiguration))
 	errList = append(errList, o.MetricEmitterPluginOptions.ApplyTo(c.MetricEmitterPluginConfiguration))
 	errList = append(errList, o.InferencePluginOptions.ApplyTo(c.InferencePluginConfiguration))
+	errList = append(errList, o.OvercommitAwarePluginOptions.ApplyTo(c.OvercommitAwarePluginConfiguration))
 	return errors.NewAggregate(errList)
 }
 

--- a/pkg/agent/sysadvisor/plugin/overcommitmentaware/overcommitment_aware.go
+++ b/pkg/agent/sysadvisor/plugin/overcommitmentaware/overcommitment_aware.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overcommitmentaware
+
+import (
+	"context"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/overcommitmentaware/realtime"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/overcommitmentaware/reporter"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	metricspool "github.com/kubewharf/katalyst-core/pkg/metrics/metrics-pool"
+)
+
+const (
+	PluginName = "overcommitment-aware-plugin"
+)
+
+// OvercommitmentAwarePlugin calculates node overcommitment ratio,
+// values will be reported to node KCNR annotations by the reporter.
+type OvercommitmentAwarePlugin struct {
+	name string
+
+	realtimeAdvisor *realtime.RealtimeOvercommitmentAdvisor
+	reporter        reporter.OvercommitRatioReporter
+
+	emitter metrics.MetricEmitter
+}
+
+func NewOvercommitmentAwarePlugin(
+	pluginName string, conf *config.Configuration,
+	_ interface{},
+	emitterPool metricspool.MetricsEmitterPool,
+	metaServer *metaserver.MetaServer,
+	_ metacache.MetaCache,
+) (plugin.SysAdvisorPlugin, error) {
+	emitter := emitterPool.GetDefaultMetricsEmitter()
+
+	realtimeOvercommitmentAdvisor := realtime.NewRealtimeOvercommitmentAdvisor(conf, metaServer, emitter)
+
+	overcommitRatioReporter, err := reporter.NewOvercommitRatioReporter(emitter, conf, realtimeOvercommitmentAdvisor)
+	if err != nil {
+		return nil, err
+	}
+
+	op := &OvercommitmentAwarePlugin{
+		name: pluginName,
+
+		realtimeAdvisor: realtimeOvercommitmentAdvisor,
+		reporter:        overcommitRatioReporter,
+	}
+
+	return op, nil
+}
+
+func (op *OvercommitmentAwarePlugin) Run(ctx context.Context) {
+	go op.realtimeAdvisor.Run(ctx)
+
+	go op.reporter.Run(ctx)
+}
+
+func (op *OvercommitmentAwarePlugin) Name() string {
+	return op.name
+}
+
+func (op *OvercommitmentAwarePlugin) Init() error {
+	return nil
+}

--- a/pkg/agent/sysadvisor/plugin/overcommitmentaware/realtime/realtime.go
+++ b/pkg/agent/sysadvisor/plugin/overcommitmentaware/realtime/realtime.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package realtime
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	qrmutil "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/metric"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+const (
+	realtimeOvercommitAdvisorUpdateFail   = "realtime_overcommit_advisor_update_fail"
+	realtimeOvercommitAdvisorSyncNodeFail = "realtime_overcommit_advisor_sync_node_fail"
+)
+
+var (
+	cpuMetricsToGather = []string{
+		consts.MetricCPUUsageContainer,
+		consts.MetricLoad1MinContainer,
+		consts.MetricLoad5MinContainer,
+	}
+
+	memoryMetricsToGather = []string{
+		consts.MetricMemRssContainer,
+	}
+)
+
+// RealtimeOvercommitmentAdvisor calculate node CPU and memory overcommitment ratio
+// by realtime metrics and node requested resources from metaSever
+type RealtimeOvercommitmentAdvisor struct {
+	mutex sync.RWMutex
+
+	metaServer *metaserver.MetaServer
+	emitter    metrics.MetricEmitter
+
+	updatePeriod   time.Duration
+	syncPodTimeout time.Duration
+
+	nodeTargetCPULoad      float64
+	nodeTargetMemoryLoad   float64
+	podEstimatedCPULoad    float64
+	podEstimatedMemoryLoad float64
+
+	cpuMetricsToGather    []string
+	memoryMetricsToGather []string
+
+	resourceOvercommitRatio map[v1.ResourceName]float64
+	resourceAllocatable     map[v1.ResourceName]resource.Quantity
+}
+
+type PodResourceInfo struct {
+	usage   float64
+	request resource.Quantity
+	limit   resource.Quantity
+}
+
+func NewRealtimeOvercommitmentAdvisor(
+	conf *config.Configuration,
+	metaServer *metaserver.MetaServer,
+	emitter metrics.MetricEmitter,
+) *RealtimeOvercommitmentAdvisor {
+	ra := &RealtimeOvercommitmentAdvisor{
+		metaServer: metaServer,
+		emitter:    emitter,
+
+		resourceOvercommitRatio: map[v1.ResourceName]float64{
+			v1.ResourceCPU:    1.0,
+			v1.ResourceMemory: 1.0,
+		},
+		resourceAllocatable: map[v1.ResourceName]resource.Quantity{},
+
+		updatePeriod:           conf.OvercommitAwarePluginConfiguration.SyncPeriod,
+		syncPodTimeout:         conf.SyncPodTimeout,
+		nodeTargetCPULoad:      conf.TargetCPULoad,
+		nodeTargetMemoryLoad:   conf.TargetMemoryLoad,
+		podEstimatedCPULoad:    conf.EstimatedPodCPULoad,
+		podEstimatedMemoryLoad: conf.EstimatedPodMemoryLoad,
+		cpuMetricsToGather:     conf.CPUMetricsToGather,
+		memoryMetricsToGather:  conf.MemoryMetricsToGather,
+	}
+
+	err := ra.syncAllocatableResource()
+	if err != nil {
+		klog.Fatalf("syncAllocatableResource fail: %v", err)
+	}
+
+	return ra
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) Run(ctx context.Context) {
+	klog.Infof("RealtimeOvercommitmentAdvisor run...")
+
+	go wait.Until(func() {
+		err := ra.syncAllocatableResource()
+		if err != nil {
+			klog.Errorf("syncAllocatableResource fail: %v", err)
+			_ = ra.emitter.StoreInt64(realtimeOvercommitAdvisorSyncNodeFail, 1, metrics.MetricTypeNameCount)
+		}
+	}, time.Hour, ctx.Done())
+
+	go wait.Until(func() {
+		err := ra.update()
+		if err != nil {
+			klog.Errorf("RealtimeOvercommitmentAdvisor update fail: %v", err)
+			_ = ra.emitter.StoreInt64(realtimeOvercommitAdvisorUpdateFail, 1, metrics.MetricTypeNameCount)
+		}
+	}, ra.updatePeriod, ctx.Done())
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) update() error {
+
+	// list pod from metaServer
+	ctx, cancel := context.WithTimeout(context.Background(), ra.syncPodTimeout)
+	defer cancel()
+	podList, err := ra.metaServer.GetPodList(ctx, nil)
+	if err != nil {
+		err = fmt.Errorf("[overcommitment-aware-realtime] list pod fail, err: %v", err)
+		klog.Error(err)
+		return err
+	}
+
+	// sum node request resource
+	nodeResourceRequest := sumUpPodsResources(podList)
+	klog.V(6).Infof("[overcommitment-aware-realtime] sumUpPodsResources, cpu: %v, memory: %v", nodeResourceRequest.Cpu().String(), nodeResourceRequest.Memory().String())
+
+	// agg node pods usage
+	nodeResourceUsage := ra.aggregateNodeMetrics(podList)
+	klog.V(6).Infof("[overcommitment-aware-realtime] aggregateNodeMetrics: %v", nodeResourceUsage)
+
+	ra.metricsToOvercommitRatio(nodeResourceRequest, nodeResourceUsage)
+
+	return nil
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) aggregateNodeMetrics(podList []*v1.Pod) map[v1.ResourceName]float64 {
+	var (
+		cpuUsage, memoryUsage float64
+	)
+
+	if len(ra.cpuMetricsToGather) != 0 {
+		cpuUsage = ra.aggregateMetrics(podList, ra.cpuMetricsToGather)
+	} else {
+		cpuUsage = ra.aggregateMetrics(podList, cpuMetricsToGather)
+	}
+
+	if len(ra.memoryMetricsToGather) != 0 {
+		memoryUsage = ra.aggregateMetrics(podList, ra.memoryMetricsToGather)
+	} else {
+		memoryUsage = ra.aggregateMetrics(podList, memoryMetricsToGather)
+	}
+
+	return map[v1.ResourceName]float64{
+		v1.ResourceCPU:    cpuUsage,
+		v1.ResourceMemory: memoryUsage,
+	}
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) aggregateMetrics(podList []*v1.Pod, metrics []string) float64 {
+	var (
+		res         float64
+		metricValue float64
+		reference   string
+	)
+
+	for _, pod := range podList {
+		metricValue = 0
+		reference = ""
+
+		for _, metricName := range metrics {
+			metricData := ra.metaServer.AggregatePodMetric([]*v1.Pod{pod}, metricName, metric.AggregatorSum, metric.DefaultContainerMetricFilter)
+			if klog.V(5).Enabled() {
+				general.Infof("pod %v metric %v value %v", pod.Name, metricName, metricData.Value)
+			}
+			if metricData.Value <= 0 {
+				continue
+			}
+
+			if metricData.Value > metricValue {
+				metricValue = metricData.Value
+				reference = metricName
+			}
+		}
+
+		if klog.V(5).Enabled() {
+			general.Infof("pod %v aggregateCPU value %v reference %v", pod.Name, metricValue, reference)
+		}
+		res += metricValue
+	}
+
+	return res
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) syncAllocatableResource() error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	kconfig, err := ra.metaServer.GetKubeletConfig(ctx)
+	if err != nil {
+		klog.Errorf("get kubeletconfig fail: %v", err)
+		return err
+	}
+
+	// parse reserved resource
+	reservedCPU, found, err := qrmutil.GetKubeletReservedQuantity(string(v1.ResourceCPU), kconfig)
+	if err != nil {
+		klog.Errorf("GetKubeletReservedQuantity fail: %v", err)
+		return err
+	}
+	if !found {
+		reservedCPU = *resource.NewQuantity(0, resource.DecimalSI)
+	}
+
+	reservedMemory, found, err := qrmutil.GetKubeletReservedQuantity(string(v1.ResourceMemory), kconfig)
+	if err != nil {
+		klog.Errorf("GetKubeletReservedQuantity fail: %v", err)
+		return err
+	}
+	if !found {
+		reservedMemory = *resource.NewQuantity(0, resource.BinarySI)
+	}
+
+	ra.syncAllocatableCPU(reservedCPU)
+	ra.syncAllocatableMemory(reservedMemory)
+	return nil
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) syncAllocatableCPU(reserved resource.Quantity) {
+	capacity := resource.NewMilliQuantity(int64(ra.metaServer.MachineInfo.NumCores*1000), resource.DecimalSI)
+	capacity.Sub(reserved)
+
+	ra.mutex.Lock()
+	ra.resourceAllocatable[v1.ResourceCPU] = *capacity
+	ra.mutex.Unlock()
+
+	klog.V(5).Infof("node allocatable cpu %v, reserved cpu %v", capacity.String(), reserved.String())
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) syncAllocatableMemory(reserved resource.Quantity) {
+	capacity := resource.NewQuantity(int64(ra.metaServer.MemoryCapacity), resource.BinarySI)
+
+	capacity.Sub(reserved)
+
+	ra.mutex.Lock()
+	ra.resourceAllocatable[v1.ResourceMemory] = *capacity
+	ra.mutex.Unlock()
+
+	klog.V(5).Infof("node allocatable memory %v, reserved memory %v", capacity.String(), reserved.String())
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) metricsToOvercommitRatio(resourceRequest v1.ResourceList, resourceUsage map[v1.ResourceName]float64) {
+	cpuOvercommitRatio := ra.resourceMetricsToOvercommitRatio(v1.ResourceCPU, *resourceRequest.Cpu(), resourceUsage[v1.ResourceCPU])
+
+	memoryOvercommitRatio := ra.resourceMetricsToOvercommitRatio(v1.ResourceMemory, *resourceRequest.Memory(), resourceUsage[v1.ResourceMemory])
+
+	ra.mutex.Lock()
+	ra.resourceOvercommitRatio[v1.ResourceCPU] = cpuOvercommitRatio
+	ra.resourceOvercommitRatio[v1.ResourceMemory] = memoryOvercommitRatio
+	ra.mutex.Unlock()
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) resourceMetricsToOvercommitRatio(resourceName v1.ResourceName, resourceRequest resource.Quantity, usage float64) float64 {
+	ra.mutex.RLock()
+	resourceAllocatable, ok := ra.resourceAllocatable[resourceName]
+	ra.mutex.RUnlock()
+
+	if !ok {
+		klog.Errorf("resource %v not exist in resourceAllocatable map", resourceName)
+		return 1.0
+	}
+
+	allocatable := resourceAllocatable.Value()
+	request := resourceRequest.Value()
+
+	if request == 0 || allocatable == 0 {
+		klog.Warningf("unexpected node resource, resourceName: %v, request: %v, allocatable: %v", resourceName, request, allocatable)
+		return 1.0
+	}
+
+	existedPodLoad := usage / float64(request)
+	if existedPodLoad > 1 {
+		existedPodLoad = 1
+	}
+	var (
+		podExpectedLoad, nodeTargetLoad float64
+	)
+	switch resourceName {
+	case v1.ResourceCPU:
+		podExpectedLoad = ra.podEstimatedCPULoad
+		nodeTargetLoad = ra.nodeTargetCPULoad
+	case v1.ResourceMemory:
+		podExpectedLoad = ra.podEstimatedMemoryLoad
+		nodeTargetLoad = ra.nodeTargetMemoryLoad
+	default:
+		klog.Warningf("unknow resourceName: %v", resourceName)
+		return 1.0
+	}
+	if existedPodLoad < podExpectedLoad {
+		existedPodLoad = podExpectedLoad
+	}
+
+	overcommitRatio := ((float64(allocatable)*nodeTargetLoad-usage)/existedPodLoad + float64(request)) / float64(allocatable)
+
+	klog.V(5).Infof("resource %v request: %v, allocatable: %v, usage: %v, targetLoad: %v, existLoad: %v, overcommitRatio: %v",
+		resourceName, request, allocatable, usage, nodeTargetLoad, existedPodLoad, overcommitRatio)
+	if overcommitRatio < 1.0 {
+		overcommitRatio = 1.0
+	}
+	return overcommitRatio
+}
+
+func sumUpPodsResources(podList []*v1.Pod) v1.ResourceList {
+	var (
+		podsCPURequest    = resource.NewQuantity(0, resource.DecimalSI)
+		podsMemoryRequest = resource.NewQuantity(0, resource.BinarySI)
+	)
+
+	for _, pod := range podList {
+		podResource := native.SumUpPodRequestResources(pod)
+
+		cpuRequest := podResource.Cpu()
+		memoryRequest := podResource.Memory()
+
+		podsCPURequest.Add(*cpuRequest)
+		podsMemoryRequest.Add(*memoryRequest)
+	}
+
+	return v1.ResourceList{
+		v1.ResourceCPU:    podsCPURequest.DeepCopy(),
+		v1.ResourceMemory: podsMemoryRequest.DeepCopy(),
+	}
+}
+
+func (ra *RealtimeOvercommitmentAdvisor) GetOvercommitRatio() (map[v1.ResourceName]float64, error) {
+	var (
+		res = map[v1.ResourceName]float64{
+			v1.ResourceCPU:    1.0,
+			v1.ResourceMemory: 1.0,
+		}
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	node, err := ra.metaServer.GetNode(ctx)
+	if err != nil {
+		klog.Error("GetOvercommitRatio getNode fail: %v", err)
+		return nil, err
+	}
+	if cpuOvercommitRatioAnno, ok := node.Annotations[apiconsts.NodeAnnotationCPUOvercommitRatioKey]; ok {
+		cpuOvercommitRatio, err := strconv.ParseFloat(cpuOvercommitRatioAnno, 64)
+		if err != nil {
+			klog.Errorf("%s parse fail: %v", cpuOvercommitRatioAnno, err)
+		} else {
+			res[v1.ResourceCPU] = cpuOvercommitRatio
+		}
+	}
+	if memOvercommitRatioAnno, ok := node.Annotations[apiconsts.NodeAnnotationMemoryOvercommitRatioKey]; ok {
+		memOvercommitRatio, err := strconv.ParseFloat(memOvercommitRatioAnno, 64)
+		if err != nil {
+			klog.Errorf("%s parse fail: %v", memOvercommitRatioAnno, err)
+		} else {
+			res[v1.ResourceMemory] = memOvercommitRatio
+		}
+	}
+
+	ra.mutex.RLock()
+	defer ra.mutex.RUnlock()
+
+	if len(ra.resourceOvercommitRatio) <= 0 {
+		return map[v1.ResourceName]float64{}, nil
+	}
+
+	// only report when overcommit ratio less than the set value
+	for resourceName, overcommitRatio := range ra.resourceOvercommitRatio {
+		if overcommitRatio >= res[resourceName] {
+			continue
+		}
+		res[resourceName] = overcommitRatio
+	}
+
+	return res, nil
+}

--- a/pkg/agent/sysadvisor/plugin/overcommitmentaware/realtime/realtime_test.go
+++ b/pkg/agent/sysadvisor/plugin/overcommitmentaware/realtime/realtime_test.go
@@ -1,0 +1,446 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package realtime
+
+import (
+	"io/ioutil"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	consts2 "github.com/kubewharf/katalyst-api/pkg/consts"
+
+	info "github.com/google/cadvisor/info/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubelet/config/v1beta1"
+
+	internalfake "github.com/kubewharf/katalyst-api/pkg/client/clientset/versioned/fake"
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
+	"github.com/kubewharf/katalyst-core/pkg/client"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/kubeletconfig"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	metric2 "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+func TestUpdate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		pods             []*v1.Pod
+		containerMetrics containerMetric
+		node             *v1.Node
+		expectRatio      map[string]float64
+		expectError      bool
+	}{
+		{
+			name: "low usage",
+			node: &v1.Node{
+				ObjectMeta: v12.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						consts2.NodeAnnotationCPUOvercommitRatioKey:    "10",
+						consts2.NodeAnnotationMemoryOvercommitRatioKey: "10",
+					},
+				},
+			},
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod1",
+						UID:  "uid-pod-1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container1",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(4*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				}, {
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod2",
+						UID:  "uid-pod-2",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container2",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(4*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			containerMetrics: containerMetric{
+				"uid-pod-1": {
+					"container1": {
+						consts.MetricCPUUsageContainer: 0.5,
+						consts.MetricLoad1MinContainer: 0.1,
+						consts.MetricLoad5MinContainer: 0.1,
+						consts.MetricMemRssContainer:   1 * 1024 * 1024 * 1024,
+					},
+				},
+				"uid-pod-2": {
+					"container2": {
+						consts.MetricCPUUsageContainer: 0.5,
+						consts.MetricLoad1MinContainer: 0.1,
+						consts.MetricLoad5MinContainer: 0.1,
+						consts.MetricMemRssContainer:   1 * 1024 * 1024 * 1024,
+					},
+				},
+			},
+			expectError: false,
+			expectRatio: map[string]float64{
+				"cpu":    1.6,
+				"memory": 1.17,
+			},
+		},
+		{
+			name: "high usage",
+			node: &v1.Node{
+				ObjectMeta: v12.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						consts2.NodeAnnotationCPUOvercommitRatioKey:    "10",
+						consts2.NodeAnnotationMemoryOvercommitRatioKey: "10",
+					},
+				},
+			},
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod1",
+						UID:  "uid-pod-1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container1",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				}, {
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod2",
+						UID:  "uid-pod-2",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container2",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(4, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			containerMetrics: containerMetric{
+				"uid-pod-1": {
+					"container1": {
+						consts.MetricCPUUsageContainer: 3,
+						consts.MetricLoad1MinContainer: 1,
+						consts.MetricLoad5MinContainer: 1,
+						consts.MetricMemRssContainer:   7 * 1024 * 1024 * 1024,
+					},
+				},
+				"uid-pod-2": {
+					"container2": {
+						consts.MetricCPUUsageContainer: 2,
+						consts.MetricLoad1MinContainer: 1,
+						consts.MetricLoad5MinContainer: 1,
+						consts.MetricMemRssContainer:   6 * 1024 * 1024 * 1024,
+					},
+				},
+			},
+			expectError: false,
+			expectRatio: map[string]float64{
+				"cpu":    1.0,
+				"memory": 1.0,
+			},
+		},
+		{
+			name: "no request",
+			node: &v1.Node{
+				ObjectMeta: v12.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						consts2.NodeAnnotationCPUOvercommitRatioKey:    "10",
+						consts2.NodeAnnotationMemoryOvercommitRatioKey: "10",
+					},
+				},
+			},
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod1",
+						UID:  "uid-pod-1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container1",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				}, {
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod2",
+						UID:  "uid-pod-2",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container2",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			containerMetrics: containerMetric{
+				"uid-pod-1": {
+					"container1": {
+						consts.MetricCPUUsageContainer: 3,
+						consts.MetricLoad1MinContainer: 1,
+						consts.MetricLoad5MinContainer: 1,
+						consts.MetricMemRssContainer:   6 * 1024 * 1024 * 1024,
+					},
+				},
+				"uid-pod-2": {
+					"container2": {
+						consts.MetricCPUUsageContainer: 2,
+						consts.MetricLoad1MinContainer: 1,
+						consts.MetricLoad5MinContainer: 1,
+						consts.MetricMemRssContainer:   6 * 1024 * 1024 * 1024,
+					},
+				},
+			},
+			expectError: false,
+			expectRatio: map[string]float64{
+				"cpu":    1.0,
+				"memory": 1.0,
+			},
+		},
+		{
+			name: "no metrics",
+			node: &v1.Node{
+				ObjectMeta: v12.ObjectMeta{
+					Name: "testNode",
+					Annotations: map[string]string{
+						consts2.NodeAnnotationCPUOvercommitRatioKey:    "10",
+						consts2.NodeAnnotationMemoryOvercommitRatioKey: "10",
+					},
+				},
+			},
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod1",
+						UID:  "uid-pod-1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container1",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(4*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				}, {
+					ObjectMeta: v12.ObjectMeta{
+						Name: "pod2",
+						UID:  "uid-pod-2",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container2",
+								Resources: v1.ResourceRequirements{
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(8, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(8*1024*1024*1024, resource.DecimalSI),
+									},
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+										v1.ResourceMemory: *resource.NewQuantity(4*1024*1024*1024, resource.DecimalSI),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			containerMetrics: containerMetric{},
+			expectError:      false,
+			expectRatio: map[string]float64{
+				"cpu":    1.75,
+				"memory": 1.25,
+			},
+		},
+	}
+
+	checkpointDir, err := ioutil.TempDir("", "checkpoint-update")
+	require.NoError(t, err)
+	defer os.RemoveAll(checkpointDir)
+
+	statefileDir, err := ioutil.TempDir("", "statefile-update")
+	require.NoError(t, err)
+	defer os.RemoveAll(statefileDir)
+
+	conf := generateTestConfiguration(t, checkpointDir, statefileDir, "testNode")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := generateTestMetaServer(t, conf, tc.pods, tc.containerMetrics, tc.node)
+			r := NewRealtimeOvercommitmentAdvisor(config.NewConfiguration(), ms, metrics.DummyMetrics{})
+			err := r.update()
+			if tc.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				ratio, _ := r.GetOvercommitRatio()
+				for resourceName, value := range ratio {
+					assert.Less(t, math.Abs(value-tc.expectRatio[string(resourceName)]), 0.01)
+				}
+			}
+		})
+	}
+}
+
+func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string, nodeName string) *config.Configuration {
+	conf, err := options.NewOptions().Config()
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+
+	conf.NodeName = nodeName
+	conf.GenericSysAdvisorConfiguration.StateFileDirectory = stateFileDir
+	conf.MetaServerConfiguration.CheckpointManagerDir = checkpointDir
+	return conf
+}
+
+func generateTestMetaServer(t *testing.T, conf *config.Configuration, podList []*v1.Pod, containerMetrics containerMetric, node *v1.Node) *metaserver.MetaServer {
+	genericClient := &client.GenericClientSet{
+		KubeClient:     fake.NewSimpleClientset(node),
+		InternalClient: internalfake.NewSimpleClientset(),
+		DynamicClient:  dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	}
+
+	meta, err := metaserver.NewMetaServer(genericClient, metrics.DummyMetrics{}, conf)
+	assert.NoError(t, err)
+
+	meta.PodFetcher = &pod.PodFetcherStub{
+		PodList: podList,
+	}
+
+	now := time.Now()
+	fakeMetricsFetcher := metric.NewFakeMetricsFetcher(metrics.DummyMetrics{}).(*metric.FakeMetricsFetcher)
+	for podUID, podData := range containerMetrics {
+		for containerName, containerData := range podData {
+			for metricName, value := range containerData {
+				fakeMetricsFetcher.SetContainerMetric(podUID, containerName, metricName, metric2.MetricData{
+					Value: value,
+					Time:  &now,
+				})
+			}
+		}
+	}
+
+	meta.MetricsFetcher = fakeMetricsFetcher
+
+	meta.KubeletConfigFetcher = kubeletconfig.NewFakeKubeletConfigFetcher(v1beta1.KubeletConfiguration{})
+
+	meta.MachineInfo = &info.MachineInfo{
+		NumCores:       16,
+		MemoryCapacity: 32 * 1024 * 1024 * 1024,
+	}
+	return meta
+}
+
+type containerMetric map[string]map[string]map[string]float64

--- a/pkg/agent/sysadvisor/plugin/overcommitmentaware/reporter/reporter.go
+++ b/pkg/agent/sysadvisor/plugin/overcommitmentaware/reporter/reporter.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-api/pkg/plugins/registration"
+	"github.com/kubewharf/katalyst-api/pkg/plugins/skeleton"
+	"github.com/kubewharf/katalyst-api/pkg/protocol/reporterplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util"
+)
+
+const (
+	overcommitRatioReporterPluginName = "overcommitratio-reporter-plugin"
+)
+
+type OvercommitManager interface {
+	GetOvercommitRatio() (map[v1.ResourceName]float64, error)
+}
+
+// OvercommitRatioReporter report node overcommitment ratio calculated by agent
+type OvercommitRatioReporter interface {
+	Run(ctx context.Context)
+}
+
+type overcommitRatioReporterImpl struct {
+	skeleton.GenericPlugin
+}
+
+func NewOvercommitRatioReporter(
+	emitter metrics.MetricEmitter,
+	conf *config.Configuration,
+	manager OvercommitManager,
+) (OvercommitRatioReporter, error) {
+	plugin, err := newOvercommitRatioReporterPlugin(emitter, conf, manager)
+	if err != nil {
+		return nil, fmt.Errorf("[overcommit-reporter] create reporter failed: %v", err)
+	}
+
+	return &overcommitRatioReporterImpl{plugin}, nil
+}
+
+func (o *overcommitRatioReporterImpl) Run(ctx context.Context) {
+	if err := o.Start(); err != nil {
+		klog.Fatalf("[overcommit-reporter] start %v failed: %v", o.Name(), err)
+	}
+	klog.Infof("[overcommit-reporter] plugin wrapper %v started", o.Name())
+
+	<-ctx.Done()
+	if err := o.Stop(); err != nil {
+		klog.Errorf("[overcommit-reporter] stop %v failed: %v", o.Name(), err)
+	}
+	klog.Infof("[overcommit-reporter] stop")
+}
+
+type OvercommitRatioReporterPlugin struct {
+	sync.Mutex
+
+	manager OvercommitManager
+
+	ctx     context.Context
+	cancel  context.CancelFunc
+	started bool
+}
+
+func newOvercommitRatioReporterPlugin(
+	emitter metrics.MetricEmitter,
+	conf *config.Configuration,
+	overcommitManager OvercommitManager,
+) (skeleton.GenericPlugin, error) {
+
+	reporter := &OvercommitRatioReporterPlugin{
+		manager: overcommitManager,
+	}
+
+	return skeleton.NewRegistrationPluginWrapper(reporter, []string{conf.PluginRegistrationDir},
+		func(key string, value int64) {
+			_ = emitter.StoreInt64(key, value, metrics.MetricTypeNameCount, metrics.ConvertMapToTags(map[string]string{
+				"pluginName": overcommitRatioReporterPluginName,
+				"pluginType": registration.ReporterPlugin,
+			})...)
+		})
+}
+
+func (o *OvercommitRatioReporterPlugin) Name() string {
+	return overcommitRatioReporterPluginName
+}
+
+func (o *OvercommitRatioReporterPlugin) Start() (err error) {
+	o.Lock()
+	defer func() {
+		if err == nil {
+			o.started = true
+		}
+		o.Unlock()
+	}()
+
+	if o.started {
+		return
+	}
+
+	o.ctx, o.cancel = context.WithCancel(context.Background())
+	return
+}
+
+func (o *OvercommitRatioReporterPlugin) Stop() error {
+	o.Lock()
+	defer func() {
+		o.started = false
+		o.Unlock()
+	}()
+
+	if !o.started {
+		return nil
+	}
+
+	o.cancel()
+	return nil
+}
+
+// GetReportContent get overcommitment ratio from manager directly.
+// Since the metrics collected by Manager are already an average within a time period,
+// we expect a faster response to node load fluctuations to avoid excessive overcommit of online resources.
+func (o *OvercommitRatioReporterPlugin) GetReportContent(_ context.Context, _ *v1alpha1.Empty) (*v1alpha1.GetReportContentResponse, error) {
+	overcommitRatioMap, err := o.manager.GetOvercommitRatio()
+	if err != nil {
+		klog.Errorf("OvercommitRatioReporterPlugin GetOvercommitMent fail: %v", err)
+		return nil, err
+	}
+	klog.V(6).Infof("reporter get overcommit ratio: %v", overcommitRatioMap)
+
+	// overcommit data to CNR data
+	reportToCNR, err := o.overcommitRatioToCNRAnnotation(overcommitRatioMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1alpha1.GetReportContentResponse{
+		Content: []*v1alpha1.ReportContent{
+			reportToCNR,
+		},
+	}, nil
+}
+
+func (o *OvercommitRatioReporterPlugin) ListAndWatchReportContent(_ *v1alpha1.Empty, server v1alpha1.ReporterPlugin_ListAndWatchReportContentServer) error {
+	for {
+		select {
+		case <-o.ctx.Done():
+			return nil
+		case <-server.Context().Done():
+			return nil
+		}
+	}
+}
+
+func (o *OvercommitRatioReporterPlugin) overcommitRatioToCNRAnnotation(overcommitRatioMap map[v1.ResourceName]float64) (*v1alpha1.ReportContent, error) {
+	if len(overcommitRatioMap) <= 0 {
+		return nil, nil
+	}
+
+	klog.V(6).Infof("overcommitRatioMap: %v", overcommitRatioMap)
+	overcommitRatioAnnotation := map[string]string{}
+	for resource := range overcommitRatioMap {
+		switch resource {
+		case v1.ResourceCPU, consts.NodeAnnotationCPUOvercommitRatioKey:
+			overcommitRatioAnnotation[consts.NodeAnnotationCPUOvercommitRatioKey] = fmt.Sprintf("%.2f", overcommitRatioMap[resource])
+		case v1.ResourceMemory, consts.NodeAnnotationMemoryOvercommitRatioKey:
+			overcommitRatioAnnotation[consts.NodeAnnotationMemoryOvercommitRatioKey] = fmt.Sprintf("%.2f", overcommitRatioMap[resource])
+		default:
+			klog.Warningf("unknown resource: %v", resource.String())
+		}
+	}
+
+	value, err := json.Marshal(&overcommitRatioAnnotation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1alpha1.ReportContent{
+		GroupVersionKind: &util.CNRGroupVersionKind,
+		Field: []*v1alpha1.ReportField{
+			{
+				FieldType: v1alpha1.FieldType_Metadata,
+				FieldName: "Annotations",
+				Value:     value,
+			},
+		},
+	}, nil
+}

--- a/pkg/agent/sysadvisor/plugin/overcommitmentaware/reporter/reporter_test.go
+++ b/pkg/agent/sysadvisor/plugin/overcommitmentaware/reporter/reporter_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGetReportContent(t *testing.T) {
+	p := &OvercommitRatioReporterPlugin{
+		manager: NewFakeOvercommitManager(map[v1.ResourceName]float64{}),
+	}
+
+	_, err := p.GetReportContent(context.TODO(), nil)
+	assert.NotNil(t, err)
+
+	p = &OvercommitRatioReporterPlugin{
+		manager: NewFakeOvercommitManager(map[v1.ResourceName]float64{
+			v1.ResourceCPU:     1.5123,
+			v1.ResourceMemory:  1.2678,
+			v1.ResourceStorage: 1.0,
+		}),
+	}
+
+	res, err := p.GetReportContent(context.TODO(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(res.Content))
+
+	ratio := map[string]string{}
+	err = json.Unmarshal(res.Content[0].Field[0].Value, &ratio)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.51", ratio[consts.NodeAnnotationCPUOvercommitRatioKey])
+	assert.Equal(t, "1.27", ratio[consts.NodeAnnotationMemoryOvercommitRatioKey])
+}
+
+func TestStart(t *testing.T) {
+	p := &OvercommitRatioReporterPlugin{
+		manager: NewFakeOvercommitManager(map[v1.ResourceName]float64{
+			v1.ResourceCPU:     1.5123,
+			v1.ResourceMemory:  1.2678,
+			v1.ResourceStorage: 1.0,
+		}),
+	}
+
+	assert.Equal(t, overcommitRatioReporterPluginName, p.Name())
+
+	p.Start()
+	assert.True(t, p.started)
+
+	p.Stop()
+	assert.False(t, p.started)
+}
+
+func NewFakeOvercommitManager(data map[v1.ResourceName]float64) OvercommitManager {
+	return &FakeOvercommitManager{
+		data: data,
+	}
+}
+
+type FakeOvercommitManager struct {
+	data map[v1.ResourceName]float64
+}
+
+func (f *FakeOvercommitManager) GetOvercommitRatio() (map[v1.ResourceName]float64, error) {
+	if len(f.data) == 0 {
+		return nil, fmt.Errorf("empty overcommit ratio data")
+	}
+	return f.data, nil
+}

--- a/pkg/agent/sysadvisor/sysadvisor.go
+++ b/pkg/agent/sysadvisor/sysadvisor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/inference"
 	metacacheplugin "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/metacache"
 	metricemitter "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/metric-emitter"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/overcommitmentaware"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
 	"github.com/kubewharf/katalyst-core/pkg/config"
@@ -45,6 +46,7 @@ func init() {
 	pkgplugin.RegisterAdvisorPlugin(types.AdvisorPluginNameMetaCache, metacacheplugin.NewMetaCachePlugin)
 	pkgplugin.RegisterAdvisorPlugin(types.AdvisorPluginNameMetricEmitter, metricemitter.NewCustomMetricEmitter)
 	pkgplugin.RegisterAdvisorPlugin(types.AdvisorPluginNameInference, inference.NewInferencePlugin)
+	pkgplugin.RegisterAdvisorPlugin(types.AdvisorPluginNameOvercommitAware, overcommitmentaware.NewOvercommitmentAwarePlugin)
 }
 
 // AdvisorAgent for sysadvisor

--- a/pkg/agent/sysadvisor/types/types.go
+++ b/pkg/agent/sysadvisor/types/types.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	AdvisorPluginNameQoSAware      = "qos_aware"
-	AdvisorPluginNameMetaCache     = "metacache"
-	AdvisorPluginNameMetricEmitter = "metric_emitter"
-	AdvisorPluginNameInference     = "inference"
+	AdvisorPluginNameQoSAware        = "qos_aware"
+	AdvisorPluginNameMetaCache       = "metacache"
+	AdvisorPluginNameMetricEmitter   = "metric_emitter"
+	AdvisorPluginNameInference       = "inference"
+	AdvisorPluginNameOvercommitAware = "overcommit_aware"
 )
 
 // QoSResourceName describes different resources under qos aware control

--- a/pkg/config/agent/sysadvisor/overcommit/overcommit_aware_plugin.go
+++ b/pkg/config/agent/sysadvisor/overcommit/overcommit_aware_plugin.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package overcommit
+
+import "github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/overcommit/realtime"
+
+// OvercommitAwarePluginConfiguration stores configurations of overcommit aware plugin
+type OvercommitAwarePluginConfiguration struct {
+	*realtime.RealtimeOvercommitConfiguration
+}
+
+// NewOvercommitAwarePluginConfiguration creates a new overcommit aware plugin configuration
+func NewOvercommitAwarePluginConfiguration() *OvercommitAwarePluginConfiguration {
+	return &OvercommitAwarePluginConfiguration{
+		RealtimeOvercommitConfiguration: realtime.NewRealtimeOvercommitConfiguration(),
+	}
+}

--- a/pkg/config/agent/sysadvisor/overcommit/realtime/realtime.go
+++ b/pkg/config/agent/sysadvisor/overcommit/realtime/realtime.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package realtime
+
+import "time"
+
+type RealtimeOvercommitConfiguration struct {
+	SyncPeriod time.Duration
+
+	SyncPodTimeout time.Duration
+
+	TargetCPULoad    float64
+	TargetMemoryLoad float64
+
+	EstimatedPodCPULoad    float64
+	EstimatedPodMemoryLoad float64
+
+	CPUMetricsToGather    []string
+	MemoryMetricsToGather []string
+}
+
+func NewRealtimeOvercommitConfiguration() *RealtimeOvercommitConfiguration {
+	return &RealtimeOvercommitConfiguration{
+		SyncPeriod:     10 * time.Second,
+		SyncPodTimeout: 2 * time.Second,
+
+		TargetCPULoad:          0.6,
+		TargetMemoryLoad:       0.8,
+		EstimatedPodCPULoad:    0.4,
+		EstimatedPodMemoryLoad: 0.8,
+
+		CPUMetricsToGather:    []string{},
+		MemoryMetricsToGather: []string{},
+	}
+}

--- a/pkg/config/agent/sysadvisor/sysadvisor_base.go
+++ b/pkg/config/agent/sysadvisor/sysadvisor_base.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/inference"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/metacache"
 	metricemitter "github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/metric-emitter"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/overcommit"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/qosaware"
 )
 
@@ -40,14 +41,16 @@ type SysAdvisorPluginsConfiguration struct {
 	*metacache.MetaCachePluginConfiguration
 	*metricemitter.MetricEmitterPluginConfiguration
 	*inference.InferencePluginConfiguration
+	*overcommit.OvercommitAwarePluginConfiguration
 }
 
 // NewSysAdvisorPluginsConfiguration creates a new sysadvisor plugins configuration.
 func NewSysAdvisorPluginsConfiguration() *SysAdvisorPluginsConfiguration {
 	return &SysAdvisorPluginsConfiguration{
-		QoSAwarePluginConfiguration:      qosaware.NewQoSAwarePluginConfiguration(),
-		MetaCachePluginConfiguration:     metacache.NewMetaCachePluginConfiguration(),
-		MetricEmitterPluginConfiguration: metricemitter.NewMetricEmitterPluginConfiguration(),
-		InferencePluginConfiguration:     inference.NewInferencePluginConfiguration(),
+		QoSAwarePluginConfiguration:        qosaware.NewQoSAwarePluginConfiguration(),
+		MetaCachePluginConfiguration:       metacache.NewMetaCachePluginConfiguration(),
+		MetricEmitterPluginConfiguration:   metricemitter.NewMetricEmitterPluginConfiguration(),
+		InferencePluginConfiguration:       inference.NewInferencePluginConfiguration(),
+		OvercommitAwarePluginConfiguration: overcommit.NewOvercommitAwarePluginConfiguration(),
 	}
 }

--- a/pkg/controller/overcommit/node/handler.go
+++ b/pkg/controller/overcommit/node/handler.go
@@ -18,12 +18,14 @@ package node
 
 import (
 	"fmt"
+	"reflect"
 
 	v1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	nodev1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
@@ -114,6 +116,49 @@ func (nc *NodeOvercommitController) updateNode(old, new interface{}) {
 	nc.enqueueNode(newNode)
 }
 
+func (nc *NodeOvercommitController) addCNR(obj interface{}) {
+	cnr, ok := obj.(*nodev1alpha1.CustomNodeResource)
+	if !ok {
+		klog.Errorf("cannot convert obj to *CustomNodeResource: %v", obj)
+		return
+	}
+
+	if len(cnr.Annotations) == 0 {
+		klog.V(6).Infof("cnr without annotation, skip")
+		return
+	}
+	_, cpuOk := cnr.Annotations[consts.NodeAnnotationCPUOvercommitRatioKey]
+	_, memOk := cnr.Annotations[consts.NodeAnnotationMemoryOvercommitRatioKey]
+	if !cpuOk && !memOk {
+		klog.V(6).Infof("cnr without overcommit ratio, skip")
+		return
+	}
+
+	klog.V(4).Infof("[noc] notice addition of CNR %s", cnr.Name)
+	nc.enqueueCNR(cnr)
+}
+
+func (nc *NodeOvercommitController) updateCNR(old, new interface{}) {
+	oldCNR, ok := old.(*nodev1alpha1.CustomNodeResource)
+	if !ok {
+		klog.Errorf("cannot convert obj to CustomNodeResource: %v", old)
+		return
+	}
+
+	newCNR, ok := new.(*nodev1alpha1.CustomNodeResource)
+	if !ok {
+		klog.Errorf("cannot convert obj to CustomNodeResource: %v", new)
+		return
+	}
+
+	if reflect.DeepEqual(newCNR.Annotations, oldCNR.Annotations) {
+		return
+	}
+
+	nc.enqueueCNR(newCNR)
+	klog.V(4).Infof("[noc] notice update of CNR %s", newCNR.Name)
+}
+
 func (nc *NodeOvercommitController) enqueueNodeOvercommitConfig(noc *v1alpha1.NodeOvercommitConfig, eventType eventType) {
 	if noc == nil {
 		klog.Warning("[noc] trying to enqueue a nil config")
@@ -148,4 +193,19 @@ func (nc *NodeOvercommitController) enqueueNode(node *v1.Node) {
 		nodeKey:   key,
 		eventType: nodeEvent,
 	})
+}
+
+func (nc *NodeOvercommitController) enqueueCNR(cnr *nodev1alpha1.CustomNodeResource) {
+	if cnr == nil {
+		klog.Warning("[noc] trying to enqueue a nil cnr")
+		return
+	}
+
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(cnr)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", cnr, err))
+		return
+	}
+
+	nc.cnrSyncQueue.Add(key)
 }

--- a/pkg/controller/overcommit/node/node_test.go
+++ b/pkg/controller/overcommit/node/node_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	cliflag "k8s.io/component-base/cli/flag"
 
+	nodev1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/apis/overcommit/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/consts"
 	katalyst_base "github.com/kubewharf/katalyst-core/cmd/base"
@@ -70,10 +71,13 @@ type testCase struct {
 	name          string
 	initNodes     []*corev1.Node
 	initConfigs   []*v1alpha1.NodeOvercommitConfig
+	initCNR       []*nodev1alpha1.CustomNodeResource
 	updateNodes   []*corev1.Node
 	updateConfigs []*v1alpha1.NodeOvercommitConfig
+	updateCNR     []*nodev1alpha1.CustomNodeResource
 	addNodes      []*corev1.Node
 	addConfigs    []*v1alpha1.NodeOvercommitConfig
+	addCNR        []*nodev1alpha1.CustomNodeResource
 	deleteNodes   []string
 	deleteConfigs []string
 	result        map[string]map[string]string
@@ -85,6 +89,24 @@ var defaultInitNodes = func() []*corev1.Node {
 		makeNode("node2", map[string]string{consts.NodeOvercommitSelectorKey: "pool2"}),
 		makeNode("node3", map[string]string{consts.NodeOvercommitSelectorKey: "pool1"}),
 		makeNode("node4", map[string]string{consts.NodeOvercommitSelectorKey: "pool3"}),
+	}
+}()
+
+var defaultInitCNR = func() []*nodev1alpha1.CustomNodeResource {
+	return []*nodev1alpha1.CustomNodeResource{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1", Annotations: map[string]string{
+			consts.NodeAnnotationCPUOvercommitRatioKey:    "1",
+			consts.NodeAnnotationMemoryOvercommitRatioKey: "1",
+		}}}, {ObjectMeta: metav1.ObjectMeta{Name: "node2", Annotations: map[string]string{
+			consts.NodeAnnotationCPUOvercommitRatioKey:    "1",
+			consts.NodeAnnotationMemoryOvercommitRatioKey: "1",
+		}}}, {ObjectMeta: metav1.ObjectMeta{Name: "node3", Annotations: map[string]string{
+			consts.NodeAnnotationCPUOvercommitRatioKey:    "3",
+			consts.NodeAnnotationMemoryOvercommitRatioKey: "3",
+		}}}, {ObjectMeta: metav1.ObjectMeta{Name: "node4", Annotations: map[string]string{
+			consts.NodeAnnotationCPUOvercommitRatioKey:    "2",
+			consts.NodeAnnotationMemoryOvercommitRatioKey: "2",
+		}}},
 	}
 }()
 
@@ -186,6 +208,58 @@ var testCases = []testCase{
 			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
 		},
 	},
+	{
+		name:      "init: node and cnr, add config",
+		initNodes: defaultInitNodes,
+		initCNR:   defaultInitCNR,
+		addConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeSelectorNoc("config-selector", "2", "2", "pool1"),
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "add CNR",
+		initNodes: defaultInitNodes,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeSelectorNoc("config-selector", "2", "2", "pool1"),
+		},
+		addCNR: defaultInitCNR,
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
+	{
+		name:      "update CNR",
+		initNodes: defaultInitNodes,
+		initCNR:   defaultInitCNR,
+		initConfigs: []*v1alpha1.NodeOvercommitConfig{
+			makeSelectorNoc("config-selector", "2", "2", "pool1"),
+		},
+		updateCNR: []*nodev1alpha1.CustomNodeResource{
+			{ObjectMeta: metav1.ObjectMeta{Name: "node3", Annotations: map[string]string{
+				consts.NodeAnnotationCPUOvercommitRatioKey:    "1.5",
+				consts.NodeAnnotationMemoryOvercommitRatioKey: "1.5",
+			}}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "node1", Annotations: map[string]string{
+				consts.NodeAnnotationCPUOvercommitRatioKey:    "3",
+				consts.NodeAnnotationMemoryOvercommitRatioKey: "3",
+			}}},
+		},
+		result: map[string]map[string]string{
+			"node1": {consts.NodeAnnotationCPUOvercommitRatioKey: "2", consts.NodeAnnotationMemoryOvercommitRatioKey: "2"},
+			"node2": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+			"node3": {consts.NodeAnnotationCPUOvercommitRatioKey: "1.5", consts.NodeAnnotationMemoryOvercommitRatioKey: "1.5"},
+			"node4": {consts.NodeAnnotationCPUOvercommitRatioKey: "1", consts.NodeAnnotationMemoryOvercommitRatioKey: "1"},
+		},
+	},
 }
 
 func TestReconcile(t *testing.T) {
@@ -216,6 +290,10 @@ func TestReconcile(t *testing.T) {
 				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
+			for _, cnr := range tc.initCNR {
+				_, err = controlCtx.Client.InternalClient.NodeV1alpha1().CustomNodeResources().Create(ctx, cnr, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
 			for _, config := range tc.initConfigs {
 				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
 				assert.NoError(t, err)
@@ -234,6 +312,10 @@ func TestReconcile(t *testing.T) {
 				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
+			for _, cnr := range tc.addCNR {
+				_, err = controlCtx.Client.InternalClient.NodeV1alpha1().CustomNodeResources().Create(ctx, cnr, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
 			for _, config := range tc.addConfigs {
 				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
 				assert.NoError(t, err)
@@ -244,6 +326,10 @@ func TestReconcile(t *testing.T) {
 			}
 			for _, config := range tc.updateConfigs {
 				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Update(ctx, config, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, cnr := range tc.updateCNR {
+				_, err = controlCtx.Client.InternalClient.NodeV1alpha1().CustomNodeResources().Update(ctx, cnr, metav1.UpdateOptions{})
 				assert.NoError(t, err)
 			}
 			for _, node := range tc.deleteNodes {
@@ -292,6 +378,10 @@ func TestRun(t *testing.T) {
 				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
+			for _, cnr := range tc.initCNR {
+				_, err = controlCtx.Client.InternalClient.NodeV1alpha1().CustomNodeResources().Create(ctx, cnr, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
 			for _, config := range tc.initConfigs {
 				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
 				assert.NoError(t, err)
@@ -309,12 +399,20 @@ func TestRun(t *testing.T) {
 				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Create(ctx, config, metav1.CreateOptions{})
 				assert.NoError(t, err)
 			}
+			for _, cnr := range tc.addCNR {
+				_, err = controlCtx.Client.InternalClient.NodeV1alpha1().CustomNodeResources().Create(ctx, cnr, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
 			for _, node := range tc.updateNodes {
 				_, err = controlCtx.Client.KubeClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
 				assert.NoError(t, err)
 			}
 			for _, config := range tc.updateConfigs {
 				_, err = controlCtx.Client.InternalClient.OvercommitV1alpha1().NodeOvercommitConfigs().Update(ctx, config, metav1.UpdateOptions{})
+				assert.NoError(t, err)
+			}
+			for _, cnr := range tc.updateCNR {
+				_, err = controlCtx.Client.InternalClient.NodeV1alpha1().CustomNodeResources().Update(ctx, cnr, metav1.UpdateOptions{})
 				assert.NoError(t, err)
 			}
 			for _, node := range tc.deleteNodes {


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

What this PR does / why we need it:
katalyst-agent: Add overcommitment aware advisor plugin, calculate node CPU and memory overcommit ratio by realtime metrics and pod requests resource. These datas will be reported to Apiserver in KCNR annotation.
katalyst-controller: watch KCNR and patch the smaller value between user set and node reported overcommit ratio to node.