### PR TITLE
fix(metaserver): disalbe metrics expire check by default

### DIFF
--- a/cmd/katalyst-agent/app/options/global/metaserver.go
+++ b/cmd/katalyst-agent/app/options/global/metaserver.go
@@ -48,7 +48,7 @@ const (
 	defaultAPIAuthTokenFile             = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	defaultKubeletPodsEndpoint          = "/pods"
 	defaultKubeletSummaryEndpoint       = "/stats/summary"
-	defaultMetricInsurancePeriod        = 120 * time.Second
+	defaultMetricInsurancePeriod        = 0 * time.Second
 )
 
 const (


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
Disable metrics expire check by default.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
