### PR TITLE
feat: adding support to qos level memory protection

### DIFF
--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/const.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/const.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpolicy
+
+const (
+	// Constants for cgroup memory statistics
+	cgroupMemoryLimit2G   = 2147483648
+	cgroupMemoryLimit128M = 134217728
+
+	controlKnobKeyMemorySoftLimitInRatio = "memory_softlimit_in_ratio"
+)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_async_handler.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_async_handler.go
@@ -72,7 +72,6 @@ func setExtraControlKnobByConfigForAllocationInfo(allocationInfo *state.Allocati
 	}
 
 	for controlKnobName, configEntry := range extraControlKnobConfigs {
-
 		if _, found := allocationInfo.ExtraControlKnobInfo[controlKnobName]; found {
 			continue
 		}
@@ -149,6 +148,47 @@ func (p *DynamicPolicy) setExtraControlKnobByConfigs() {
 	p.state.SetMachineState(resourcesMachineState)
 }
 
+func convertMemRatioToBytes(memLimit, memRatio uint64) uint64 {
+	limitInBytes := memLimit / 100 * memRatio
+	// Any value related to cgroup memory limitation should be aligned with the page size.
+	limitInBytes = general.AlignToPageSize(limitInBytes)
+
+	return limitInBytes
+}
+
+func getSoftMemLimitInBytes(memLimit, memRatio uint64) uint64 {
+	// Step1, convert ratio into bytes
+	result := convertMemRatioToBytes(memLimit, memRatio)
+	// Step2, performing specific operations within the memory.low
+	// Notice: we limited memory.low between {128M, 2G}
+	result = uint64(general.Clamp(float64(result), float64(cgroupMemoryLimit128M), float64(cgroupMemoryLimit2G)))
+
+	return result
+}
+
+func getUserSpecifiedMemorySoftLimitInBytes(podUID, containerID, controlKnobValue string) string {
+	relCgroupPath, err := common.GetContainerRelativeCgroupPath(podUID, containerID)
+	if err != nil {
+		general.Warningf("getUserSpecifiedMemorySoftLimitInBytes failed with err: %v", err)
+		return "0"
+	}
+
+	memStat, err := cgroupmgr.GetMemoryWithRelativePath(relCgroupPath)
+	if err != nil {
+		general.Warningf("getUserSpecifiedMemorySoftLimitInBytes failed with err: %v", err)
+		return "0"
+	}
+
+	softLimitRatio, err := strconv.Atoi(controlKnobValue)
+	if err != nil {
+		general.Warningf("getUserSpecifiedMemorySoftLimitInBytes failed with err: %v", err)
+		return "0"
+	}
+
+	softLimitInBytes := getSoftMemLimitInBytes(memStat.Limit, uint64(softLimitRatio))
+	return strconv.FormatUint(softLimitInBytes, 10)
+}
+
 func (p *DynamicPolicy) applyExternalCgroupParams() {
 	general.Infof("called")
 
@@ -187,6 +227,12 @@ func (p *DynamicPolicy) applyExternalCgroupParams() {
 					continue
 				}
 
+				// Notice: for some memory cgroup configurations, we need to convert the ratio configuration into bytes.
+				// Such as: memory.low, memory.min.
+				if controlKnobName == controlKnobKeyMemorySoftLimitInRatio {
+					entry.ControlKnobValue = getUserSpecifiedMemorySoftLimitInBytes(podUID, containerID, entry.ControlKnobValue)
+				}
+
 				general.InfoS("ApplyUnifiedDataForContainer",
 					"podNamespace", allocationInfo.PodNamespace,
 					"podName", allocationInfo.PodName,
@@ -197,7 +243,6 @@ func (p *DynamicPolicy) applyExternalCgroupParams() {
 					"cgroupIfaceName", cgroupIfaceName)
 
 				err := cgroupmgr.ApplyUnifiedDataForContainer(podUID, containerID, entry.CgroupSubsysName, cgroupIfaceName, entry.ControlKnobValue)
-
 				if err != nil {
 					general.ErrorS(err, "ApplyUnifiedDataForContainer failed",
 						"podNamespace", allocationInfo.PodNamespace,

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
@@ -3418,3 +3418,34 @@ func TestDynamicPolicy_adjustAllocationEntries(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSoftMemLimitInBytes(t *testing.T) {
+	t.Parallel()
+	// Test case where memRatio is 50% of memLimit
+	result := getSoftMemLimitInBytes(1024*1024*1024, 50)
+	expected := uint64(536870912) // 50% of 1GB
+	assert.Equal(t, expected, result, "Test case 1 failed")
+
+	// Test case where memRatio is 75% of memLimit
+	result = getSoftMemLimitInBytes(1024*1024*1024, 75)
+	expected = uint64(805306368) // 75% of 1GB
+	assert.Equal(t, expected, result, "Test case 2 failed")
+
+	// Test case where memRatio is 25% of memLimit
+	result = getSoftMemLimitInBytes(512*1024*1024, 25)
+	expected = uint64(134217728) // 25% of 512MB
+	assert.Equal(t, expected, result, "Test case 3 failed")
+
+	// Test case where memRatio is 0% (minimum value)
+	result = getSoftMemLimitInBytes(1024*1024*1024, 0)
+	expected = uint64(134217728) // 0% should be clamped to the minimum value
+	assert.Equal(t, expected, result, "Test case 4 failed")
+}
+
+func TestGetUserSpecifiedMemorySoftLimitInBytes(t *testing.T) {
+	t.Parallel()
+
+	result := getUserSpecifiedMemorySoftLimitInBytes("fake", "fake", "15")
+	expected := "0"
+	assert.Equal(t, expected, result, "Test getUserSpecifiedMemorySoftLimitInBytes failed")
+}

--- a/pkg/util/general/common.go
+++ b/pkg/util/general/common.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -346,6 +347,12 @@ func CovertUInt64ToInt(numUInt64 uint64) (int, error) {
 // Clamp returns value itself if min < value < max; min if value < min; max if value > max
 func Clamp(value, min, max float64) float64 {
 	return math.Max(math.Min(value, max), min)
+}
+
+func AlignToPageSize(number uint64) uint64 {
+	pageSize := uint64(syscall.Getpagesize())
+	alignedNumber := (number + pageSize - 1) &^ (pageSize - 1)
+	return alignedNumber
 }
 
 // FormatMemoryQuantity aligned to Gi Mi Ki


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
This patch provied the feature of memory.low protection.
There are a couple great benefits about memory.low protection:
1, it provides a gradient of protection. As a cgroup's usage grows past the protected amount, the protected amount remains protected, but reclaim pressure for the excess amount gradually increases. 
2, it's work-conserving - if the protected cgroup doesn't use the memory, it's available for others to use. 

#### Which issue(s) this PR fixes:
In production area, some critical services and  pods are affected by  system thrashing.

#### Special notes for your reviewer:
None.
