### PR TITLE
feat: adding support to qos level memory.low protection

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -45,8 +45,9 @@ type SockMemOptions struct {
 }
 
 type MemProtectionOptions struct {
-	EnableSettingMemProtection     bool
-	MemSoftLimitQoSLevelConfigFile string
+	EnableSettingMemProtection        bool
+	MemSoftLimitQoSLevelConfigFile    string
+	MemSoftLimitCgroupLevelConfigFile string
 }
 
 func NewMemoryOptions() *MemoryOptions {
@@ -63,8 +64,9 @@ func NewMemoryOptions() *MemoryOptions {
 			SetCgroupTCPMemRatio: 100, // default: 100% * {cgroup memory}
 		},
 		MemProtectionOptions: MemProtectionOptions{
-			EnableSettingMemProtection:     false,
-			MemSoftLimitQoSLevelConfigFile: "",
+			EnableSettingMemProtection:        false,
+			MemSoftLimitQoSLevelConfigFile:    "",
+			MemSoftLimitCgroupLevelConfigFile: "",
 		},
 	}
 }
@@ -98,7 +100,10 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.EnableSettingMemProtection, "if set true, we will do memory protection in qos level")
 	fs.StringVar(&o.MemSoftLimitQoSLevelConfigFile, "mem-softlimit-qos-config-file",
 		o.MemSoftLimitQoSLevelConfigFile, "the absolute path of mem.low qos level config file")
+	fs.StringVar(&o.MemSoftLimitCgroupLevelConfigFile, "mem-softlimit-cgroup-config-file",
+		o.MemSoftLimitCgroupLevelConfigFile, "the absolute path of mem.low cgroup level config file")
 }
+
 func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.PolicyName = o.PolicyName
 	conf.ReservedMemoryGB = o.ReservedMemoryGB
@@ -113,5 +118,6 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.SetCgroupTCPMemRatio = o.SetCgroupTCPMemRatio
 	conf.EnableSettingMemProtection = o.EnableSettingMemProtection
 	conf.MemSoftLimitQoSLevelConfigFile = o.MemSoftLimitQoSLevelConfigFile
+	conf.MemSoftLimitCgroupLevelConfigFile = o.MemSoftLimitCgroupLevelConfigFile
 	return nil
 }

--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -33,6 +33,7 @@ type MemoryOptions struct {
 	OOMPriorityPinnedMapAbsPath string
 
 	SockMemOptions
+	MemProtectionOptions
 }
 
 type SockMemOptions struct {
@@ -41,6 +42,11 @@ type SockMemOptions struct {
 	SetGlobalTCPMemRatio int
 	// SetCgroupTCPMemLimitRatio limit cgroup max tcp memory usage.
 	SetCgroupTCPMemRatio int
+}
+
+type MemProtectionOptions struct {
+	EnableSettingMemProtection     bool
+	MemSoftLimitQoSLevelConfigFile string
 }
 
 func NewMemoryOptions() *MemoryOptions {
@@ -55,6 +61,10 @@ func NewMemoryOptions() *MemoryOptions {
 			EnableSettingSockMem: false,
 			SetGlobalTCPMemRatio: 20,  // default: 20% * {host total memory}
 			SetCgroupTCPMemRatio: 100, // default: 100% * {cgroup memory}
+		},
+		MemProtectionOptions: MemProtectionOptions{
+			EnableSettingMemProtection:     false,
+			MemSoftLimitQoSLevelConfigFile: "",
 		},
 	}
 }
@@ -84,6 +94,10 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.SetGlobalTCPMemRatio, "limit global max tcp memory usage")
 	fs.IntVar(&o.SetCgroupTCPMemRatio, "qrm-memory-cgroup-tcpmem-ratio",
 		o.SetCgroupTCPMemRatio, "limit cgroup max tcp memory usage")
+	fs.BoolVar(&o.EnableSettingMemProtection, "enable-setting-mem-protection",
+		o.EnableSettingMemProtection, "if set true, we will do memory protection in qos level")
+	fs.StringVar(&o.MemSoftLimitQoSLevelConfigFile, "mem-softlimit-qos-config-file",
+		o.MemSoftLimitQoSLevelConfigFile, "the absolute path of mem.low qos level config file")
 }
 func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.PolicyName = o.PolicyName
@@ -97,5 +111,7 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.EnableSettingSockMem = o.EnableSettingSockMem
 	conf.SetGlobalTCPMemRatio = o.SetGlobalTCPMemRatio
 	conf.SetCgroupTCPMemRatio = o.SetCgroupTCPMemRatio
+	conf.EnableSettingMemProtection = o.EnableSettingMemProtection
+	conf.MemSoftLimitQoSLevelConfigFile = o.MemSoftLimitQoSLevelConfigFile
 	return nil
 }

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -339,11 +339,13 @@ func (p *DynamicPolicy) Start() (err error) {
 
 	if p.enableSettingMemProtection {
 		general.Infof("setMemProtection enabled")
-		err := periodicalhandler.RegisterPeriodicalHandler(qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
-			memprotection.EnableSetMemProtectionPeriodicalHandlerName, memprotection.MemProtectionTaskFunc, 60*time.Second)
-		if err != nil {
-			general.Infof("setSockMem failed, err=%v", err)
-		}
+	} else {
+		general.Infof("setMemProtection disabled, try to disable memory protection related configurations")
+	}
+	err = periodicalhandler.RegisterPeriodicalHandler(qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
+		memprotection.EnableSetMemProtectionPeriodicalHandlerName, memprotection.MemProtectionTaskFunc, 60*time.Second)
+	if err != nil {
+		general.Infof("setSockMem failed, err=%v", err)
 	}
 
 	go wait.Until(func() {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/memoryadvisor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/oom"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/state"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/memprotection"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/handlers/sockmem"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	"github.com/kubewharf/katalyst-core/pkg/agent/utilcomponent/periodicalhandler"
@@ -134,6 +135,7 @@ type DynamicPolicy struct {
 
 	enableSettingMemoryMigrate bool
 	enableSettingSockMem       bool
+	enableSettingMemProtection bool
 	enableMemoryAdvisor        bool
 	memoryAdvisorSocketAbsPath string
 	memoryPluginSocketAbsPath  string
@@ -195,6 +197,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		asyncWorkers:               asyncworker.NewAsyncWorkers(memoryPluginAsyncWorkersName, wrappedEmitter),
 		enableSettingMemoryMigrate: conf.EnableSettingMemoryMigrate,
 		enableSettingSockMem:       conf.EnableSettingSockMem,
+		enableSettingMemProtection: conf.EnableSettingMemProtection,
 		enableMemoryAdvisor:        conf.EnableMemoryAdvisor,
 		memoryAdvisorSocketAbsPath: conf.MemoryAdvisorSocketAbsPath,
 		memoryPluginSocketAbsPath:  conf.MemoryPluginSocketAbsPath,
@@ -329,6 +332,15 @@ func (p *DynamicPolicy) Start() (err error) {
 		err := periodicalhandler.RegisterPeriodicalHandlerWithHealthz(memconsts.SetSockMem,
 			general.HealthzCheckStateNotReady, qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
 			sockmem.SetSockMemLimit, 60*time.Second, healthCheckTolerationTimes)
+		if err != nil {
+			general.Infof("setSockMem failed, err=%v", err)
+		}
+	}
+
+	if p.enableSettingMemProtection {
+		general.Infof("setMemProtection enabled")
+		err := periodicalhandler.RegisterPeriodicalHandler(qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
+			memprotection.EnableSetMemProtectionPeriodicalHandlerName, memprotection.MemProtectionTaskFunc, 60*time.Second)
 		if err != nil {
 			general.Infof("setSockMem failed, err=%v", err)
 		}

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/const.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/const.go
@@ -20,6 +20,7 @@ const EnableSetMemProtectionPeriodicalHandlerName = "SetCGMemProtection"
 
 const (
 	// Constants for cgroup memory statistics
+	cgroupMemory32M       = 33554432
 	cgroupMemory128M      = 134217728
 	cgroupMemoryUnlimited = 9223372036854771712
 

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/const.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/const.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memprotection
+
+const EnableSetMemProtectionPeriodicalHandlerName = "SetCGMemProtection"
+
+const (
+	// Constants for cgroup memory statistics
+	cgroupMemory128M      = 134217728
+	cgroupMemoryUnlimited = 9223372036854771712
+
+	controlKnobKeyMemSoftLimit = "mem_softlimit"
+)
+
+const (
+	metricNameMemLow = "async_handler_cgroup_memlow"
+)

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux.go
@@ -1,0 +1,178 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memprotection
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	cgroupcm "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	cgroupmgr "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+func calculatedBestSoftLimit(memUsage, memFileInactive, userSoftLimit uint64) uint64 {
+	if memFileInactive > memUsage {
+		return 0
+	}
+	minSoftLimit := memUsage - memFileInactive + cgroupMemory128M
+	maxSoftLimit := memUsage + cgroupMemory128M
+	softLimit := uint64(general.Clamp(float64(userSoftLimit), float64(minSoftLimit), float64(maxSoftLimit)))
+	return softLimit
+}
+
+func getUserSpecifiedMemoryProtectionInBytes(memLimit, memUsage uint64, ratioUser string) uint64 {
+	ratio, err := strconv.Atoi(ratioUser)
+	if err != nil {
+		general.Infof("Atoi failed with err: %v", err)
+		return 0
+	}
+	if ratio > 100 || ratio <= 0 {
+		general.Infof("Bad ratio %v", ratio)
+		return 0
+	}
+
+	maxLimit := memLimit
+	if memLimit == cgroupMemoryUnlimited {
+		maxLimit = memUsage + cgroupMemory128M
+	}
+	softLimit := uint64(float64(maxLimit) / 100.0 * float64(ratio))
+	softLimit = general.AlignToPageSize(softLimit)
+	return softLimit
+}
+
+func applyMemSoftLimitQoSLevelConfig(conf *coreconfig.Configuration,
+	emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer) {
+	if conf.MemSoftLimitQoSLevelConfigFile == "" {
+		general.Infof("no MemSoftLimitQoSLevelConfigFile found")
+		return
+	}
+
+	var extraControlKnobConfigs commonstate.ExtraControlKnobConfigs
+	if err := general.LoadJsonConfig(conf.MemSoftLimitQoSLevelConfigFile, &extraControlKnobConfigs); err != nil {
+		general.Errorf("MemSoftLimitQoSLevelConfigFile load failed:%v", err)
+		return
+	}
+	ctx := context.Background()
+	podList, err := metaServer.GetPodList(ctx, native.PodIsActive)
+	if err != nil {
+		general.Infof("get pod list failed: %v", err)
+		return
+	}
+
+	for _, pod := range podList {
+		if pod == nil {
+			general.Warningf("get nil pod from metaServer")
+			continue
+		}
+		if conf.QoSConfiguration == nil {
+			continue
+		}
+		qosConfig := conf.QoSConfiguration
+		qosLevel, err := qosConfig.GetQoSLevelForPod(pod)
+		if err != nil {
+			general.Warningf("GetQoSLevelForPod failed:%v", err)
+			continue
+		}
+		qosLevelDefaultValue, ok := extraControlKnobConfigs[controlKnobKeyMemSoftLimit].QoSLevelToDefaultValue[qosLevel]
+		if !ok {
+			continue
+		}
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			podUID, containerID := string(pod.UID), native.TrimContainerIDPrefix(containerStatus.ContainerID)
+			relCgPath, err := cgroupcm.GetContainerRelativeCgroupPath(podUID, containerID)
+			if err != nil {
+				general.Warningf("GetContainerRelativeCgroupPath failed, pod=%v, container=%v, err=%v", podUID, containerID, err)
+				continue
+			}
+			/*
+			 * I hope to protect cgroup from System-Thrashing(insufficient hot file memory)
+			 * during mem_cgroup_soft_limit_reclaim() through memory.low.
+			 */
+			// Step1, get cgroup memory.limit, memory.usage, inactive-file-memory.
+			memStat, err := cgroupmgr.GetMemoryWithRelativePath(relCgPath)
+			if err != nil {
+				general.Warningf("GetMemoryWithRelativePath failed with err: %v", err)
+				continue
+			}
+
+			// Step2, Reserve a certain ratio of file memory for high-QoS cgroups.
+			userSoftLimit := getUserSpecifiedMemoryProtectionInBytes(memStat.Limit, memStat.Usage, qosLevelDefaultValue)
+			if userSoftLimit == 0 {
+				general.Warningf("getUserSpecifiedMemoryProtectionBytes return 0")
+				continue
+			}
+
+			// Step3, I don't want to hurt existing hot file-memory.
+			// If the reserve file memory is not sufficient for current hot file-memory,
+			// then the final memory.low will be based on current hot file-memory.
+			softLimit := calculatedBestSoftLimit(memStat.Usage, memStat.FileInactive, userSoftLimit)
+
+			// Step4, OK. Set the value for memory.low.
+			var data *cgroupcm.MemoryData
+			data = &cgroupcm.MemoryData{SoftLimitInBytes: int64(softLimit)}
+			if err := cgroupmgr.ApplyMemoryWithRelativePath(relCgPath, data); err != nil {
+				general.Warningf("ApplyMemoryWithRelativePath failed, cgpath=%v, err=%v", relCgPath, err)
+				continue
+			}
+
+			_ = emitter.StoreInt64(metricNameMemLow, int64(softLimit), metrics.MetricTypeNameRaw,
+				metrics.ConvertMapToTags(map[string]string{
+					"podUID":      podUID,
+					"containerID": containerID,
+				})...)
+		}
+	}
+}
+
+func MemProtectionTaskFunc(conf *coreconfig.Configuration,
+	_ interface{}, _ *dynamicconfig.DynamicAgentConfiguration,
+	emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer) {
+	general.Infof("called")
+
+	if conf == nil {
+		general.Errorf("nil extraConf")
+		return
+	} else if emitter == nil {
+		general.Errorf("nil emitter")
+		return
+	} else if metaServer == nil {
+		general.Errorf("nil metaServer")
+		return
+	}
+
+	// SettingMemProtection featuregate.
+	if !conf.EnableSettingMemProtection {
+		general.Infof("EnableSettingMemProtection disabled")
+		return
+	}
+
+	// checking qos-level memory.low configuration.
+	if len(conf.MemSoftLimitQoSLevelConfigFile) > 0 {
+		applyMemSoftLimitQoSLevelConfig(conf, emitter, metaServer)
+	}
+}

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
 	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
@@ -34,6 +35,10 @@ import (
 	cgroupmgr "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+var (
+	initializeOnce sync.Once
 )
 
 func calculatedBestSoftLimit(memUsage, memFileInactive, userSoftLimit uint64) uint64 {
@@ -59,6 +64,14 @@ func getUserSpecifiedMemoryProtectionInBytes(memLimit, memUsage, ratio uint64) u
 	softLimit := uint64(float64(maxLimit) / 100.0 * float64(ratio))
 	softLimit = general.AlignToPageSize(softLimit)
 	return softLimit
+}
+
+func getCgroupMemLowDisableValue() uint64 {
+	var disable uint64 = 1
+	if !common.CheckCgroup2UnifiedMode() {
+		disable = cgroupMemoryUnlimited
+	}
+	return disable
 }
 
 func calculateMemSoftLimit(relCgPath string, ratio uint64) (uint64, error) {
@@ -89,7 +102,7 @@ func calculateMemSoftLimit(relCgPath string, ratio uint64) (uint64, error) {
 }
 
 func applyMemSoftLimitCgroupLevelConfig(conf *coreconfig.Configuration,
-	emitter metrics.MetricEmitter) {
+	emitter metrics.MetricEmitter, enable bool) {
 	if conf.MemSoftLimitCgroupLevelConfigFile == "" {
 		general.Errorf("MemSoftLimitCgroupLevelConfigFile isn't configured")
 		return
@@ -103,11 +116,14 @@ func applyMemSoftLimitCgroupLevelConfig(conf *coreconfig.Configuration,
 	}
 
 	for relCgPath, ratio := range memSoftLimitCgroupLevelConfigs {
-		softLimit, err := calculateMemSoftLimit(relCgPath, ratio)
-		if err != nil {
-			general.Errorf("calculateMemSoftLimit for relativeCgPath: %s failed with error: %v",
-				relCgPath, err)
-			continue
+		var softLimit uint64 = getCgroupMemLowDisableValue()
+		if enable {
+			softLimit, err = calculateMemSoftLimit(relCgPath, ratio)
+			if err != nil {
+				general.Errorf("calculateMemSoftLimit for relativeCgPath: %s failed with error: %v",
+					relCgPath, err)
+				continue
+			}
 		}
 
 		// OK. Set the value for memory.low.
@@ -125,8 +141,7 @@ func applyMemSoftLimitCgroupLevelConfig(conf *coreconfig.Configuration,
 	}
 }
 
-func applyMemSoftLimitQoSLevelConfig(conf *coreconfig.Configuration,
-	emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer) {
+func applyMemSoftLimitQoSLevelConfig(conf *coreconfig.Configuration, emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer, enable bool) {
 	if conf.MemSoftLimitQoSLevelConfigFile == "" {
 		general.Infof("no MemSoftLimitQoSLevelConfigFile found")
 		return
@@ -137,6 +152,7 @@ func applyMemSoftLimitQoSLevelConfig(conf *coreconfig.Configuration,
 		general.Errorf("MemSoftLimitQoSLevelConfigFile load failed:%v", err)
 		return
 	}
+
 	ctx := context.Background()
 	podList, err := metaServer.GetPodList(ctx, native.PodIsActive)
 	if err != nil {
@@ -149,9 +165,11 @@ func applyMemSoftLimitQoSLevelConfig(conf *coreconfig.Configuration,
 			general.Warningf("get nil pod from metaServer")
 			continue
 		}
+
 		if conf.QoSConfiguration == nil {
 			continue
 		}
+
 		qosConfig := conf.QoSConfiguration
 		qosLevel, err := qosConfig.GetQoSLevelForPod(pod)
 		if err != nil {
@@ -177,19 +195,20 @@ func applyMemSoftLimitQoSLevelConfig(conf *coreconfig.Configuration,
 				general.Warningf("GetContainerRelativeCgroupPath failed, pod=%v, container=%v, err=%v", podUID, containerID, err)
 				continue
 			}
-			var softLimit uint64 = 1
-			if ratio != 0 {
-				softLimit, err = calculateMemSoftLimit(relCgPath, uint64(ratio))
-				if err != nil {
-					general.Errorf("calculateMemSoftLimit for relativeCgPath: %s failed with error: %v",
-						relCgPath, err)
-					continue
+
+			var softLimit uint64 = getCgroupMemLowDisableValue()
+			if enable {
+				if ratio != 0 {
+					softLimit, err = calculateMemSoftLimit(relCgPath, uint64(ratio))
+					if err != nil {
+						general.Errorf("calculateMemSoftLimit for relativeCgPath: %s failed with error: %v", relCgPath, err)
+						continue
+					}
 				}
 			}
 
 			// OK. Set the value for memory.low.
-			var data *cgroupcm.MemoryData
-			data = &cgroupcm.MemoryData{SoftLimitInBytes: int64(softLimit)}
+			data := &cgroupcm.MemoryData{SoftLimitInBytes: int64(softLimit)}
 			if err := cgroupmgr.ApplyMemoryWithRelativePath(relCgPath, data); err != nil {
 				general.Warningf("ApplyMemoryWithRelativePath failed, cgpath=%v, err=%v", relCgPath, err)
 				continue
@@ -223,6 +242,10 @@ func MemProtectionTaskFunc(conf *coreconfig.Configuration,
 	// SettingMemProtection featuregate.
 	if !conf.EnableSettingMemProtection {
 		general.Infof("EnableSettingMemProtection disabled")
+		initializeOnce.Do(func() {
+			applyMemSoftLimitQoSLevelConfig(conf, emitter, metaServer, false)
+			applyMemSoftLimitCgroupLevelConfig(conf, emitter, false)
+		})
 		return
 	}
 
@@ -234,11 +257,11 @@ func MemProtectionTaskFunc(conf *coreconfig.Configuration,
 
 	// checking qos-level memory.low configuration.
 	if len(conf.MemSoftLimitQoSLevelConfigFile) > 0 {
-		applyMemSoftLimitQoSLevelConfig(conf, emitter, metaServer)
+		applyMemSoftLimitQoSLevelConfig(conf, emitter, metaServer, true)
 	}
 
 	// checking cgroup-level memory.low configuration.
 	if len(conf.MemSoftLimitCgroupLevelConfigFile) > 0 {
-		applyMemSoftLimitCgroupLevelConfig(conf, emitter)
+		applyMemSoftLimitCgroupLevelConfig(conf, emitter, true)
 	}
 }

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux_test.go
@@ -1,0 +1,367 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memprotection
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent"
+	configagent "github.com/kubewharf/katalyst-core/pkg/config/agent"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	metaagent "github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string) *config.Configuration {
+	testConfiguration, err := options.NewOptions().Config()
+	require.NoError(t, err)
+	require.NotNil(t, testConfiguration)
+
+	testConfiguration.GenericSysAdvisorConfiguration.StateFileDirectory = stateFileDir
+	testConfiguration.MetaServerConfiguration.CheckpointManagerDir = checkpointDir
+
+	return testConfiguration
+}
+
+func makeMetaServer() (*metaserver.MetaServer, error) {
+	server := &metaserver.MetaServer{
+		MetaAgent: &metaagent.MetaAgent{},
+	}
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 1, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	server.KatalystMachineInfo = &machine.KatalystMachineInfo{
+		CPUTopology: cpuTopology,
+	}
+	server.MetricsFetcher = metric.NewFakeMetricsFetcher(metrics.DummyMetrics{})
+	return server, nil
+}
+
+func TestMemProtection(t *testing.T) {
+	t.Parallel()
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection: false,
+						},
+					},
+				},
+			},
+		},
+	}, nil, &dynamicconfig.DynamicAgentConfiguration{}, nil, nil)
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection: true,
+						},
+					},
+				},
+			},
+		},
+	}, nil, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, nil)
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection: true,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, nil)
+
+	metaServer, err := makeMetaServer()
+	assert.NoError(t, err)
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{}}
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection: true,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection: false,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	normalPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  "normalPod",
+			Name: "normalPod",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c",
+				},
+			},
+		},
+	}
+
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{normalPod}}
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection: true,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:     true,
+							MemSoftLimitQoSLevelConfigFile: "",
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	MemProtectionTaskFunc(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:     true,
+							MemSoftLimitQoSLevelConfigFile: "fake",
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, &dynamicconfig.DynamicAgentConfiguration{}, metrics.DummyMetrics{}, metaServer)
+
+	applyMemSoftLimitQoSLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:     true,
+							MemSoftLimitQoSLevelConfigFile: "",
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{}, metaServer)
+
+	jsonContent := `{
+		"mem_softlimit": {
+			"control_knob_info": {
+				"cgroup_subsys_name": "memory",
+				"cgroup_version_to_iface_name": {
+					"v1": "memory.soft_limit_in_bytes",
+					"v2": "memory.low"
+				},
+				"control_knob_value": "0",
+				"oci_property_name": ""
+			},
+			"pod_explicitly_annotation_key": "MemcgSoftLimitValue",
+			"qos_level_to_default_value": {
+				"dedicated_cores": "15",
+				"shared_cores": "15"
+			}
+		}
+	}`
+
+	// Create a temporary file
+	tempFile, err := ioutil.TempFile("", "test.json")
+	if err != nil {
+		fmt.Println("Error creating temporary file:", err)
+		return
+	}
+	defer os.Remove(tempFile.Name()) // Defer removing the temporary file
+
+	// Write the JSON content to the temporary file
+	if _, err := tempFile.WriteString(jsonContent); err != nil {
+		fmt.Println("Error writing to temporary file:", err)
+		return
+	}
+
+	absPath, err := filepath.Abs(tempFile.Name())
+	if err != nil {
+		fmt.Println("Error obtaining absolute path:", err)
+		return
+	}
+
+	applyMemSoftLimitQoSLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:     true,
+							MemSoftLimitQoSLevelConfigFile: absPath,
+						},
+					},
+				},
+			},
+		},
+		GenericConfiguration: &generic.GenericConfiguration{
+			QoSConfiguration: nil,
+		},
+	}, metrics.DummyMetrics{}, metaServer)
+
+	checkpointDir, err := ioutil.TempDir("", "checkpoint-FetchModelResult")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(checkpointDir) }()
+
+	stateFileDir, err := ioutil.TempDir("", "statefile-FetchModelResult")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(stateFileDir) }()
+
+	conf := generateTestConfiguration(t, checkpointDir, stateFileDir)
+
+	applyMemSoftLimitQoSLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:     true,
+							MemSoftLimitQoSLevelConfigFile: absPath,
+						},
+					},
+				},
+			},
+		},
+		GenericConfiguration: &generic.GenericConfiguration{
+			QoSConfiguration: conf.QoSConfiguration,
+		},
+	}, metrics.DummyMetrics{}, metaServer)
+
+	metaServerNil, err := makeMetaServer()
+	assert.NoError(t, err)
+	metaServerNil.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{}}
+
+	applyMemSoftLimitQoSLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:     true,
+							MemSoftLimitQoSLevelConfigFile: absPath,
+						},
+					},
+				},
+			},
+		},
+		GenericConfiguration: &generic.GenericConfiguration{
+			QoSConfiguration: nil,
+		},
+	}, metrics.DummyMetrics{}, metaServerNil)
+}
+
+func TestGetUserSpecifiedMemoryProtectionInBytes(t *testing.T) {
+	t.Parallel()
+
+	result := getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, "10")
+	var expected uint64 = 107376640
+	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
+
+	result = getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, "1a")
+	expected = 0
+	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
+
+	result = getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, "123")
+	expected = 0
+	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
+
+	result = getUserSpecifiedMemoryProtectionInBytes(9223372036854771712, 1073741824, "10")
+	expected = 120799232
+	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
+}
+
+func TestCalculatedBestSoftLimit(t *testing.T) {
+	t.Parallel()
+
+	result := calculatedBestSoftLimit(1073741824.0, 536870912.0, 536870912.0)
+	var expected uint64 = 671088640
+	assert.Equal(t, expected, result, "Test alculatedBestSoftLimit failed")
+
+	result = calculatedBestSoftLimit(1073741824.0, 5368709120.0, 536870912.0)
+	expected = 0
+	assert.Equal(t, expected, result, "Test alculatedBestSoftLimit failed")
+}

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux_test.go
@@ -224,7 +224,7 @@ func TestMemProtection(t *testing.T) {
 				},
 			},
 		},
-	}, metrics.DummyMetrics{}, metaServer)
+	}, metrics.DummyMetrics{}, metaServer, true)
 
 	applyMemSoftLimitCgroupLevelConfig(&coreconfig.Configuration{
 		AgentConfiguration: &agent.AgentConfiguration{
@@ -239,7 +239,7 @@ func TestMemProtection(t *testing.T) {
 				},
 			},
 		},
-	}, metrics.DummyMetrics{})
+	}, metrics.DummyMetrics{}, true)
 
 	applyMemSoftLimitCgroupLevelConfig(&coreconfig.Configuration{
 		AgentConfiguration: &agent.AgentConfiguration{
@@ -254,7 +254,7 @@ func TestMemProtection(t *testing.T) {
 				},
 			},
 		},
-	}, metrics.DummyMetrics{})
+	}, metrics.DummyMetrics{}, true)
 
 	jsonContent := `{
 		"mem_softlimit": {
@@ -311,7 +311,7 @@ func TestMemProtection(t *testing.T) {
 		GenericConfiguration: &generic.GenericConfiguration{
 			QoSConfiguration: nil,
 		},
-	}, metrics.DummyMetrics{}, metaServer)
+	}, metrics.DummyMetrics{}, metaServer, true)
 
 	jsonContent2 := `{
 "fake1": 20,
@@ -351,7 +351,7 @@ func TestMemProtection(t *testing.T) {
 				},
 			},
 		},
-	}, metrics.DummyMetrics{})
+	}, metrics.DummyMetrics{}, true)
 
 	checkpointDir, err := ioutil.TempDir("", "checkpoint-FetchModelResult")
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestMemProtection(t *testing.T) {
 		GenericConfiguration: &generic.GenericConfiguration{
 			QoSConfiguration: conf.QoSConfiguration,
 		},
-	}, metrics.DummyMetrics{}, metaServer)
+	}, metrics.DummyMetrics{}, metaServer, true)
 
 	metaServerNil, err := makeMetaServer()
 	assert.NoError(t, err)
@@ -401,7 +401,7 @@ func TestMemProtection(t *testing.T) {
 		GenericConfiguration: &generic.GenericConfiguration{
 			QoSConfiguration: nil,
 		},
-	}, metrics.DummyMetrics{}, metaServerNil)
+	}, metrics.DummyMetrics{}, metaServerNil, true)
 
 	calculateMemSoftLimit("fake", 10)
 }

--- a/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/memprotection/memprotection_linux_test.go
@@ -226,6 +226,36 @@ func TestMemProtection(t *testing.T) {
 		},
 	}, metrics.DummyMetrics{}, metaServer)
 
+	applyMemSoftLimitCgroupLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:        true,
+							MemSoftLimitCgroupLevelConfigFile: "",
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{})
+
+	applyMemSoftLimitCgroupLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:        true,
+							MemSoftLimitCgroupLevelConfigFile: "fake",
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{})
+
 	jsonContent := `{
 		"mem_softlimit": {
 			"control_knob_info": {
@@ -283,6 +313,46 @@ func TestMemProtection(t *testing.T) {
 		},
 	}, metrics.DummyMetrics{}, metaServer)
 
+	jsonContent2 := `{
+"fake1": 20,
+    "fake2": 20
+}`
+
+	// Create a temporary file
+	tempFile2, err := ioutil.TempFile("", "test2.json")
+	if err != nil {
+		fmt.Println("Error creating temporary file:", err)
+		return
+	}
+	defer os.Remove(tempFile2.Name()) // Defer removing the temporary file
+
+	// Write the JSON content to the temporary file
+	if _, err := tempFile2.WriteString(jsonContent2); err != nil {
+		fmt.Println("Error writing to temporary file:", err)
+		return
+	}
+
+	absPath2, err := filepath.Abs(tempFile2.Name())
+	if err != nil {
+		fmt.Println("Error obtaining absolute path:", err)
+		return
+	}
+
+	applyMemSoftLimitCgroupLevelConfig(&coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			StaticAgentConfiguration: &configagent.StaticAgentConfiguration{
+				QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+					MemoryQRMPluginConfig: &qrm.MemoryQRMPluginConfig{
+						MemProtectionOptions: qrm.MemProtectionOptions{
+							EnableSettingMemProtection:        true,
+							MemSoftLimitCgroupLevelConfigFile: absPath2,
+						},
+					},
+				},
+			},
+		},
+	}, metrics.DummyMetrics{})
+
 	checkpointDir, err := ioutil.TempDir("", "checkpoint-FetchModelResult")
 	require.NoError(t, err)
 	defer func() { _ = os.RemoveAll(checkpointDir) }()
@@ -332,24 +402,22 @@ func TestMemProtection(t *testing.T) {
 			QoSConfiguration: nil,
 		},
 	}, metrics.DummyMetrics{}, metaServerNil)
+
+	calculateMemSoftLimit("fake", 10)
 }
 
 func TestGetUserSpecifiedMemoryProtectionInBytes(t *testing.T) {
 	t.Parallel()
 
-	result := getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, "10")
+	result := getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, 10)
 	var expected uint64 = 107376640
 	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
 
-	result = getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, "1a")
+	result = getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, 123)
 	expected = 0
 	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
 
-	result = getUserSpecifiedMemoryProtectionInBytes(1073741824, 107374182, "123")
-	expected = 0
-	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
-
-	result = getUserSpecifiedMemoryProtectionInBytes(9223372036854771712, 1073741824, "10")
+	result = getUserSpecifiedMemoryProtectionInBytes(9223372036854771712, 1073741824, 10)
 	expected = 120799232
 	assert.Equal(t, expected, result, "Test getUserSpecifiedMemProtectionInBytes failed")
 }
@@ -358,7 +426,7 @@ func TestCalculatedBestSoftLimit(t *testing.T) {
 	t.Parallel()
 
 	result := calculatedBestSoftLimit(1073741824.0, 536870912.0, 536870912.0)
-	var expected uint64 = 671088640
+	var expected uint64 = 0x22000000
 	assert.Equal(t, expected, result, "Test alculatedBestSoftLimit failed")
 
 	result = calculatedBestSoftLimit(1073741824.0, 5368709120.0, 536870912.0)

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -50,8 +50,9 @@ type SockMemQRMPluginConfig struct {
 }
 
 type MemProtectionOptions struct {
-	EnableSettingMemProtection     bool
-	MemSoftLimitQoSLevelConfigFile string
+	EnableSettingMemProtection        bool
+	MemSoftLimitQoSLevelConfigFile    string
+	MemSoftLimitCgroupLevelConfigFile string
 }
 
 func NewMemoryQRMPluginConfig() *MemoryQRMPluginConfig {

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -36,6 +36,8 @@ type MemoryQRMPluginConfig struct {
 
 	// SockMemQRMPluginConfig: the configuration for sockmem limitation in cgroup and host level
 	SockMemQRMPluginConfig
+	// MemProtectionOptions: the configuration for cgroup memory protection in qos level
+	MemProtectionOptions
 }
 
 type SockMemQRMPluginConfig struct {
@@ -45,6 +47,11 @@ type SockMemQRMPluginConfig struct {
 	SetGlobalTCPMemRatio int
 	// SetCgroupTCPMemRatio limit cgroup max tcp memory usage.
 	SetCgroupTCPMemRatio int
+}
+
+type MemProtectionOptions struct {
+	EnableSettingMemProtection     bool
+	MemSoftLimitQoSLevelConfigFile string
 }
 
 func NewMemoryQRMPluginConfig() *MemoryQRMPluginConfig {

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -152,8 +152,10 @@ func (iocmd *IOCostModelData) String() string {
 
 // MemoryStats get cgroup memory data
 type MemoryStats struct {
-	Limit uint64
-	Usage uint64
+	Limit        uint64
+	Usage        uint64
+	File         uint64
+	FileInactive uint64
 }
 
 // CPUStats get cgroup cpu data

--- a/pkg/util/cgroup/manager/v1/fs_linux_test.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux_test.go
@@ -92,3 +92,47 @@ func Test_manager_ApplyMemory(t *testing.T) {
 		})
 	}
 }
+
+func Test_manager_GetMemory(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		absCgroupPath string
+	}
+	tests := []struct {
+		name    string
+		m       *manager
+		args    args
+		want    *common.MemoryStats
+		wantErr bool
+	}{
+		{
+			name: "test get memory",
+			m:    NewManager(),
+			args: args{
+				absCgroupPath: "test-fake-path",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &manager{}
+			got, err := m.GetMemory(tt.args.absCgroupPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("manager.GetMemory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("manager.GetMemory() = %v, want %v", got, tt.want)
+			}
+
+			_, _, err = GetMemoryStatsFromStatFile(tt.args.absCgroupPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMemoryStatsFromStatFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/pkg/util/cgroup/manager/v2/fs_linux.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux.go
@@ -245,6 +245,36 @@ func (m *manager) ApplyUnifiedData(absCgroupPath, cgroupFileName, data string) e
 	return nil
 }
 
+func GetMemoryStatsFromStatFile(absCgroupPath string) (uint64, uint64, error) {
+	statFile := filepath.Join(absCgroupPath, "memory.stat")
+	content, err := ioutil.ReadFile(statFile)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read %s: %v", statFile, err)
+	}
+
+	var cache, fileInactive uint64
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		key := fields[0]
+		value, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("failed to parse value in %s: %v", statFile, err)
+		}
+		switch key {
+		case "file":
+			cache = value
+		case "inactive_file":
+			fileInactive = value
+		}
+	}
+
+	return cache, fileInactive, nil
+}
+
 func (m *manager) GetMemory(absCgroupPath string) (*common.MemoryStats, error) {
 	memoryStats := &common.MemoryStats{}
 	moduleName := "memory"
@@ -262,6 +292,13 @@ func (m *manager) GetMemory(absCgroupPath string) (*common.MemoryStats, error) {
 		return nil, fmt.Errorf("failed to parse %s, %v", usageFile, err)
 	}
 	memoryStats.Usage = usage
+
+	cache, fileInactive, err := GetMemoryStatsFromStatFile(absCgroupPath)
+	if err != nil {
+		return nil, err
+	}
+	memoryStats.File = cache
+	memoryStats.FileInactive = fileInactive
 
 	return memoryStats, nil
 }

--- a/pkg/util/cgroup/manager/v2/fs_linux_test.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux_test.go
@@ -406,6 +406,12 @@ func Test_manager_GetMemory(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("manager.GetMemory() = %v, want %v", got, tt.want)
 			}
+
+			_, _, err = GetMemoryStatsFromStatFile(tt.args.absCgroupPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMemoryStatsFromStatFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 		})
 	}
 }

--- a/pkg/util/general/common.go
+++ b/pkg/util/general/common.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -346,6 +347,13 @@ func CovertUInt64ToInt(numUInt64 uint64) (int, error) {
 // Clamp returns value itself if min < value < max; min if value < min; max if value > max
 func Clamp(value, min, max float64) float64 {
 	return math.Max(math.Min(value, max), min)
+}
+
+// AlignToPageSize returns the value aligned with page size
+func AlignToPageSize(number uint64) uint64 {
+	pageSize := uint64(syscall.Getpagesize())
+	alignedNumber := (number + pageSize - 1) &^ (pageSize - 1)
+	return alignedNumber
 }
 
 // FormatMemoryQuantity aligned to Gi Mi Ki

--- a/pkg/util/general/common_test.go
+++ b/pkg/util/general/common_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package general
 
 import (
+	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -148,4 +150,17 @@ func TestFormatMemoryQutantity(t *testing.T) {
 	as.Equal("1024[1Ki]", FormatMemoryQuantity(1<<10))
 	as.Equal("1.048576e+06[1Mi]", FormatMemoryQuantity(1<<20))
 	as.Equal("1.073741824e+09[1Gi]", FormatMemoryQuantity(1<<30))
+}
+
+func TestAlignToPageSize(t *testing.T) {
+	t.Parallel()
+	pageSize := uint64(syscall.Getpagesize())
+
+	// Test case 1: Number already aligned to page size
+	result := AlignToPageSize(pageSize * 2)
+	assert.Equal(t, pageSize*2, result, "Unexpected result for aligned number")
+
+	// Test case 2: Number smaller than page size
+	result = AlignToPageSize(pageSize - 1)
+	assert.Equal(t, pageSize, result, "Unexpected result for number smaller than page size")
 }


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
This patch provied the feature of memory.low protection.
There are a couple great benefits about memory.low protection:
1, it provides a gradient of protection. As a cgroup's usage grows past the protected amount, the protected amount remains protected, but reclaim pressure for the excess amount gradually increases.
2, it's work-conserving - if the protected cgroup doesn't use the memory, it's available for others to use.

#### Which issue(s) this PR fixes:
In production area, some critical services and pods are affected by system thrashing.

#### Special notes for your reviewer:
None