### PR TITLE
feat(metric): add rodan metric provisioner

### DIFF
--- a/cmd/katalyst-agent/app/options/metaserver/metaserver.go
+++ b/cmd/katalyst-agent/app/options/metaserver/metaserver.go
@@ -56,6 +56,8 @@ const defaultCustomNodeResourceCacheTTL = 15 * time.Second
 
 const defaultCustomNodeConfigCacheTTL = 15 * time.Second
 
+const defaultRodanServerPort = 9102
+
 // MetaServerOptions holds all the configurations for metaserver.
 // we will not try to separate this structure into several individual
 // structures since it will not be used directly by other components; instead,
@@ -79,6 +81,7 @@ type MetaServerOptions struct {
 	// configurations for metric-fetcher
 	MetricInsurancePeriod time.Duration
 	MetricProvisions      []string
+	RodanServerPort       int
 
 	// configurations for pod-cache
 	KubeletPodCacheSyncPeriod    time.Duration
@@ -109,6 +112,7 @@ func NewMetaServerOptions() *MetaServerOptions {
 
 		MetricInsurancePeriod: defaultMetricInsurancePeriod,
 		MetricProvisions:      []string{metaserver.MetricProvisionerMalachite, metaserver.MetricProvisionerKubelet},
+		RodanServerPort:       defaultRodanServerPort,
 
 		KubeletPodCacheSyncPeriod:    defaultKubeletPodCacheSyncPeriod,
 		KubeletPodCacheSyncMaxRate:   defaultKubeletPodCacheSyncMaxRate,
@@ -150,6 +154,8 @@ func (o *MetaServerOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"The meta server return metric data and MetricDataExpired if the update time of metric data is earlier than this period.")
 	fs.StringSliceVar(&o.MetricProvisions, "metric-provisioners", o.MetricProvisions,
 		"The provisioners that should be enabled by default")
+	fs.IntVar(&o.RodanServerPort, "rodan-server-port", o.RodanServerPort,
+		"The rodan metric provisioner server port")
 
 	fs.DurationVar(&o.KubeletPodCacheSyncPeriod, "kubelet-pod-cache-sync-period", o.KubeletPodCacheSyncPeriod,
 		"The period of meta server to sync pod from kubelet 10255 port")
@@ -183,6 +189,7 @@ func (o *MetaServerOptions) ApplyTo(c *metaserver.MetaServerConfiguration) error
 
 	c.MetricInsurancePeriod = o.MetricInsurancePeriod
 	c.MetricProvisions = o.MetricProvisions
+	c.RodanServerPort = o.RodanServerPort
 
 	c.KubeletPodCacheSyncPeriod = o.KubeletPodCacheSyncPeriod
 	c.KubeletPodCacheSyncMaxRate = rate.Limit(o.KubeletPodCacheSyncMaxRate)

--- a/pkg/config/agent/metaserver/agent.go
+++ b/pkg/config/agent/metaserver/agent.go
@@ -26,6 +26,7 @@ const (
 	MetricProvisionerMalachite = "malachite"
 	MetricProvisionerCgroup    = "cgroup"
 	MetricProvisionerKubelet   = "kubelet"
+	MetricProvisionerRodan     = "rodan"
 )
 
 type MetricConfiguration struct {

--- a/pkg/config/agent/metaserver/agent.go
+++ b/pkg/config/agent/metaserver/agent.go
@@ -32,6 +32,11 @@ const (
 type MetricConfiguration struct {
 	MetricInsurancePeriod time.Duration
 	MetricProvisions      []string
+	*RodanMetricConfiguration
+}
+
+type RodanMetricConfiguration struct {
+	RodanServerPort int
 }
 
 type PodConfiguration struct {
@@ -65,10 +70,12 @@ type AgentConfiguration struct {
 
 func NewAgentConfiguration() *AgentConfiguration {
 	return &AgentConfiguration{
-		MetricConfiguration: &MetricConfiguration{},
-		PodConfiguration:    &PodConfiguration{},
-		NodeConfiguration:   &NodeConfiguration{},
-		CNRConfiguration:    &CNRConfiguration{},
-		CNCConfiguration:    &CNCConfiguration{},
+		MetricConfiguration: &MetricConfiguration{
+			RodanMetricConfiguration: &RodanMetricConfiguration{},
+		},
+		PodConfiguration:  &PodConfiguration{},
+		NodeConfiguration: &NodeConfiguration{},
+		CNRConfiguration:  &CNRConfiguration{},
+		CNCConfiguration:  &CNCConfiguration{},
 	}
 }

--- a/pkg/metaserver/agent/metric/metric_impl.go
+++ b/pkg/metaserver/agent/metric/metric_impl.go
@@ -233,7 +233,7 @@ func NewMetricsFetcher(baseConf *global.BaseConfiguration, metricConf *metaserve
 	var enabledProvisioners []types.MetricsProvisioner
 	for _, name := range metricConf.MetricProvisions {
 		if f, ok := registeredProvisioners[name]; ok {
-			enabledProvisioners = append(enabledProvisioners, f(baseConf, emitter, podFetcher, metricStore))
+			enabledProvisioners = append(enabledProvisioners, f(baseConf, metricConf, emitter, podFetcher, metricStore))
 		}
 	}
 

--- a/pkg/metaserver/agent/metric/metric_provisoner.go
+++ b/pkg/metaserver/agent/metric/metric_provisoner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/cgroup"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/kubelet"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
@@ -34,6 +35,7 @@ func init() {
 	RegisterProvisioners(metaserver.MetricProvisionerMalachite, malachite.NewMalachiteMetricsProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerKubelet, kubelet.NewKubeletSummaryProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerCgroup, cgroup.NewCGroupMetricsProvisioner)
+	RegisterProvisioners(metaserver.MetricProvisionerRodan, rodan.NewRodanMetricsProvisioner)
 }
 
 type ProvisionerInitFunc func(baseConf *global.BaseConfiguration,

--- a/pkg/metaserver/agent/metric/metric_provisoner.go
+++ b/pkg/metaserver/agent/metric/metric_provisoner.go
@@ -38,7 +38,7 @@ func init() {
 	RegisterProvisioners(metaserver.MetricProvisionerRodan, rodan.NewRodanMetricsProvisioner)
 }
 
-type ProvisionerInitFunc func(baseConf *global.BaseConfiguration,
+type ProvisionerInitFunc func(baseConf *global.BaseConfiguration, metricConf *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter, fetcher pod.PodFetcher, metricStore *utilmetric.MetricStore) types.MetricsProvisioner
 
 // provisioners stores the initializing function for each-provisioner

--- a/pkg/metaserver/agent/metric/provisioner/cgroup/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/cgroup/provisioner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
@@ -27,7 +28,7 @@ import (
 )
 
 // NewCGroupMetricsProvisioner returns the default implementation of CGroup.
-func NewCGroupMetricsProvisioner(baseConf *global.BaseConfiguration,
+func NewCGroupMetricsProvisioner(baseConf *global.BaseConfiguration, _ *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter, _ pod.PodFetcher, metricStore *utilmetric.MetricStore) types.MetricsProvisioner {
 	return &CGroupMetricsProvisioner{
 		metricStore: metricStore,

--- a/pkg/metaserver/agent/metric/provisioner/kubelet/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/kubelet/provisioner.go
@@ -24,6 +24,7 @@ import (
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/kubelet/client"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
@@ -36,7 +37,7 @@ const (
 	metricsNamKubeletSummaryUnHealthy = "kubelet_summary_unhealthy"
 )
 
-func NewKubeletSummaryProvisioner(baseConf *global.BaseConfiguration,
+func NewKubeletSummaryProvisioner(baseConf *global.BaseConfiguration, _ *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter, _ pod.PodFetcher, metricStore *utilmetric.MetricStore) types.MetricsProvisioner {
 	return &KubeletSummaryProvisioner{
 		metricStore: metricStore,

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/client"
 	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
@@ -53,7 +54,7 @@ const (
 )
 
 // NewMalachiteMetricsProvisioner returns the default implementation of MetricsFetcher.
-func NewMalachiteMetricsProvisioner(baseConf *global.BaseConfiguration,
+func NewMalachiteMetricsProvisioner(baseConf *global.BaseConfiguration, _ *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter, fetcher pod.PodFetcher, metricStore *utilmetric.MetricStore) types.MetricsProvisioner {
 	return &MalachiteMetricsProvisioner{
 		malachiteClient: client.NewMalachiteClient(fetcher),

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
 	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
@@ -32,7 +33,7 @@ func Test_noneExistMetricsProvisioner(t *testing.T) {
 	store := utilmetric.NewMetricStore()
 
 	var err error
-	implement := NewMalachiteMetricsProvisioner(&global.BaseConfiguration{}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store)
+	implement := NewMalachiteMetricsProvisioner(&global.BaseConfiguration{}, &metaserver.MetricConfiguration{}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store)
 
 	fakeSystemCompute := &malachitetypes.SystemComputeData{
 		CPU: []malachitetypes.CPU{

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client.go
@@ -33,10 +33,10 @@ type RodanClient struct {
 	metricFunc MetricFunc
 }
 
-func NewRodanClient(fetcher pod.PodFetcher, metricFunc MetricFunc) *RodanClient {
+func NewRodanClient(fetcher pod.PodFetcher, metricFunc MetricFunc, port int) *RodanClient {
 	urls := make(map[string]string)
 	for path := range types.MetricsMap {
-		urls[path] = fmt.Sprintf("http://localhost:%d%s", types.RodanServerPort, path)
+		urls[path] = fmt.Sprintf("http://localhost:%d%s", port, path)
 	}
 
 	if metricFunc == nil {

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+)
+
+type RodanClient struct {
+	urls map[string]string
+
+	fetcher pod.PodFetcher
+
+	metricFunc MetricFunc
+}
+
+func NewRodanClient(fetcher pod.PodFetcher, metricFunc MetricFunc) *RodanClient {
+	urls := make(map[string]string)
+	for path := range types.MetricsMap {
+		urls[path] = fmt.Sprintf("http://localhost:%d%s", types.RodanServerPort, path)
+	}
+
+	if metricFunc == nil {
+		metricFunc = getMetrics
+	}
+
+	return &RodanClient{
+		fetcher:    fetcher,
+		urls:       urls,
+		metricFunc: metricFunc,
+	}
+}
+
+type MetricFunc func(url string, params map[string]string) ([]byte, error)
+
+func getMetrics(url string, params map[string]string) ([]byte, error) {
+	if len(params) != 0 {
+		firstParam := true
+
+		for k, v := range params {
+			if firstParam {
+				url += "?"
+				firstParam = false
+			} else {
+				url += "&"
+			}
+			url = fmt.Sprintf("%s%s=%s", url, k, v)
+		}
+	}
+
+	rsp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get metrics, url: %v, err: %v", url, err)
+	}
+	defer func() { _ = rsp.Body.Close() }()
+
+	if rsp.StatusCode != 200 {
+		return nil, fmt.Errorf("invalid http response status code %d, status: %s, url: %s", rsp.StatusCode, rsp.Status, url)
+	}
+
+	return io.ReadAll(rsp.Body)
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/types"
+)
+
+func (c *RodanClient) GetNodeMemoryStats() ([]types.Cell, error) {
+	url := c.urls[types.NodeMemoryPath]
+
+	data, err := c.metricFunc(url, nil)
+	if err != nil {
+		klog.Errorf("GetNodeMemoryStats fail, err: %v", err)
+		return nil, err
+	}
+
+	rsp := &types.NodeMemoryResponse{}
+	if err = json.Unmarshal(data, rsp); err != nil {
+		klog.Errorf("faild to unmarshal node memory response, err: %v, data: %v", err, string(data))
+		return nil, err
+	}
+
+	if len(rsp.Data) == 0 {
+		err = fmt.Errorf("GetNodeMemoryStats fail, empty data")
+		klog.Error(err)
+		return nil, err
+	}
+
+	return rsp.Data, nil
+}
+
+func (c *RodanClient) GetNodeCgroupMemoryStats() ([]types.Cell, error) {
+	url := c.urls[types.NodeCgroupMemoryPath]
+
+	data, err := c.metricFunc(url, nil)
+	if err != nil {
+		klog.Errorf("GetNodeNUMAMemoryStatus fail, err: %v", err)
+		return nil, err
+	}
+
+	rsp := &types.NodeCgroupMemoryResponse{}
+	if err = json.Unmarshal(data, rsp); err != nil {
+		klog.Errorf("faild to unmarshal node cgroup memory response, err: %v, data: %v", err, string(data))
+		return nil, err
+	}
+
+	return rsp.Data, err
+}
+
+func (c *RodanClient) GetNUMAMemoryStats() (map[int][]types.Cell, error) {
+	url := c.urls[types.NumaMemoryPath]
+
+	data, err := c.metricFunc(url, nil)
+	if err != nil {
+		klog.Errorf("GetNUMAMemoryStats fail, err: %v", err)
+		return nil, err
+	}
+
+	rsp := &types.NUMAMemoryResponse{}
+	if err = json.Unmarshal(data, rsp); err != nil {
+		err = fmt.Errorf("failed to unmarshal numa memory response, err: %v, data: %v", err, string(data))
+		return nil, err
+	}
+
+	res := make(map[int][]types.Cell)
+	for _, cell := range rsp.Data {
+		numaNode, metric, err := types.ParseNumastatKey(cell.Key)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := res[numaNode]; !ok {
+			res[numaNode] = make([]types.Cell, 0)
+		}
+		res[numaNode] = append(res[numaNode], types.Cell{
+			Key: metric,
+			Val: cell.Val,
+		})
+	}
+
+	return res, err
+}
+
+func (c *RodanClient) GetCoreCPUStats() (map[int][]types.Cell, error) {
+	url := c.urls[types.NodeCPUPath]
+
+	data, err := c.metricFunc(url, nil)
+	if err != nil {
+		klog.Errorf("GetCoreCPUStats fail, err: %v", err)
+		return nil, err
+	}
+
+	rsp := &types.CoreCPUResponse{}
+	if err = json.Unmarshal(data, rsp); err != nil {
+		err = fmt.Errorf("failed to unmarshal core cpu response, err: %v, data: %v", err, string(data))
+		return nil, err
+	}
+
+	res := make(map[int][]types.Cell)
+	for _, cell := range rsp.Data {
+		cpu, metric, err := types.ParseCorestatKey(cell.Key)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := res[cpu]; !ok {
+			res[cpu] = make([]types.Cell, 0)
+		}
+		res[cpu] = append(res[cpu], types.Cell{
+			Key: metric,
+			Val: cell.Val,
+		})
+	}
+
+	return res, err
+}
+
+func (c *RodanClient) GetNodeSysctl() ([]types.Cell, error) {
+	url := c.urls[types.NodeSysctlPath]
+
+	data, err := c.metricFunc(url, nil)
+	if err != nil {
+		klog.Errorf("GetNodeSysctl fail, err: %v", err)
+		return nil, err
+	}
+
+	rsp := &types.NodeSysctlResponse{}
+	if err = json.Unmarshal(data, rsp); err != nil {
+		err = fmt.Errorf("failed to unmarshal node sysctl response, err: %v, data: %v", err, string(data))
+		return nil, err
+	}
+
+	if len(rsp.Data) == 0 {
+		err = fmt.Errorf("GetNodeSysctl fail, empty data")
+		klog.Error(err)
+		return nil, err
+	}
+
+	return rsp.Data, nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNodeMemoryStats(t *testing.T) {
+	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":[{"key":"memory_swaptotal","val":0},{"key":"memory_sreclaimable","val":573520},{"key":"memory_shmem","val":1643536},{"key":"memory_writeback","val":0},{"key":"memory_memavailable","val":19710408},{"key":"memory_pgsteal_kswapd","val":7067178},{"key":"memory_cached","val":16703864},{"key":"memory_memtotal","val":32614152},{"key":"memory_swapfree","val":0},{"key":"memory_buffers","val":360688},{"key":"memory_memfree","val":14053836},{"key":"memory_dirty","val":1124}]}`), nil
+	})
+
+	res, err := ic.GetNodeMemoryStats()
+	require.NoError(t, err)
+	require.Equal(t, 12, len(res))
+}
+
+func TestGetNUMAMemoryStats(t *testing.T) {
+	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":[{"key":"numastat_node0_memfree","val":14549598208},{"key":"numastat_node0_memtotal","val":33396891648}]}`), nil
+	})
+
+	res, err := ic.GetNUMAMemoryStats()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res))
+	require.NotNil(t, res[0])
+	require.Equal(t, 2, len(res[0]))
+}
+
+func TestGetNodeCgroupMemoryStats(t *testing.T) {
+	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":[{"key":"qosgroupmem_besteffort_memory_rss","val":112414720},{"key":"qosgroupmem_besteffort_memory_usage","val":1244418048},{"key":"qosgroupmem_burstable_memory_rss","val":183828480},{"key":"qosgroupmem_burstable_memory_usage","val":377950208}]}`), nil
+	})
+
+	res, err := ic.GetNodeCgroupMemoryStats()
+	require.NoError(t, err)
+	require.Equal(t, 4, len(res))
+}
+
+func TestGetCoreCPUStats(t *testing.T) {
+	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":[{"key":"percorecpu_cpu5_sched_wait","val":0},{"key":"percorecpu_cpu0_usage","val":19},{"key":"percorecpu_cpu3_sched_wait","val":0},{"key":"percorecpu_cpu7_usage","val":53},{"key":"percorecpu_cpu0_sched_wait","val":0},{"key":"percorecpu_cpu6_usage","val":31},{"key":"percorecpu_cpu7_sched_wait","val":0},{"key":"percorecpu_cpu2_usage","val":23},{"key":"percorecpu_cpu1_usage","val":28},{"key":"percorecpu_cpu6_sched_wait","val":0},{"key":"percorecpu_cpu3_usage","val":78},{"key":"percorecpu_cpu4_sched_wait","val":0},{"key":"percorecpu_cpu2_sched_wait","val":0},{"key":"percorecpu_cpu1_sched_wait","val":0},{"key":"percorecpu_cpu5_usage","val":64},{"key":"percorecpu_cpu4_usage","val":32}]}`), nil
+	})
+
+	res, err := ic.GetCoreCPUStats()
+	require.NoError(t, err)
+	require.Equal(t, 8, len(res))
+	require.NotNil(t, res[0])
+	require.Equal(t, 2, len(res[0]))
+}
+
+func TestGetNodeSysctl(t *testing.T) {
+	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":[{"key":"sysctl_vm_watermark_scale_factor","val":1000},{"key":"sysctl_tcp_mem_pressure","val":507145},{"key":"sysctl_tcp_mem_extreme","val":760716},{"key":"sysctl_tcp_mem_original","val":380358}]}`), nil
+	})
+
+	res, err := ic.GetNodeSysctl()
+	require.NoError(t, err)
+	require.Equal(t, 4, len(res))
+}
+
+type FakePodFetcher struct {
+	GetPodFunc func(ctx context.Context, podUID string) (*v1.Pod, error)
+}
+
+func (f *FakePodFetcher) Run(ctx context.Context) {
+	return
+}
+
+func (f *FakePodFetcher) GetContainerID(podUID, containerName string) (string, error) {
+	return "", nil
+}
+
+func (f *FakePodFetcher) GetContainerSpec(podUID, containerName string) (*v1.Container, error) {
+	return nil, nil
+}
+
+func (f *FakePodFetcher) GetPod(ctx context.Context, podUID string) (*v1.Pod, error) {
+	return f.GetPodFunc(ctx, podUID)
+}
+
+func (f *FakePodFetcher) GetPodList(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error) {
+	return nil, nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 func TestGetNodeMemoryStats(t *testing.T) {
+	t.Parallel()
 	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":[{"key":"memory_swaptotal","val":0},{"key":"memory_sreclaimable","val":573520},{"key":"memory_shmem","val":1643536},{"key":"memory_writeback","val":0},{"key":"memory_memavailable","val":19710408},{"key":"memory_pgsteal_kswapd","val":7067178},{"key":"memory_cached","val":16703864},{"key":"memory_memtotal","val":32614152},{"key":"memory_swapfree","val":0},{"key":"memory_buffers","val":360688},{"key":"memory_memfree","val":14053836},{"key":"memory_dirty","val":1124}]}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetNodeMemoryStats()
 	require.NoError(t, err)
@@ -36,9 +37,10 @@ func TestGetNodeMemoryStats(t *testing.T) {
 }
 
 func TestGetNUMAMemoryStats(t *testing.T) {
+	t.Parallel()
 	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":[{"key":"numastat_node0_memfree","val":14549598208},{"key":"numastat_node0_memtotal","val":33396891648}]}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetNUMAMemoryStats()
 	require.NoError(t, err)
@@ -48,9 +50,10 @@ func TestGetNUMAMemoryStats(t *testing.T) {
 }
 
 func TestGetNodeCgroupMemoryStats(t *testing.T) {
+	t.Parallel()
 	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":[{"key":"qosgroupmem_besteffort_memory_rss","val":112414720},{"key":"qosgroupmem_besteffort_memory_usage","val":1244418048},{"key":"qosgroupmem_burstable_memory_rss","val":183828480},{"key":"qosgroupmem_burstable_memory_usage","val":377950208}]}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetNodeCgroupMemoryStats()
 	require.NoError(t, err)
@@ -58,9 +61,10 @@ func TestGetNodeCgroupMemoryStats(t *testing.T) {
 }
 
 func TestGetCoreCPUStats(t *testing.T) {
+	t.Parallel()
 	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":[{"key":"percorecpu_cpu5_sched_wait","val":0},{"key":"percorecpu_cpu0_usage","val":19},{"key":"percorecpu_cpu3_sched_wait","val":0},{"key":"percorecpu_cpu7_usage","val":53},{"key":"percorecpu_cpu0_sched_wait","val":0},{"key":"percorecpu_cpu6_usage","val":31},{"key":"percorecpu_cpu7_sched_wait","val":0},{"key":"percorecpu_cpu2_usage","val":23},{"key":"percorecpu_cpu1_usage","val":28},{"key":"percorecpu_cpu6_sched_wait","val":0},{"key":"percorecpu_cpu3_usage","val":78},{"key":"percorecpu_cpu4_sched_wait","val":0},{"key":"percorecpu_cpu2_sched_wait","val":0},{"key":"percorecpu_cpu1_sched_wait","val":0},{"key":"percorecpu_cpu5_usage","val":64},{"key":"percorecpu_cpu4_usage","val":32}]}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetCoreCPUStats()
 	require.NoError(t, err)
@@ -70,9 +74,10 @@ func TestGetCoreCPUStats(t *testing.T) {
 }
 
 func TestGetNodeSysctl(t *testing.T) {
+	t.Parallel()
 	ic := NewRodanClient(&FakePodFetcher{}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":[{"key":"sysctl_vm_watermark_scale_factor","val":1000},{"key":"sysctl_tcp_mem_pressure","val":507145},{"key":"sysctl_tcp_mem_extreme","val":760716},{"key":"sysctl_tcp_mem_original","val":380358}]}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetNodeSysctl()
 	require.NoError(t, err)

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_pod.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_pod.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/types"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+func (c *RodanClient) GetPodContainerCPUStats(ctx context.Context, podUID string) (map[string][]types.Cell, error) {
+	url := c.urls[types.ContainerCPUPath]
+
+	return c.GetPodContainerStats(ctx, podUID, url)
+}
+
+func (c *RodanClient) GetPodContainerCgroupMemStats(ctx context.Context, podUID string) (map[string][]types.Cell, error) {
+	url := c.urls[types.ContainerCgroupMemoryPath]
+
+	return c.GetPodContainerStats(ctx, podUID, url)
+}
+
+func (c *RodanClient) GetPodContainerLoadStats(ctx context.Context, podUID string) (map[string][]types.Cell, error) {
+	url := c.urls[types.ContainerLoadPath]
+
+	return c.GetPodContainerStats(ctx, podUID, url)
+}
+
+func (c *RodanClient) GetPodContainerCghardwareStats(ctx context.Context, podUID string) (map[string][]types.Cell, error) {
+	url := c.urls[types.ContainerCghardwarePath]
+
+	return c.GetPodContainerStats(ctx, podUID, url)
+}
+
+func (c *RodanClient) GetPodContainerCgNumaStats(ctx context.Context, podUId string) (map[string]map[int][]types.Cell, error) {
+	url := c.urls[types.ContainerNumaStatPath]
+
+	cghardwareData, err := c.GetPodContainerStats(ctx, podUId, url)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[string]map[int][]types.Cell)
+	for container, cells := range cghardwareData {
+		res[container] = make(map[int][]types.Cell)
+
+		for _, cell := range cells {
+			if cell.Key == "cgnumastat_filepage" {
+				continue
+			}
+			numaNode, metric, err := types.ParseNumastatKey(cell.Key)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := res[container][numaNode]; !ok {
+				res[container][numaNode] = make([]types.Cell, 0)
+			}
+			res[container][numaNode] = append(res[container][numaNode], types.Cell{
+				Key: metric,
+				Val: cell.Val,
+			})
+		}
+	}
+
+	return res, nil
+}
+
+func (c *RodanClient) GetPodContainerStats(ctx context.Context, podUID string, url string) (map[string][]types.Cell, error) {
+	pod, err := c.fetcher.GetPod(ctx, podUID)
+	if err != nil {
+		return nil, fmt.Errorf("GetPodContainerStats %s fetch-pod err %v", podUID, err)
+	}
+
+	containersStats := make(map[string][]types.Cell)
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		containerID := native.TrimContainerIDPrefix(containerStatus.ContainerID)
+
+		data, err := c.metricFunc(url, map[string]string{
+			"container": containerID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("GetPodContainerStats fail, containerId: %v, err: %v", containerID, err)
+		}
+
+		rsp := &types.ContainerResponse{}
+		if err = json.Unmarshal(data, &rsp); err != nil {
+			err = fmt.Errorf("failed to unmarshal container response, err: %v, data: %v", err, string(data))
+			return nil, err
+		}
+
+		if len(rsp.Data) == 0 {
+			err = fmt.Errorf("GetPodContainerStats fail, containerId: %v, data empty", containerID)
+			return nil, err
+		}
+		if _, ok := rsp.Data[containerID]; !ok {
+			err = fmt.Errorf("GetPodContainerStats fail, response without containerId %v", containerID)
+			return nil, err
+		}
+		containersStats[containerStatus.Name] = rsp.Data[containerID]
+	}
+
+	return containersStats, nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_pod_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_pod_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPodContainerCPUStats(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "containerd://da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0",
+				},
+			},
+		},
+	}
+
+	ic := NewRodanClient(&FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+	}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cgcpu_usage","val":99},{"key":"cgcpu_sysusage","val":0},{"key":"cgcpu_user_nsecs","val":2777495188589},{"key":"cgcpu_sys_nsecs","val":337561580},{"key":"cgcpu_userusage","val":99},{"key":"cgcpu_nsecs","val":2777832750169}]}}`), nil
+	})
+
+	res, err := ic.GetPodContainerCPUStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
+	require.NoError(t, err)
+	require.NotNil(t, res["testcontainer"])
+}
+
+func TestGetPodContainerCgroupMemStats(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "containerd://da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0",
+				},
+			},
+		},
+	}
+
+	ic := NewRodanClient(&FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+	}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cgmem_total_shmem","val":0},{"key":"cgmem_total_rss","val":0},{"key":"cgmem_total_cache","val":0},{"key":"cgmem_total_dirty","val":0}]}}`), nil
+	})
+
+	res, err := ic.GetPodContainerCgroupMemStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
+	require.NoError(t, err)
+	require.NotNil(t, res["testcontainer"])
+}
+
+func TestGetPodContainerLoadStats(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "containerd://da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0",
+				},
+			},
+		},
+	}
+
+	ic := NewRodanClient(&FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+	}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"loadavg_loadavg15","val":48},{"key":"loadavg_loadavg5","val":48},{"key":"loadavg_nrrunning","val":48},{"key":"loadavg_loadavg1","val":48},{"key":"loadavg_nriowait","val":48},{"key":"loadavg_nrsleeping","val":48},{"key":"loadavg_nruninterruptible","val":48}]}}`), nil
+	})
+
+	res, err := ic.GetPodContainerLoadStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
+	require.NoError(t, err)
+	require.NotNil(t, res["testcontainer"])
+}
+
+func TestGetPodContainerCghardwareStats(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "containerd://da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0",
+				},
+			},
+		},
+	}
+
+	ic := NewRodanClient(&FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+	}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cghardware_cycles","val":0},{"key":"cghardware_instructions","val":0}]}}`), nil
+	})
+
+	res, err := ic.GetPodContainerCghardwareStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
+	require.NoError(t, err)
+	require.NotNil(t, res["testcontainer"])
+}
+
+func TestGetPodContainerCgNumaStats(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "containerd://da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0",
+				},
+			},
+		},
+	}
+
+	ic := NewRodanClient(&FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+	}, func(url string, params map[string]string) ([]byte, error) {
+		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cgnumastat_filepage","val":5},{"key":"cgnumastat_node0_filepage","val":5}]}}`), nil
+	})
+
+	res, err := ic.GetPodContainerCgNumaStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
+	require.NoError(t, err)
+	require.NotNil(t, res["testcontainer"])
+	require.NotNil(t, res["testcontainer"][0])
+	require.Equal(t, 1, len(res["testcontainer"]))
+}
+
+func TestGetMetrics(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testcontainer",
+					ContainerID: "containerd://da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0",
+				},
+			},
+		},
+	}
+
+	ic := NewRodanClient(&FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+	}, nil)
+
+	res, err := ic.GetPodContainerCgNumaStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
+	require.Error(t, err)
+	require.Nil(t, res)
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_pod_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_pod_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestGetPodContainerCPUStats(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -47,7 +48,7 @@ func TestGetPodContainerCPUStats(t *testing.T) {
 		},
 	}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cgcpu_usage","val":99},{"key":"cgcpu_sysusage","val":0},{"key":"cgcpu_user_nsecs","val":2777495188589},{"key":"cgcpu_sys_nsecs","val":337561580},{"key":"cgcpu_userusage","val":99},{"key":"cgcpu_nsecs","val":2777832750169}]}}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetPodContainerCPUStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
 	require.NoError(t, err)
@@ -55,6 +56,7 @@ func TestGetPodContainerCPUStats(t *testing.T) {
 }
 
 func TestGetPodContainerCgroupMemStats(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -76,7 +78,7 @@ func TestGetPodContainerCgroupMemStats(t *testing.T) {
 		},
 	}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cgmem_total_shmem","val":0},{"key":"cgmem_total_rss","val":0},{"key":"cgmem_total_cache","val":0},{"key":"cgmem_total_dirty","val":0}]}}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetPodContainerCgroupMemStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
 	require.NoError(t, err)
@@ -84,6 +86,7 @@ func TestGetPodContainerCgroupMemStats(t *testing.T) {
 }
 
 func TestGetPodContainerLoadStats(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -105,7 +108,7 @@ func TestGetPodContainerLoadStats(t *testing.T) {
 		},
 	}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"loadavg_loadavg15","val":48},{"key":"loadavg_loadavg5","val":48},{"key":"loadavg_nrrunning","val":48},{"key":"loadavg_loadavg1","val":48},{"key":"loadavg_nriowait","val":48},{"key":"loadavg_nrsleeping","val":48},{"key":"loadavg_nruninterruptible","val":48}]}}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetPodContainerLoadStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
 	require.NoError(t, err)
@@ -113,6 +116,7 @@ func TestGetPodContainerLoadStats(t *testing.T) {
 }
 
 func TestGetPodContainerCghardwareStats(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -134,7 +138,7 @@ func TestGetPodContainerCghardwareStats(t *testing.T) {
 		},
 	}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cghardware_cycles","val":0},{"key":"cghardware_instructions","val":0}]}}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetPodContainerCghardwareStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
 	require.NoError(t, err)
@@ -142,6 +146,7 @@ func TestGetPodContainerCghardwareStats(t *testing.T) {
 }
 
 func TestGetPodContainerCgNumaStats(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -163,7 +168,7 @@ func TestGetPodContainerCgNumaStats(t *testing.T) {
 		},
 	}, func(url string, params map[string]string) ([]byte, error) {
 		return []byte(`{"data":{"da2f6c58a278f9966c2951f3297ed2ac6b8c73cc92460e68f6865bc0448137f0":[{"key":"cgnumastat_filepage","val":5},{"key":"cgnumastat_node0_filepage","val":5}]}}`), nil
-	})
+	}, 9102)
 
 	res, err := ic.GetPodContainerCgNumaStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
 	require.NoError(t, err)
@@ -173,6 +178,7 @@ func TestGetPodContainerCgNumaStats(t *testing.T) {
 }
 
 func TestGetMetrics(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -192,7 +198,7 @@ func TestGetMetrics(t *testing.T) {
 		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
 			return testPod, nil
 		},
-	}, nil)
+	}, nil, 9102)
 
 	res, err := ic.GetPodContainerCgNumaStats(context.Background(), "2126079c-8e0a-4cfe-9a0b-583199c14027")
 	require.Error(t, err)

--- a/pkg/metaserver/agent/metric/provisioner/rodan/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/provisioner.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rodan
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/client"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/types"
+	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+const (
+	pageShift = 12
+)
+
+type RodanMetricsProvisioner struct {
+	client *client.RodanClient
+
+	metricStore *utilmetric.MetricStore
+
+	podFetcher pod.PodFetcher
+
+	emitter metrics.MetricEmitter
+
+	synced bool
+}
+
+// NewRodanMetricsProvisioner returns the fetcher that fetch metrics by Inspector client
+func NewRodanMetricsProvisioner(
+	_ *global.BaseConfiguration,
+	emitter metrics.MetricEmitter,
+	fetcher pod.PodFetcher,
+	metricStore *utilmetric.MetricStore) metrictypes.MetricsProvisioner {
+	return &RodanMetricsProvisioner{
+		metricStore: metricStore,
+		podFetcher:  fetcher,
+		client:      client.NewRodanClient(fetcher, nil),
+		emitter:     emitter,
+		synced:      false,
+	}
+}
+
+func (i *RodanMetricsProvisioner) Run(ctx context.Context) {
+	go wait.Until(func() {
+		i.sample(ctx)
+	}, 5*time.Second, ctx.Done())
+}
+
+func (i *RodanMetricsProvisioner) sample(ctx context.Context) {
+	i.updateNodeStats()
+
+	i.updateNUMAStats()
+
+	i.updateNodeCgroupStats()
+
+	i.updateNodeSysctlStats()
+
+	i.updateCoreStats()
+
+	i.updatePodStats(ctx)
+
+	i.synced = true
+}
+
+func (i *RodanMetricsProvisioner) HasSynced() bool {
+	return i.synced
+}
+
+func (i *RodanMetricsProvisioner) updateNodeStats() {
+
+	// update node memory stats
+	nodeMemoryData, err := i.client.GetNodeMemoryStats()
+	if err != nil {
+		klog.Errorf("[inspector] get node memory stats failed, err: %v", err)
+	} else {
+		i.processNodeMemoryData(nodeMemoryData)
+	}
+}
+
+// updateNodeCgroupStats update only besteffort and burstable QoS level cgroup stats
+func (i *RodanMetricsProvisioner) updateNodeCgroupStats() {
+
+	// update cgroup memory stats
+	memoryCgroupData, err := i.client.GetNodeCgroupMemoryStats()
+	if err != nil {
+		klog.Errorf("[inspector] get memory cgroup stats failed, err: %v", err)
+	} else {
+		i.processCgroupMemoryData(memoryCgroupData)
+	}
+}
+
+func (i *RodanMetricsProvisioner) updateNodeSysctlStats() {
+
+	// update node sysctl data
+	sysctlData, err := i.client.GetNodeSysctl()
+	if err != nil {
+		klog.Errorf("[inspector] get node sysctl failed, err: %v", err)
+	} else {
+		i.processNodeSysctlData(sysctlData)
+	}
+}
+
+func (i *RodanMetricsProvisioner) updateNUMAStats() {
+
+	// update NUMA memory stats
+	NUMAMemoryData, err := i.client.GetNUMAMemoryStats()
+	if err != nil {
+		klog.Errorf("[inspector] get NUMA memory stats failed, err: %v", err)
+	} else {
+		i.processNUMAMemoryData(NUMAMemoryData)
+	}
+}
+
+func (i *RodanMetricsProvisioner) updateCoreStats() {
+
+	// update core CPU stats
+	coreCPUData, err := i.client.GetCoreCPUStats()
+	if err != nil {
+		klog.Errorf("[inspector] get core CPU stats failed, err: %v", err)
+	} else {
+		i.processCoreCPUData(coreCPUData)
+	}
+}
+
+func (i *RodanMetricsProvisioner) updatePodStats(ctx context.Context) {
+	// list all pods
+	pods, err := i.podFetcher.GetPodList(ctx, func(_ *v1.Pod) bool { return true })
+	if err != nil {
+		klog.Errorf("[inspector] GetPodList fail: %v", err)
+		return
+	}
+
+	podUIDSet := make(map[string]bool)
+	for _, pod := range pods {
+		podUIDSet[string(pod.UID)] = true
+		cpuStats, err := i.client.GetPodContainerCPUStats(ctx, string(pod.UID))
+		if err != nil {
+			klog.Errorf("[inspector] get container CPU stats failed, pod: %v, err: %v", pod.Name, err)
+		} else {
+			for containerName, containerCPUStats := range cpuStats {
+				i.processContainerCPUData(string(pod.UID), containerName, containerCPUStats)
+			}
+		}
+
+		cgroupMemStats, err := i.client.GetPodContainerCgroupMemStats(ctx, string(pod.UID))
+		if err != nil {
+			klog.Errorf("[inspector] get container cgroupmem stats failed, pod: %v, err: %v", pod.Name, err)
+		} else {
+			for containerName, containerCgroupMem := range cgroupMemStats {
+				i.processContainerCgroupMemData(string(pod.UID), containerName, containerCgroupMem)
+			}
+		}
+
+		loadStats, err := i.client.GetPodContainerLoadStats(ctx, string(pod.UID))
+		if err != nil {
+			klog.Errorf("[inspector] get container load stats failed, pod: %v, err: %v", pod.Name, err)
+		} else {
+			for containerName, containerLoad := range loadStats {
+				i.processContainerLoadData(string(pod.UID), containerName, containerLoad)
+			}
+		}
+
+		cghardware, err := i.client.GetPodContainerCghardwareStats(ctx, string(pod.UID))
+		if err != nil {
+			klog.Errorf("[inspector] get container cghardware failed, pod: %v, err: %v", pod.Name, err)
+		} else {
+			for containerName, containerCghardware := range cghardware {
+				i.processContainerCghardwareData(string(pod.UID), containerName, containerCghardware)
+			}
+		}
+
+		cgNumaStats, err := i.client.GetPodContainerCgNumaStats(ctx, string(pod.UID))
+		if err != nil {
+			klog.Errorf("[inspector] get container numa stats failed, pod: %v, err: %v", pod.Name, err)
+		} else {
+			for containerName, containerNumaStats := range cgNumaStats {
+				i.processContainerNumaData(string(pod.UID), containerName, containerNumaStats)
+			}
+		}
+	}
+	i.metricStore.GCPodsMetric(podUIDSet)
+}
+
+func (i *RodanMetricsProvisioner) processNodeMemoryData(nodeMemoryData []types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.NodeMemoryPath]
+
+	for _, cell := range nodeMemoryData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+		switch cell.Key {
+		case "memory_pgsteal_kswapd":
+			i.metricStore.SetNodeMetric(
+				metricName,
+				utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+			)
+		default:
+			i.metricStore.SetNodeMetric(
+				metricName,
+				utilmetric.MetricData{Value: float64(int(cell.Val) << 10), Time: &updateTime},
+			)
+		}
+	}
+}
+
+func (i *RodanMetricsProvisioner) processNodeSysctlData(nodeSysctlData []types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.NodeSysctlPath]
+
+	for _, cell := range nodeSysctlData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+
+		i.metricStore.SetNodeMetric(
+			metricName,
+			utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+		)
+
+	}
+}
+
+func (i *RodanMetricsProvisioner) processCgroupMemoryData(cgroupMemoryData []types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.NodeCgroupMemoryPath]
+	for _, cell := range cgroupMemoryData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+
+		switch cell.Key {
+		case "qosgroupmem_besteffort_memory_rss", "qosgroupmem_besteffort_memory_usage":
+			i.metricStore.SetCgroupMetric(common.CgroupFsRootPathBestEffort, metricName,
+				utilmetric.MetricData{Value: cell.Val, Time: &updateTime})
+		case "qosgroupmem_burstable_memory_rss", "qosgroupmem_burstable_memory_usage":
+			i.metricStore.SetCgroupMetric(common.CgroupFsRootPathBurstable, metricName,
+				utilmetric.MetricData{Value: cell.Val, Time: &updateTime})
+		}
+	}
+}
+
+func (i *RodanMetricsProvisioner) processNUMAMemoryData(NUMAMemoryData map[int][]types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.NumaMemoryPath]
+
+	for numaID, cells := range NUMAMemoryData {
+		for _, cell := range cells {
+			metricName, ok := metricMap[cell.Key]
+			if !ok {
+				continue
+			}
+
+			i.metricStore.SetNumaMetric(
+				numaID,
+				metricName,
+				utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+			)
+		}
+	}
+}
+
+func (i *RodanMetricsProvisioner) processCoreCPUData(coreCPUData map[int][]types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.NodeCPUPath]
+
+	for cpuID, coreData := range coreCPUData {
+		for _, cell := range coreData {
+			metricName, ok := metricMap[cell.Key]
+			if !ok {
+				continue
+			}
+
+			switch cell.Key {
+			case "usage":
+				// node cpu usage if cpuID == -1
+				if cpuID == -1 {
+					i.metricStore.SetNodeMetric(
+						consts.MetricCPUUsageRatio,
+						utilmetric.MetricData{Value: cell.Val / 100.0, Time: &updateTime},
+					)
+				} else {
+					i.metricStore.SetCPUMetric(
+						cpuID,
+						consts.MetricCPUUsageRatio,
+						utilmetric.MetricData{Value: cell.Val / 100.0, Time: &updateTime},
+					)
+				}
+			case "sched_wait":
+				i.metricStore.SetCPUMetric(
+					cpuID,
+					consts.MetricCPUSchedwait,
+					utilmetric.MetricData{Value: cell.Val * 1000, Time: &updateTime},
+				)
+			default:
+				i.metricStore.SetCPUMetric(
+					cpuID,
+					metricName,
+					utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+				)
+			}
+		}
+	}
+}
+
+func (i *RodanMetricsProvisioner) processContainerCPUData(podUID, containerName string, cpuData []types.Cell) {
+	var (
+		updateTime = time.Now()
+		metricMap  = types.MetricsMap[types.ContainerCPUPath]
+	)
+
+	for _, cell := range cpuData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+
+		switch cell.Key {
+		case "cgcpu_usage":
+			i.metricStore.SetContainerMetric(
+				podUID,
+				containerName,
+				metricName,
+				utilmetric.MetricData{Value: cell.Val / 100.0, Time: &updateTime},
+			)
+		default:
+			i.metricStore.SetContainerMetric(
+				podUID,
+				containerName,
+				metricName,
+				utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+			)
+		}
+	}
+}
+
+func (i *RodanMetricsProvisioner) processContainerCghardwareData(podUID, containerName string, cghardwareData []types.Cell) {
+	var (
+		updateTime = time.Now()
+		metricMap  = types.MetricsMap[types.ContainerCghardwarePath]
+
+		cyclesOld, _         = i.metricStore.GetContainerMetric(podUID, containerName, consts.MetricCPUCyclesContainer)
+		instructionsOld, _   = i.metricStore.GetContainerMetric(podUID, containerName, consts.MetricCPUInstructionsContainer)
+		cycles, instructions float64
+	)
+
+	for _, cell := range cghardwareData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+
+		i.metricStore.SetContainerMetric(
+			podUID,
+			containerName,
+			metricName,
+			utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+		)
+
+		if cell.Key == "cycles" {
+			cycles = cell.Val
+		}
+		if cell.Key == "instructions" {
+			instructions = cell.Val
+		}
+	}
+	if cyclesOld.Value > 0 && cycles > 0 && instructionsOld.Value > 0 && instructions > 0 {
+		instructionDiff := instructions - instructionsOld.Value
+		if instructionDiff > 0 {
+			cpi := (cycles - cyclesOld.Value) / instructionDiff
+			i.metricStore.SetContainerMetric(
+				podUID,
+				containerName,
+				consts.MetricCPUCPIContainer,
+				utilmetric.MetricData{Value: cpi, Time: &updateTime},
+			)
+		}
+	}
+}
+
+func (i *RodanMetricsProvisioner) processContainerCgroupMemData(podUID, containerName string, cgroupMemData []types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.ContainerCgroupMemoryPath]
+
+	for _, cell := range cgroupMemData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+
+		i.metricStore.SetContainerMetric(
+			podUID,
+			containerName,
+			metricName,
+			utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+		)
+	}
+}
+
+func (i *RodanMetricsProvisioner) processContainerLoadData(podUID, containerName string, loadData []types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.ContainerLoadPath]
+
+	for _, cell := range loadData {
+		metricName, ok := metricMap[cell.Key]
+		if !ok {
+			continue
+		}
+
+		switch cell.Key {
+		case "loadavg_loadavg1", "loadavg_loadavg5", "loadavg_loadavg15":
+			i.metricStore.SetContainerMetric(
+				podUID,
+				containerName,
+				metricName,
+				utilmetric.MetricData{Value: cell.Val / 100.0, Time: &updateTime},
+			)
+		default:
+			i.metricStore.SetContainerMetric(
+				podUID,
+				containerName,
+				metricName,
+				utilmetric.MetricData{Value: cell.Val, Time: &updateTime},
+			)
+		}
+
+	}
+}
+
+func (i *RodanMetricsProvisioner) processContainerNumaData(podUID, containerName string, containerNumaData map[int][]types.Cell) {
+	updateTime := time.Now()
+
+	metricMap := types.MetricsMap[types.ContainerNumaStatPath]
+
+	for numaNode, cells := range containerNumaData {
+		for _, cell := range cells {
+			metricName, ok := metricMap[cell.Key]
+			if !ok {
+				continue
+			}
+
+			switch cell.Key {
+			case "filepage":
+				i.metricStore.SetContainerNumaMetric(podUID, containerName, strconv.Itoa(numaNode), metricName,
+					utilmetric.MetricData{Value: float64(int(cell.Val) << pageShift), Time: &updateTime})
+			default:
+
+			}
+		}
+	}
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/provisioner.go
@@ -21,12 +21,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/client"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/types"
@@ -56,13 +56,14 @@ type RodanMetricsProvisioner struct {
 // NewRodanMetricsProvisioner returns the fetcher that fetch metrics by Inspector client
 func NewRodanMetricsProvisioner(
 	_ *global.BaseConfiguration,
+	metricConf *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter,
 	fetcher pod.PodFetcher,
 	metricStore *utilmetric.MetricStore) metrictypes.MetricsProvisioner {
 	return &RodanMetricsProvisioner{
 		metricStore: metricStore,
 		podFetcher:  fetcher,
-		client:      client.NewRodanClient(fetcher, nil),
+		client:      client.NewRodanClient(fetcher, nil, metricConf.RodanServerPort),
 		emitter:     emitter,
 		synced:      false,
 	}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestSample(t *testing.T) {
+	t.Parallel()
 	testPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
@@ -62,7 +63,7 @@ func TestSample(t *testing.T) {
 	f := &RodanMetricsProvisioner{
 		metricStore: utilmetric.NewMetricStore(),
 		podFetcher:  podFetcher,
-		client:      client.NewRodanClient(podFetcher, makeTestMetricClient()),
+		client:      client.NewRodanClient(podFetcher, makeTestMetricClient(), 9102),
 		emitter:     metrics.DummyMetrics{},
 		synced:      false,
 	}
@@ -198,10 +199,4 @@ func (f *FakePodFetcher) GetPod(ctx context.Context, podUID string) (*v1.Pod, er
 
 func (f *FakePodFetcher) GetPodList(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error) {
 	return f.GetPodListFunc(ctx, podFilter)
-}
-
-func TestT(t *testing.T) {
-	a := 32614152
-	a = a << 10
-	fmt.Println(a)
 }

--- a/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rodan
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/client"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/rodan/types"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+func TestSample(t *testing.T) {
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "2126079c-8e0a-4cfe-9a0b-583199c14027",
+			Name: "testPod",
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        "testContainer",
+					ContainerID: "containerd://1df178c3a7bddf1269d18b556c1d22a025bdf194c4617d9b411d0ef4b9229ec6",
+				},
+			},
+		},
+	}
+
+	podFetcher := &FakePodFetcher{
+		GetPodFunc: func(ctx context.Context, podUID string) (*v1.Pod, error) {
+			return testPod, nil
+		},
+		GetPodListFunc: func(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error) {
+			return []*v1.Pod{
+				testPod,
+			}, nil
+		},
+	}
+
+	f := &RodanMetricsProvisioner{
+		metricStore: utilmetric.NewMetricStore(),
+		podFetcher:  podFetcher,
+		client:      client.NewRodanClient(podFetcher, makeTestMetricClient()),
+		emitter:     metrics.DummyMetrics{},
+		synced:      false,
+	}
+
+	f.sample(context.Background())
+
+	data, err := f.metricStore.GetNodeMetric(consts.MetricMemTotalSystem)
+	require.NoError(t, err)
+	require.Equal(t, float64(32614152<<10), data.Value)
+
+	data, err = f.metricStore.GetNodeMetric(consts.MetricMemFreeSystem)
+	require.NoError(t, err)
+	require.Equal(t, float64(12891380<<10), data.Value)
+
+	data, err = f.metricStore.GetNodeMetric(consts.MetricMemUsedSystem)
+	require.NoError(t, err)
+	require.Equal(t, float64(968376<<10), data.Value)
+
+	data, err = f.metricStore.GetNodeMetric(consts.MetricMemScaleFactorSystem)
+	require.NoError(t, err)
+	require.Equal(t, 1000.0, data.Value)
+
+	data, err = f.metricStore.GetNodeMetric(consts.MetricMemPageCacheSystem)
+	require.NoError(t, err)
+	require.Equal(t, float64(17783636<<10), data.Value)
+
+	data, err = f.metricStore.GetNodeMetric(consts.MetricMemBufferSystem)
+	require.NoError(t, err)
+	require.Equal(t, float64(365640<<10), data.Value)
+
+	data, err = f.metricStore.GetNodeMetric(consts.MetricMemKswapdstealSystem)
+	require.NoError(t, err)
+	require.Equal(t, 7067178.0, data.Value)
+
+	data, err = f.metricStore.GetNumaMetric(0, consts.MetricMemTotalNuma)
+	require.NoError(t, err)
+	require.Equal(t, 33396891648.0, data.Value)
+
+	data, err = f.metricStore.GetNumaMetric(0, consts.MetricMemFreeNuma)
+	require.NoError(t, err)
+	require.Equal(t, 13186412544.0, data.Value)
+
+	data, err = f.metricStore.GetCPUMetric(1, consts.MetricCPUUsageRatio)
+	require.NoError(t, err)
+	require.Equal(t, 0.04, data.Value)
+
+	data, err = f.metricStore.GetCPUMetric(6, consts.MetricCPUSchedwait)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricLoad1MinContainer)
+	require.NoError(t, err)
+	require.Equal(t, 0.54, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricLoad5MinContainer)
+	require.NoError(t, err)
+	require.Equal(t, 0.54, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricCPUNrRunnableContainer)
+	require.NoError(t, err)
+	require.Equal(t, 54.0, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricCPUUsageContainer)
+	require.NoError(t, err)
+	require.Equal(t, 0.99, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricMemRssContainer)
+	require.NoError(t, err)
+	require.Equal(t, 16220160.0, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricMemCacheContainer)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, data.Value)
+
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricMemShmemContainer)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, data.Value)
+
+	data, err = f.metricStore.GetContainerNumaMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", "0", consts.MetricsMemFilePerNumaContainer)
+	require.NoError(t, err)
+	require.Equal(t, float64(3352<<12), data.Value)
+}
+
+func makeTestMetricClient() client.MetricFunc {
+	return func(url string, params map[string]string) ([]byte, error) {
+		switch url {
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.NodeMemoryPath):
+			return []byte(`{"data":[{"key":"memory_memavailable","val":19583568},{"key":"memory_swapfree","val":0},{"key":"memory_pgsteal_kswapd","val":7067178},{"key":"memory_memused","val":968376},{"key":"memory_writeback","val":0},{"key":"memory_shmem","val":1708908},{"key":"memory_sreclaimable","val":605120},{"key":"memory_cached","val":17783636},{"key":"memory_swaptotal","val":0},{"key":"memory_dirty","val":956},{"key":"memory_memtotal","val":32614152},{"key":"memory_memfree","val":12891380},{"key":"memory_buffers","val":365640}]}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.NodeSysctlPath):
+			return []byte(`{"data":[{"key":"sysctl_tcp_mem_pressure","val":507145},{"key":"sysctl_tcp_mem_original","val":380358},{"key":"sysctl_tcp_mem_extreme","val":760716},{"key":"sysctl_vm_watermark_scale_factor","val":1000}]}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.NumaMemoryPath):
+			return []byte(`{"data":[{"key":"numastat_node0_memtotal","val":33396891648},{"key":"numastat_node0_memfree","val":13186412544}]}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.NodeCgroupMemoryPath):
+			return []byte(`{"data":[{"key":"qosgroupmem_besteffort_memory_usage","val":1266978816},{"key":"qosgroupmem_burstable_memory_rss","val":185856000},{"key":"qosgroupmem_besteffort_memory_rss","val":112910336},{"key":"qosgroupmem_burstable_memory_usage","val":380174336}]}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.NodeCPUPath):
+			return []byte(`{"data":[{"key":"percorecpu_cpu6_usage","val":21},{"key":"percorecpu_cpu0_sched_wait","val":0},{"key":"percorecpu_cpu2_sched_wait","val":0},{"key":"percorecpu_cpu1_usage","val":4},{"key":"percorecpu_cpu7_usage","val":22},{"key":"percorecpu_cpu6_sched_wait","val":0},{"key":"percorecpu_cpu7_sched_wait","val":0},{"key":"percorecpu_cpu5_usage","val":14},{"key":"percorecpu_cpu0_usage","val":5},{"key":"percorecpu_cpu3_usage","val":4},{"key":"percorecpu_cpu3_sched_wait","val":0},{"key":"percorecpu_cpu2_usage","val":5},{"key":"percorecpu_cpu5_sched_wait","val":0},{"key":"percorecpu_cpu4_usage","val":29},{"key":"percorecpu_cpu4_sched_wait","val":0},{"key":"percorecpu_cpu1_sched_wait","val":0}]}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.ContainerCPUPath):
+			return []byte(`{"data":{"1df178c3a7bddf1269d18b556c1d22a025bdf194c4617d9b411d0ef4b9229ec6":[{"key":"cgcpu_nsecs","val":2015872049910},{"key":"cgcpu_sysusage","val":0},{"key":"cgcpu_userusage","val":99},{"key":"cgcpu_sys_nsecs","val":179907376},{"key":"cgcpu_user_nsecs","val":2015692142534},{"key":"cgcpu_usage","val":99}]}}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.ContainerLoadPath):
+			return []byte(`{"data":{"1df178c3a7bddf1269d18b556c1d22a025bdf194c4617d9b411d0ef4b9229ec6":[{"key":"loadavg_nruninterruptible","val":54},{"key":"loadavg_loadavg15","val":54},{"key":"loadavg_loadavg5","val":54},{"key":"loadavg_nrrunning","val":54},{"key":"loadavg_nriowait","val":54},{"key":"loadavg_loadavg1","val":54},{"key":"loadavg_nrsleeping","val":54}]}}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.ContainerCghardwarePath):
+			return []byte(`{"data":{"1df178c3a7bddf1269d18b556c1d22a025bdf194c4617d9b411d0ef4b9229ec6":[{"key":"cghardware_cycles","val":0},{"key":"cghardware_instructions","val":0}]}}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.ContainerCgroupMemoryPath):
+			return []byte(`{"data":{"1df178c3a7bddf1269d18b556c1d22a025bdf194c4617d9b411d0ef4b9229ec6":[{"key":"cgmem_total_dirty","val":0},{"key":"cgmem_total_shmem","val":0},{"key":"cgmem_total_rss","val":16220160},{"key":"cgmem_total_cache","val":0}]}}`), nil
+		case fmt.Sprintf("%s%s", "http://localhost:9102", types.ContainerNumaStatPath):
+			return []byte(`{"data":{"1df178c3a7bddf1269d18b556c1d22a025bdf194c4617d9b411d0ef4b9229ec6":[{"key":"cgnumastat_filepage","val":3352},{"key":"cgnumastat_node0_filepage","val":3352}]}}`), nil
+		default:
+			return nil, fmt.Errorf("unknow url")
+		}
+	}
+}
+
+type FakePodFetcher struct {
+	GetPodFunc     func(ctx context.Context, podUID string) (*v1.Pod, error)
+	GetPodListFunc func(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error)
+}
+
+func (f *FakePodFetcher) Run(ctx context.Context) {
+	return
+}
+
+func (f *FakePodFetcher) GetContainerID(podUID, containerName string) (string, error) {
+	return "", nil
+}
+
+func (f *FakePodFetcher) GetContainerSpec(podUID, containerName string) (*v1.Container, error) {
+	return nil, nil
+}
+
+func (f *FakePodFetcher) GetPod(ctx context.Context, podUID string) (*v1.Pod, error) {
+	return f.GetPodFunc(ctx, podUID)
+}
+
+func (f *FakePodFetcher) GetPodList(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error) {
+	return f.GetPodListFunc(ctx, podFilter)
+}
+
+func TestT(t *testing.T) {
+	a := 32614152
+	a = a << 10
+	fmt.Println(a)
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/types/consts.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/types/consts.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import "github.com/kubewharf/katalyst-core/pkg/consts"
+
+const (
+	RodanServerPort = 9102
+
+	NodeMemoryPath       = "/node/memory"
+	NodeCgroupMemoryPath = "/node/qosgroupmem"
+
+	NumaMemoryPath = "/node/numastat"
+
+	NodeCPUPath    = "/node/nodecpu"
+	NodeSysctlPath = "/node/sysctl"
+
+	ContainerCPUPath          = "/container/cgcpu"
+	ContainerCgroupMemoryPath = "/container/cgmem"
+	ContainerNumaStatPath     = "/container/cgnumastat"
+	ContainerLoadPath         = "/container/loadavg"
+	ContainerCghardwarePath   = "/container/cghardware"
+)
+
+// read only
+var MetricsMap = map[string]map[string]string{
+	NodeMemoryPath: {
+		"memory_memtotal":       consts.MetricMemTotalSystem,
+		"memory_memfree":        consts.MetricMemFreeSystem,
+		"memory_memused":        consts.MetricMemUsedSystem,
+		"memory_cached":         consts.MetricMemPageCacheSystem,
+		"memory_buffers":        consts.MetricMemBufferSystem,
+		"memory_pgsteal_kswapd": consts.MetricMemKswapdstealSystem,
+	},
+	NodeCgroupMemoryPath: {
+		"qosgroupmem_besteffort_memory_rss":   consts.MetricMemRssCgroup,
+		"qosgroupmem_besteffort_memory_usage": consts.MetricMemUsageCgroup,
+		"qosgroupmem_burstable_memory_rss":    consts.MetricMemRssCgroup,
+		"qosgroupmem_burstable_memory_usage":  consts.MetricMemUsageCgroup,
+	},
+	NumaMemoryPath: {
+		"memtotal": consts.MetricMemTotalNuma,
+		"memfree":  consts.MetricMemFreeNuma,
+	},
+	NodeCPUPath: {
+		"usage":      consts.MetricCPUUsageRatio,
+		"sched_wait": consts.MetricCPUSchedwait,
+	},
+	NodeSysctlPath: {
+		"sysctl_vm_watermark_scale_factor": consts.MetricMemScaleFactorSystem,
+	},
+	ContainerCPUPath: {
+		"cgcpu_usage": consts.MetricCPUUsageContainer,
+	},
+	ContainerCgroupMemoryPath: {
+		"cgmem_total_shmem": consts.MetricMemShmemContainer,
+		"cgmem_total_rss":   consts.MetricMemRssContainer,
+		"cgmem_total_cache": consts.MetricMemCacheContainer,
+	},
+	ContainerLoadPath: {
+		"loadavg_nrrunning": consts.MetricCPUNrRunnableContainer,
+		"loadavg_loadavg1":  consts.MetricLoad1MinContainer,
+		"loadavg_loadavg5":  consts.MetricLoad5MinContainer,
+		"loadavg_loadavg15": consts.MetricLoad15MinContainer,
+	},
+	ContainerNumaStatPath: {
+		"filepage": consts.MetricsMemFilePerNumaContainer,
+	},
+	ContainerCghardwarePath: {
+		"cghardware_cycles":       consts.MetricCPUCyclesContainer,
+		"cghardware_instructions": consts.MetricCPUInstructionsContainer,
+	},
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/types/types.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/types/types.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Cell is the basic unit of the indicator
+type Cell struct {
+	Key string  `json:"key"`
+	Val float64 `json:"val"`
+}
+
+type CellList struct {
+	Data []Cell `json:"data"`
+}
+
+type NodeMemoryResponse CellList
+
+type NodeCgroupMemoryResponse CellList
+
+type NUMAMemoryResponse CellList
+
+type CoreCPUResponse CellList
+
+type NodeSysctlResponse CellList
+
+type ContainerResponse struct {
+	Data map[string][]Cell `json:"data"`
+}
+
+// key: numastat_{nodeNum}_{metricName}, eg, numastat_node0_memtotal
+// return numaNode, metricName, error
+func ParseNumastatKey(key string) (int, string, error) {
+	data := strings.SplitN(key, "_", 3)
+	if len(data) != 3 {
+		return 0, "", fmt.Errorf("unknow numastat key %s", key)
+	}
+
+	if len(data[1]) < 5 {
+		return 0, "", fmt.Errorf("unknow numastat key %s", key)
+	}
+	numaNode := data[1][4:len(data[1])]
+	numaNodeNum, err := strconv.Atoi(numaNode)
+	if err != nil {
+		return 0, "", fmt.Errorf("unknow numastat key %s, numaNode %s", key, numaNode)
+	}
+
+	return numaNodeNum, data[2], nil
+}
+
+func ParseCorestatKey(key string) (int, string, error) {
+	if key == "nodecpu_all" {
+		return -1, "usage", nil
+	}
+
+	data := strings.SplitN(key, "_", 3)
+	if len(data) != 3 {
+		return 0, "", fmt.Errorf("unknow cpustat key %s", key)
+	}
+
+	if len(data[1]) < 4 {
+		return 0, "", fmt.Errorf("unknow cpustat key %s", key)
+	}
+	cpu := data[1][3:len(data[1])]
+	cpuNum, err := strconv.Atoi(cpu)
+	if err != nil {
+		return 0, "", fmt.Errorf("unknow cpustat key %s, cpu %s", key, cpu)
+	}
+
+	return cpuNum, data[2], nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/types/types_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/types/types_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNumastatKey(t *testing.T) {
+	t.Parallel()
+
+	testCase := []struct {
+		name         string
+		key          string
+		expectNuma   int
+		expectMetric string
+		expectErr    bool
+	}{
+		{
+			name:         "numastat_node0_memtotal",
+			key:          "numastat_node0_memtotal",
+			expectNuma:   0,
+			expectMetric: "memtotal",
+			expectErr:    false,
+		},
+		{
+			name:         "numastat_node10_memtotal",
+			key:          "numastat_node10_memtotal",
+			expectNuma:   10,
+			expectMetric: "memtotal",
+			expectErr:    false,
+		},
+		{
+			name:         "numastat_node10",
+			key:          "numastat_node10",
+			expectNuma:   0,
+			expectMetric: "",
+			expectErr:    true,
+		},
+		{
+			name:         "numastat_nodexx_memtotal",
+			key:          "numastat_nodexx_memtotal",
+			expectNuma:   0,
+			expectMetric: "",
+			expectErr:    true,
+		},
+		{
+			name:         "numastat_node_memtotal",
+			key:          "numastat_node_memtotal",
+			expectNuma:   0,
+			expectMetric: "",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			numa, metric, err := ParseNumastatKey(tc.key)
+			if tc.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, numa, tc.expectNuma)
+				assert.Equal(t, metric, tc.expectMetric)
+			}
+		})
+	}
+}
+
+func TestParseCorestatKey(t *testing.T) {
+	t.Parallel()
+
+	testCase := []struct {
+		name         string
+		key          string
+		expectCpu    int
+		expectMetric string
+		expectErr    bool
+	}{
+		{
+			name:         "percorecpu_cpu4_usage",
+			key:          "percorecpu_cpu4_usage",
+			expectCpu:    4,
+			expectMetric: "usage",
+			expectErr:    false,
+		},
+		{
+			name:         "percorecpu_cpu1_sched_wait",
+			key:          "percorecpu_cpu1_sched_wait",
+			expectCpu:    1,
+			expectMetric: "sched_wait",
+			expectErr:    false,
+		},
+		{
+			name:         "percorecpu_cpu1",
+			key:          "percorecpu_cpu1",
+			expectCpu:    0,
+			expectMetric: "",
+			expectErr:    true,
+		},
+	}
+
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			numa, metric, err := ParseCorestatKey(tc.key)
+			if tc.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, numa, tc.expectCpu)
+				assert.Equal(t, metric, tc.expectMetric)
+			}
+		})
+	}
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/types/types_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/types/types_test.go
@@ -70,7 +70,9 @@ func TestParseNumastatKey(t *testing.T) {
 	}
 
 	for _, tc := range testCase {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			numa, metric, err := ParseNumastatKey(tc.key)
 			if tc.expectErr {
 				assert.NotNil(t, err)
@@ -116,7 +118,9 @@ func TestParseCorestatKey(t *testing.T) {
 	}
 
 	for _, tc := range testCase {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			numa, metric, err := ParseCorestatKey(tc.key)
 			if tc.expectErr {
 				assert.NotNil(t, err)


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
Add a metric provisioner that requests metrics from rodan(metrics collector like malachite).

Add a config which allows metric fetcher to init provisioners according to the provisioner name list. Malachite and kubelet are used by default, and rodan is used in private scenarios.