### PR TITLE
kubelet reporter plugin support shared_cores with numa_binding pod

### DIFF
--- a/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin.go
+++ b/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin.go
@@ -88,9 +88,9 @@ func NewKubeletReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaser
 		StopControl: process.NewStopControl(time.Time{}),
 	}
 
-	topologyStatusAdapter, err := topology.NewPodResourcesServerTopologyAdapter(metaServer,
+	topologyStatusAdapter, err := topology.NewPodResourcesServerTopologyAdapter(metaServer, conf.QoSConfiguration,
 		conf.PodResourcesServerEndpoints, conf.KubeletResourcePluginPaths, conf.ResourceNameToZoneTypeMap,
-		nil, p.getNumaInfo, nil, podresources.GetV1Client)
+		nil, p.getNumaInfo, topology.GenericPodResourcesFilter(conf.QoSConfiguration), podresources.GetV1Client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/resourcemanager/fetcher/kubelet/topology/filter.go
+++ b/pkg/agent/resourcemanager/fetcher/kubelet/topology/filter.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	v1 "k8s.io/api/core/v1"
+	podresv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	"github.com/kubewharf/katalyst-core/pkg/util/qos"
+)
+
+// GenericPodResourcesFilter is used to filter pod resources by qos conf
+func GenericPodResourcesFilter(qosConf *generic.QoSConfiguration) PodResourcesFilter {
+	return func(pod *v1.Pod, podResources *podresv1.PodResources) (*podresv1.PodResources, error) {
+		if podResources == nil || pod == nil {
+			return nil, nil
+		}
+
+		podIsNumaBinding := qos.IsPodNumaBinding(qosConf, pod)
+		for _, container := range podResources.Containers {
+			newResources := make([]*podresv1.TopologyAwareResource, 0, len(container.Resources))
+			for _, resource := range container.Resources {
+				if resource == nil {
+					continue
+				}
+
+				// skip cpu and memory if pod is not numa binding
+				if !podIsNumaBinding &&
+					(resource.ResourceName == string(v1.ResourceCPU) || resource.ResourceName == string(v1.ResourceMemory)) {
+					continue
+				}
+
+				newResources = append(newResources, resource)
+			}
+
+			container.Resources = newResources
+		}
+
+		return podResources, nil
+	}
+}

--- a/pkg/controller/spd/spd_test.go
+++ b/pkg/controller/spd/spd_test.go
@@ -749,7 +749,7 @@ func TestIndicatorUpdater(t *testing.T) {
 			Current: &value,
 		},
 	})
-	time.Sleep(time.Millisecond * 100)
+	time.Sleep(time.Second)
 	newSPD, err := controlCtx.Client.InternalClient.WorkloadV1alpha1().
 		ServiceProfileDescriptors("default").Get(ctx, "spd1", metav1.GetOptions{})
 	assert.NoError(t, err)

--- a/pkg/util/qos/mem_enhancement.go
+++ b/pkg/util/qos/mem_enhancement.go
@@ -34,11 +34,6 @@ func ParseMemoryEnhancement(qosConf *generic.QoSConfiguration, pod *v1.Pod) map[
 
 // IsPodNumaBinding checks whether the pod needs numa-binding
 func IsPodNumaBinding(qosConf *generic.QoSConfiguration, pod *v1.Pod) bool {
-	isDedicatedPod, err := qosConf.CheckDedicatedQoS(pod, map[string]string{})
-	if err != nil || !isDedicatedPod {
-		return false
-	}
-
 	memoryEnhancement := ParseMemoryEnhancement(qosConf, pod)
 	return AnnotationsIndicateNUMABinding(memoryEnhancement)
 }
@@ -47,6 +42,11 @@ func IsPodNumaBinding(qosConf *generic.QoSConfiguration, pod *v1.Pod) bool {
 func IsPodNumaExclusive(qosConf *generic.QoSConfiguration, pod *v1.Pod) bool {
 	isPodNumaBinding := IsPodNumaBinding(qosConf, pod)
 	if !isPodNumaBinding {
+		return false
+	}
+
+	isDedicatedPod, err := qosConf.CheckDedicatedQoS(pod, map[string]string{})
+	if err != nil || !isDedicatedPod {
 		return false
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
kubelet reporter plugin support report shared_cores with numa_binding pod, and add GenericPodResourcesFilter to filter out cpu and memory of shared_cores without numa_binding pod.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
