### PR TITLE
fix(vpa webhook): fix vpa webhook could not update request for pod without setting limit

### DIFF
--- a/pkg/util/vpa.go
+++ b/pkg/util/vpa.go
@@ -405,13 +405,14 @@ func CheckVPAStatusLegal(vpa *apis.KatalystVerticalPodAutoscaler, pods []*core.P
 			resourceNames := []core.ResourceName{core.ResourceCPU, core.ResourceMemory}
 			for _, resourceName := range resourceNames {
 				// check if resource are not negative
-				if native.IsResourceGreaterThan(zeroQuantity, container.Resources.Requests[resourceName]) {
+				limit := container.Resources.Limits[resourceName]
+				request := container.Resources.Requests[resourceName]
+				if native.IsResourceGreaterThan(zeroQuantity, request) {
 					return false, fmt.Sprintf("resource %s request value is negative", resourceName), nil
-				} else if native.IsResourceGreaterThan(zeroQuantity, container.Resources.Limits[resourceName]) {
+				} else if native.IsResourceGreaterThan(zeroQuantity, limit) {
 					return false, fmt.Sprintf("resource %s limit value is negative", resourceName), nil
 				}
-
-				if native.IsResourceGreaterThan(container.Resources.Requests[resourceName], container.Resources.Limits[resourceName]) {
+				if !limit.IsZero() && native.IsResourceGreaterThan(request, limit) {
 					return false, fmt.Sprintf("resource %s request greater than limit", resourceName), nil
 				}
 			}

--- a/pkg/util/vpa_test.go
+++ b/pkg/util/vpa_test.go
@@ -459,6 +459,90 @@ func TestIsVPAStatusLegal(t *testing.T) {
 			},
 		},
 	}
+	vpa2 := &apis.KatalystVerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vpa2",
+			Namespace: "default",
+			UID:       "vpauid2",
+		},
+		Status: apis.KatalystVerticalPodAutoscalerStatus{
+			PodResources: nil,
+			ContainerResources: []apis.ContainerResources{
+				{
+					ContainerName: pointer.String("c1"),
+					Requests: &apis.ContainerResourceList{
+						Target: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:    *resource.NewQuantity(2, resource.DecimalSI),
+							v1.ResourceMemory: *resource.NewQuantity(2*int64(units.GiB), resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
+	vpa3 := &apis.KatalystVerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vpa2",
+			Namespace: "default",
+			UID:       "vpauid2",
+		},
+		Status: apis.KatalystVerticalPodAutoscalerStatus{
+			PodResources: nil,
+			ContainerResources: []apis.ContainerResources{
+				{
+					ContainerName: pointer.String("c1"),
+					Requests: &apis.ContainerResourceList{
+						Target: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:    *resource.NewQuantity(-2, resource.DecimalSI),
+							v1.ResourceMemory: *resource.NewQuantity(2*int64(units.GiB), resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
+	vpa4 := &apis.KatalystVerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vpa2",
+			Namespace: "default",
+			UID:       "vpauid2",
+		},
+		Status: apis.KatalystVerticalPodAutoscalerStatus{
+			PodResources: nil,
+			ContainerResources: []apis.ContainerResources{
+				{
+					ContainerName: pointer.String("c1"),
+					Limits: &apis.ContainerResourceList{
+						Target: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:    *resource.NewQuantity(1, resource.DecimalSI),
+							v1.ResourceMemory: *resource.NewQuantity(-2*int64(units.GiB), resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
+	vpa5 := &apis.KatalystVerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vpa2",
+			Namespace: "default",
+			UID:       "vpauid2",
+		},
+		Status: apis.KatalystVerticalPodAutoscalerStatus{
+			PodResources: nil,
+			ContainerResources: []apis.ContainerResources{
+				{
+					ContainerName: pointer.String("c1"),
+					Requests: &apis.ContainerResourceList{
+						Target: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:    *resource.NewQuantity(10, resource.DecimalSI),
+							v1.ResourceMemory: *resource.NewQuantity(2*int64(units.GiB), resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
 	pod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod1",
@@ -534,6 +618,25 @@ func TestIsVPAStatusLegal(t *testing.T) {
 			QOSClass: v1.PodQOSBurstable,
 		},
 	}
+	pod4 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod4",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: map[v1.ResourceName]resource.Quantity{
+							v1.ResourceCPU:    *resource.NewQuantity(3, resource.DecimalSI),
+							v1.ResourceMemory: *resource.NewQuantity(3*int64(units.GiB), resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
 
 	for _, tc := range []struct {
 		name  string
@@ -573,6 +676,41 @@ func TestIsVPAStatusLegal(t *testing.T) {
 				pod3,
 			},
 			legal: true,
+		},
+		{
+			name: "legal: Limit not set",
+			vpa:  vpa2,
+			pods: []*v1.Pod{
+				pod4,
+			},
+			legal: true,
+		},
+		{
+			name: "legal: request less than 0",
+			vpa:  vpa3,
+			pods: []*v1.Pod{
+				pod1,
+			},
+			legal: false,
+			msg:   "resource cpu request value is negative",
+		},
+		{
+			name: "legal: limit less than 0",
+			vpa:  vpa4,
+			pods: []*v1.Pod{
+				pod1,
+			},
+			legal: false,
+			msg:   "resource memory limit value is negative",
+		},
+		{
+			name: "legal: request less than limit",
+			vpa:  vpa5,
+			pods: []*v1.Pod{
+				pod1,
+			},
+			legal: false,
+			msg:   "resource cpu request greater than limit",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
…thout setting limit

#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
vpa In recreate update mode, webhook will update the recommended request to the newly created pod. Before updating, it will check whether request is less than limit. 

However, if limit is not set, an error will be reported and the update cannot be made.

This pr is designed to fix this bug

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
