### PR TITLE
feat(topology scheduler plugin): check shared resource in topologyMatch

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -78,6 +78,7 @@ func (cache *extendedCache) RemovePod(pod *v1.Pod) error {
 		klog.ErrorS(nil, "Node not found when trying to remove pod", "node", klog.KRef("", pod.Spec.NodeName), "pod", klog.KObj(pod))
 	} else {
 		n.RemovePod(key, pod)
+		n.DeleteAssumedPod(pod)
 	}
 
 	return nil

--- a/pkg/scheduler/cache/nodeinfo.go
+++ b/pkg/scheduler/cache/nodeinfo.go
@@ -22,9 +22,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	apis "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/scheduler/util"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
@@ -32,6 +34,9 @@ import (
 type PodInfo struct {
 	QoSResourcesRequested        *native.QoSResource
 	QoSResourcesNonZeroRequested *native.QoSResource
+
+	ResourcesRequested        *framework.Resource
+	ResourcesNonZeroRequested *framework.Resource
 }
 
 // NodeInfo is node level aggregated information.
@@ -51,8 +56,15 @@ type NodeInfo struct {
 	// as int64, to avoid conversions and accessing map.
 	QoSResourcesAllocatable *native.QoSResource
 
+	// Total requested shared resources of this node, includes assumed pods.
+	// available resource on nonDedicated numa should be checked when scheduling
+	// shared pods and dedicated pods.
+	SharedResourcesRequested        *framework.Resource
+	SharedResourcesNonZeroRequested *framework.Resource
+
 	// record PodInfo here since we may have the functionality to
 	// change pod resources.
+	// reclaimed and shared pods are recorded.
 	Pods map[string]*PodInfo
 
 	// node TopologyPolicy and TopologyZones from CNR status.
@@ -68,12 +80,14 @@ type NodeInfo struct {
 // the returned object.
 func NewNodeInfo() *NodeInfo {
 	ni := &NodeInfo{
-		QoSResourcesRequested:        &native.QoSResource{},
-		QoSResourcesNonZeroRequested: &native.QoSResource{},
-		QoSResourcesAllocatable:      &native.QoSResource{},
-		Pods:                         make(map[string]*PodInfo),
-		ResourceTopology:             new(ResourceTopology),
-		AssumedPodResources:          native.PodResource{},
+		QoSResourcesRequested:           &native.QoSResource{},
+		QoSResourcesNonZeroRequested:    &native.QoSResource{},
+		QoSResourcesAllocatable:         &native.QoSResource{},
+		SharedResourcesRequested:        &framework.Resource{},
+		SharedResourcesNonZeroRequested: &framework.Resource{},
+		Pods:                            make(map[string]*PodInfo),
+		ResourceTopology:                new(ResourceTopology),
+		AssumedPodResources:             native.PodResource{},
 	}
 	return ni
 }
@@ -137,7 +151,49 @@ func (n *NodeInfo) updateTopology(cnr *apis.CustomNodeResource) {
 
 // AddPod adds pod information to this NodeInfo.
 func (n *NodeInfo) AddPod(key string, pod *v1.Pod) {
-	// always try to clean previous pod, and then insert
+	qosLevel, err := util.GetQosLevelForPod(pod)
+	if err != nil {
+		klog.Errorf("AddPod %v fail: %v", key, err)
+		return
+	}
+
+	switch qosLevel {
+	case consts.PodAnnotationQoSLevelReclaimedCores:
+		n.addReclaimedPod(key, pod)
+	case consts.PodAnnotationQoSLevelSharedCores:
+		n.addSharedPod(key, pod)
+	default:
+		// only add reclaimed and shared pods when they are watched.
+		// dedicated caches will be updated when CNR updated.
+		return
+	}
+}
+
+// RemovePod subtracts pod information from this NodeInfo.
+func (n *NodeInfo) RemovePod(key string, _ *v1.Pod) {
+	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
+
+	podInfo, ok := n.Pods[key]
+	if !ok {
+		return
+	}
+	n.QoSResourcesRequested.ReclaimedMilliCPU -= podInfo.QoSResourcesRequested.ReclaimedMilliCPU
+	n.QoSResourcesRequested.ReclaimedMemory -= podInfo.QoSResourcesRequested.ReclaimedMemory
+
+	n.QoSResourcesNonZeroRequested.ReclaimedMilliCPU -= podInfo.QoSResourcesNonZeroRequested.ReclaimedMilliCPU
+	n.QoSResourcesNonZeroRequested.ReclaimedMemory -= podInfo.QoSResourcesNonZeroRequested.ReclaimedMemory
+
+	n.SharedResourcesRequested.MilliCPU -= podInfo.ResourcesRequested.MilliCPU
+	n.SharedResourcesRequested.Memory -= podInfo.ResourcesRequested.Memory
+
+	n.SharedResourcesNonZeroRequested.MilliCPU -= podInfo.ResourcesNonZeroRequested.MilliCPU
+	n.SharedResourcesNonZeroRequested.Memory -= podInfo.ResourcesNonZeroRequested.Memory
+
+	delete(n.Pods, key)
+}
+
+func (n *NodeInfo) addReclaimedPod(key string, pod *v1.Pod) {
 	n.RemovePod(key, pod)
 
 	res, non0CPU, non0Mem := native.CalculateQoSResource(pod)
@@ -151,6 +207,8 @@ func (n *NodeInfo) AddPod(key string, pod *v1.Pod) {
 			ReclaimedMilliCPU: non0CPU,
 			ReclaimedMemory:   non0Mem,
 		},
+		ResourcesRequested:        &framework.Resource{},
+		ResourcesNonZeroRequested: &framework.Resource{},
 	}
 
 	n.QoSResourcesRequested.ReclaimedMilliCPU += res.ReclaimedMilliCPU
@@ -160,21 +218,34 @@ func (n *NodeInfo) AddPod(key string, pod *v1.Pod) {
 	n.QoSResourcesNonZeroRequested.ReclaimedMemory += non0Mem
 }
 
-// RemovePod subtracts pod information from this NodeInfo.
-func (n *NodeInfo) RemovePod(key string, pod *v1.Pod) {
-	n.Mutex.Lock()
-	defer n.Mutex.Unlock()
-
-	podInfo, ok := n.Pods[key]
-	if !ok {
+func (n *NodeInfo) addSharedPod(key string, pod *v1.Pod) {
+	// skip daemon pod
+	if native.CheckDaemonPod(pod) {
 		return
 	}
 
-	n.QoSResourcesRequested.ReclaimedMilliCPU -= podInfo.QoSResourcesRequested.ReclaimedMilliCPU
-	n.QoSResourcesRequested.ReclaimedMemory -= podInfo.QoSResourcesRequested.ReclaimedMemory
+	n.RemovePod(key, pod)
 
-	n.QoSResourcesNonZeroRequested.ReclaimedMilliCPU -= podInfo.QoSResourcesNonZeroRequested.ReclaimedMilliCPU
-	n.QoSResourcesNonZeroRequested.ReclaimedMemory -= podInfo.QoSResourcesNonZeroRequested.ReclaimedMemory
+	res, non0CPU, non0Mem := util.CalculateEffectiveResource(pod)
+
+	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
+
+	n.Pods[key] = &PodInfo{
+		QoSResourcesRequested:        &native.QoSResource{},
+		QoSResourcesNonZeroRequested: &native.QoSResource{},
+		ResourcesRequested:           &res,
+		ResourcesNonZeroRequested: &framework.Resource{
+			MilliCPU: non0CPU,
+			Memory:   non0Mem,
+		},
+	}
+
+	n.SharedResourcesRequested.MilliCPU += res.MilliCPU
+	n.SharedResourcesRequested.Memory += res.Memory
+
+	n.SharedResourcesNonZeroRequested.MilliCPU += non0CPU
+	n.SharedResourcesNonZeroRequested.Memory += non0Mem
 }
 
 func (n *NodeInfo) AddAssumedPod(pod *v1.Pod) {
@@ -199,4 +270,11 @@ func (n *NodeInfo) GetResourceTopologyCopy(filterFn podFilter) *ResourceTopology
 	}
 
 	return n.ResourceTopology.WithPodReousrce(n.AssumedPodResources, filterFn)
+}
+
+func (n *NodeInfo) GetSharedResourcesRequested() *framework.Resource {
+	n.Mutex.RLock()
+	defer n.Mutex.RUnlock()
+
+	return n.SharedResourcesRequested.Clone()
 }

--- a/pkg/scheduler/eventhandlers/cache_test.go
+++ b/pkg/scheduler/eventhandlers/cache_test.go
@@ -27,7 +27,9 @@ import (
 
 	apis "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
 	schedulercache "github.com/kubewharf/katalyst-core/pkg/scheduler/cache"
+	"github.com/kubewharf/katalyst-core/pkg/scheduler/util"
 )
 
 var makeCachedPod = func(uid types.UID, name string, res v1.ResourceList, node string) *v1.Pod {
@@ -36,6 +38,9 @@ var makeCachedPod = func(uid types.UID, name string, res v1.ResourceList, node s
 			Namespace: "n1",
 			Name:      name,
 			UID:       uid,
+			Annotations: map[string]string{
+				consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
@@ -68,6 +73,7 @@ var makeCachedCNR = func(name string, res v1.ResourceList) *apis.CustomNodeResou
 func Test_CalculateQoSResource(t *testing.T) {
 	t.Parallel()
 
+	util.SetQoSConfig(generic.NewQoSConfiguration())
 	cache := schedulercache.GetCache()
 
 	_, err := cache.GetNodeInfo("c1")

--- a/pkg/scheduler/eventhandlers/pod_handler.go
+++ b/pkg/scheduler/eventhandlers/pod_handler.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/kubewharf/katalyst-api/pkg/client/informers/externalversions"
 	schedulercache "github.com/kubewharf/katalyst-core/pkg/scheduler/cache"
-	"github.com/kubewharf/katalyst-core/pkg/scheduler/util"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
@@ -39,12 +38,12 @@ func AddPodEventHandler(informerFactory informers.SharedInformerFactory, _ exter
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
 				case *v1.Pod:
-					return util.IsReclaimedPod(t) && native.IsAssignedPod(t)
+					return native.IsAssignedPod(t)
 				case cache.DeletedFinalStateUnknown:
-					if pod, ok := t.Obj.(*v1.Pod); ok {
+					if _, ok := t.Obj.(*v1.Pod); ok {
 						// The carried object may be stale, so we don't use it to check if
 						// it's assigned or not. Attempting to cleanup anyways.
-						return util.IsReclaimedPod(pod)
+						return true
 					}
 					utilruntime.HandleError(fmt.Errorf("unable to convert object %T to *v1.Pod", obj))
 					return false

--- a/pkg/scheduler/plugins/noderesourcetopology/filter.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/filter.go
@@ -92,6 +92,14 @@ func (tm *TopologyMatch) filterHanlder(pod *v1.Pod, nodeResourceTopology *cache.
 	}
 
 	if tm.resourcePolicy == consts.ResourcePluginPolicyNameDynamic {
+		// shared_cores
+		// check nonDedicated NUMA resource satisfied for shared requests.
+		if util.IsSharedPod(pod) {
+			return func(pod *v1.Pod, zones []*v1alpha1.TopologyZone, info *framework.NodeInfo) *framework.Status {
+				return tm.sharedCoresHandler(pod, zones, info)
+			}
+		}
+
 		// dedicated_cores + numa_binding
 		// single-numa-node and numeric container level supported
 		if util.IsDedicatedPod(pod) && util.IsNumaBinding(pod) && !util.IsExclusive(pod) {
@@ -157,7 +165,65 @@ func singleNUMAContainerLevelHandler(pod *v1.Pod, zones []*v1alpha1.TopologyZone
 		subtractFromNUMA(NUMANodes, numaID, container)
 	}
 
+	if policy == consts.ResourcePluginPolicyNameDynamic {
+		// check if nonDedicated NUMA resource satisfied for shared pods.
+		err := resourcesAvailableForSharedPods(NUMANodes, nil, nodeInfo)
+		if err != nil {
+			return framework.NewStatus(framework.Unschedulable, err.Error())
+		}
+	}
+
 	return nil
+}
+
+func resourcesAvailableForSharedPods(numaNodes NUMANodeList, sharedPod *v1.Pod, nodeInfo *framework.NodeInfo) error {
+	// get allocated shared requests including reserved shared pods.
+	nodeCache, err := cache.GetCache().GetNodeInfo(nodeInfo.Node().Name)
+	if err != nil {
+		klog.Errorf("getNodeInfo %v from cache fail: %v", nodeInfo.Node().Name, err)
+		return err
+	}
+	sharedResourcesRequested := nodeCache.GetSharedResourcesRequested()
+	if sharedPod != nil {
+		// if sharedPod is not nil, add pod requests to allocated requests.
+		podRequest := util.GetPodEffectiveRequest(sharedPod)
+		sharedResourcesRequested.Add(podRequest)
+	}
+
+	// get available resource for shared pods from dedicated NUMA allocated data.
+	availableResources := getAvailableResourceForSharedPods(numaNodes)
+	klog.V(6).Infof("node %v sharedResourcesRequested cpu: %v, sharedResourceRequested memory: %v, availableResources cpu: %v, availableResources memory: %v",
+		nodeInfo.Node().Name, sharedResourcesRequested.MilliCPU, sharedResourcesRequested.Memory, availableResources.MilliCPU, availableResources.Memory)
+
+	// check resource satisfied, only CPU and memory now.
+	if availableResources.MilliCPU < sharedResourcesRequested.MilliCPU {
+		err = fmt.Errorf("node %v shared milliCPU insufficient, availableResources milliCPU: %v, sharedResourcesRequested milliCPU: %v",
+			nodeInfo.Node().Name, availableResources.MilliCPU, sharedResourcesRequested.MilliCPU)
+		klog.V(5).Infof(err.Error())
+		return err
+	}
+	if availableResources.Memory < sharedResourcesRequested.Memory {
+		err = fmt.Errorf("node %v shared memory insufficient, availableResources memory: %v, sharedResourcesRequested memory: %v",
+			nodeInfo.Node().Name, availableResources.Memory, sharedResourcesRequested.Memory)
+		klog.V(5).Infof(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func getAvailableResourceForSharedPods(numaNodes NUMANodeList) *framework.Resource {
+	resource := &framework.Resource{}
+
+	for _, numaNode := range numaNodes {
+		if numaNode.Allocated {
+			continue
+		}
+
+		resource.Add(numaNode.Allocatable)
+	}
+
+	return resource
 }
 
 func resourcesAvailableInAnyNUMANodes(numaNodes NUMANodeList, resources v1.ResourceList, alignedResource sets.String, nodeInfo *framework.NodeInfo) (int, bool) {
@@ -250,6 +316,7 @@ func subtractFromNUMA(nodes NUMANodeList, numaID int, container v1.Container) {
 			}
 			nRes[resName] = nodeResQuan
 		}
+		nodes[i].Allocated = true
 	}
 }
 
@@ -298,6 +365,7 @@ func subtractFromNUMAs(
 				}
 			}
 			numaNode.Available[v1.ResourceName(resourceName)] = resourceQuantity
+			numaNode.Allocated = true
 			nodeMap[numaID] = numaNode
 		}
 	}

--- a/pkg/scheduler/plugins/noderesourcetopology/filter_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/filter_test.go
@@ -998,3 +998,986 @@ func TestFilterDedicatedExclusive(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterSharedCores(t *testing.T) {
+	type testCase struct {
+		name       string
+		cnr        *v1alpha1.CustomNodeResource
+		node       *v1.Node
+		existsPods []*v1.Pod
+		pod        *v1.Pod
+		wantRes    *framework.Status
+	}
+
+	testCases := []testCase{
+		{
+			name: "empty node",
+			cnr: &v1alpha1.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1alpha1.CustomNodeResourceStatus{
+					TopologyZone: []*v1alpha1.TopologyZone{
+						{
+							Name: "0",
+							Type: v1alpha1.TopologyTypeSocket,
+							Children: []*v1alpha1.TopologyZone{
+								{
+									Name: "0",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+								},
+								{
+									Name: "1",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existsPods: []*v1.Pod{},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1.NodeStatus{
+					Capacity: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPod",
+					UID:  "testUID",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "testContainer",
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRes: nil,
+		},
+		{
+			name: "numa not satisfy",
+			cnr: &v1alpha1.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1alpha1.CustomNodeResourceStatus{
+					TopologyZone: []*v1alpha1.TopologyZone{
+						{
+							Name: "0",
+							Type: v1alpha1.TopologyTypeSocket,
+							Children: []*v1alpha1.TopologyZone{
+								{
+									Name: "0",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+									Allocations: []*v1alpha1.Allocation{
+										{
+											Consumer: "/dedicated1/dedicated1",
+											Requests: &v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("4Gi"),
+											},
+										},
+									},
+								},
+								{
+									Name: "1",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+									Allocations: []*v1alpha1.Allocation{
+										{
+											Consumer: "/dedicated2/dedicated2",
+											Requests: &v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("4Gi"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existsPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dedicated1",
+						UID:  "dedicated1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+							consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dedicated2",
+						UID:  "dedicated2",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+							consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1.NodeStatus{
+					Capacity: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPod",
+					UID:  "testUID",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "testContainer",
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRes: framework.NewStatus(framework.Unschedulable, ""),
+		},
+		{
+			name: "single numa resource not satisfy",
+			cnr: &v1alpha1.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1alpha1.CustomNodeResourceStatus{
+					TopologyZone: []*v1alpha1.TopologyZone{
+						{
+							Name: "0",
+							Type: v1alpha1.TopologyTypeSocket,
+							Children: []*v1alpha1.TopologyZone{
+								{
+									Name: "0",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+									Allocations: []*v1alpha1.Allocation{
+										{
+											Consumer: "/dedicated1/dedicated1",
+											Requests: &v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("4Gi"),
+											},
+										},
+									},
+								},
+								{
+									Name: "1",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existsPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dedicated1",
+						UID:  "dedicated1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+							consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared1",
+						UID:  "shared1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1.NodeStatus{
+					Capacity: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPod",
+					UID:  "testUID",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "testContainer",
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("6Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("6Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRes: framework.NewStatus(framework.Unschedulable, ""),
+		},
+		{
+			name: "numa resource not satisfy for existed shared pods",
+			cnr: &v1alpha1.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1alpha1.CustomNodeResourceStatus{
+					TopologyPolicy: "NumericContainerLevel",
+					TopologyZone: []*v1alpha1.TopologyZone{
+						{
+							Name: "0",
+							Type: v1alpha1.TopologyTypeSocket,
+							Children: []*v1alpha1.TopologyZone{
+								{
+									Name: "0",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+									Allocations: []*v1alpha1.Allocation{
+										{
+											Consumer: "/dedicated1/dedicated1",
+											Requests: &v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("4Gi"),
+											},
+										},
+									},
+								},
+								{
+									Name: "1",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existsPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared2",
+						UID:  "shared2",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared1",
+						UID:  "shared1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared3",
+						UID:  "shared3",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1.NodeStatus{
+					Capacity: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPod",
+					UID:  "testUID",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+						consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "testContainer",
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRes: framework.NewStatus(framework.Unschedulable, ""),
+		},
+		{
+			name: "numa resource not satisfy for existed shared pods singlenumanode",
+			cnr: &v1alpha1.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1alpha1.CustomNodeResourceStatus{
+					TopologyPolicy: "SingleNUMANodeContainerLevel",
+					TopologyZone: []*v1alpha1.TopologyZone{
+						{
+							Name: "0",
+							Type: v1alpha1.TopologyTypeSocket,
+							Children: []*v1alpha1.TopologyZone{
+								{
+									Name: "0",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+									Allocations: []*v1alpha1.Allocation{
+										{
+											Consumer: "/dedicated1/dedicated1",
+											Requests: &v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("4Gi"),
+											},
+										},
+									},
+								},
+								{
+									Name: "1",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existsPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared2",
+						UID:  "shared2",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared1",
+						UID:  "shared1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared3",
+						UID:  "shared3",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1.NodeStatus{
+					Capacity: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPod",
+					UID:  "testUID",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+						consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "testContainer",
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRes: framework.NewStatus(framework.Unschedulable, ""),
+		},
+		{
+			name: "numa resource satisfy for existed shared pods",
+			cnr: &v1alpha1.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1alpha1.CustomNodeResourceStatus{
+					TopologyPolicy: "SingleNumaNodeContainerLevel",
+					TopologyZone: []*v1alpha1.TopologyZone{
+						{
+							Name: "0",
+							Type: v1alpha1.TopologyTypeSocket,
+							Children: []*v1alpha1.TopologyZone{
+								{
+									Name: "0",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+									Allocations: []*v1alpha1.Allocation{
+										{
+											Consumer: "/dedicated1/dedicated1",
+											Requests: &v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse("2"),
+												v1.ResourceMemory: resource.MustParse("4Gi"),
+											},
+										},
+									},
+								},
+								{
+									Name: "1",
+									Type: v1alpha1.TopologyTypeNuma,
+									Resources: v1alpha1.Resources{
+										Capacity: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+										Allocatable: &v1.ResourceList{
+											v1.ResourceCPU:    resource.MustParse("4"),
+											v1.ResourceMemory: resource.MustParse("8Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existsPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared2",
+						UID:  "shared2",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "shared1",
+						UID:  "shared1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dedicated1",
+						UID:  "dedicated1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "testNode",
+						Containers: []v1.Container{
+							{
+								Name: "testContainer",
+								Resources: v1.ResourceRequirements{
+									Requests: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+									Limits: map[v1.ResourceName]resource.Quantity{
+										v1.ResourceCPU:    resource.MustParse("2"),
+										v1.ResourceMemory: resource.MustParse("4Gi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode",
+				},
+				Status: v1.NodeStatus{
+					Capacity: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testPod",
+					UID:  "testUID",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+						consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "testContainer",
+							Resources: v1.ResourceRequirements{
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceCPU:    resource.MustParse("2"),
+									v1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantRes: nil,
+		},
+	}
+
+	c := cache.GetCache()
+	util.SetQoSConfig(generic.NewQoSConfiguration())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.AddOrUpdateCNR(tc.cnr)
+			for _, pod := range tc.existsPods {
+				c.AddPod(pod)
+			}
+
+			nodeInfo := framework.NewNodeInfo(tc.existsPods...)
+			nodeInfo.SetNode(tc.node)
+
+			f, err := runtime.NewFramework(nil, nil,
+				runtime.WithSnapshotSharedLister(newTestSharedLister(tc.existsPods, []*v1.Node{tc.node})))
+			assert.NoError(t, err)
+
+			tm, err := MakeTestTm(MakeTestArgs(config.MostAllocated, []string{}, "dynamic"), f)
+			assert.NoError(t, err)
+
+			status := tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.pod, nodeInfo)
+			if status == nil {
+				assert.Equal(t, tc.wantRes, status)
+			} else {
+				assert.Equal(t, tc.wantRes.Code(), status.Code())
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/noderesourcetopology/plugin.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/plugin.go
@@ -56,6 +56,7 @@ type NUMANode struct {
 	Allocatable v1.ResourceList
 	Available   v1.ResourceList
 	Costs       map[int]int
+	Allocated   bool
 }
 
 type NUMANodeList []NUMANode
@@ -140,7 +141,7 @@ func (tm *TopologyMatch) topologyMatchSupport(pod *v1.Pod) bool {
 
 	if tm.resourcePolicy == consts.ResourcePluginPolicyNameDynamic {
 		// dynamic policy, only dedicated_cores with numaBinding supported
-		if util.IsDedicatedPod(pod) && util.IsNumaBinding(pod) {
+		if util.IsSharedPod(pod) || (util.IsDedicatedPod(pod) && util.IsNumaBinding(pod)) {
 			return true
 		}
 	}
@@ -205,13 +206,14 @@ func TopologyZonesToNUMANodeList(zones []*v1alpha1.TopologyZone) NUMANodeList {
 				klog.Error(err)
 				continue
 			}
-			capacity, allocatable, available := extractAvailableResources(child)
+			capacity, allocatable, available, allocated := extractAvailableResources(child)
 			nodes = append(nodes, NUMANode{
 				SocketID:    topologyZone.Name,
 				NUMAID:      numaID,
 				Capacity:    capacity,
 				Allocatable: allocatable,
 				Available:   available,
+				Allocated:   allocated,
 			})
 		}
 	}
@@ -235,13 +237,14 @@ func TopologyZonesToNUMANodeMap(zones []*v1alpha1.TopologyZone) map[int]NUMANode
 				klog.Error(err)
 				continue
 			}
-			capacity, allocatable, available := extractAvailableResources(child)
+			capacity, allocatable, available, allocated := extractAvailableResources(child)
 			numaNodeMap[numaID] = NUMANode{
 				SocketID:    topologyZone.Name,
 				NUMAID:      numaID,
 				Capacity:    capacity,
 				Allocatable: allocatable,
 				Available:   available,
+				Allocated:   allocated,
 			}
 		}
 	}
@@ -262,7 +265,7 @@ func getID(name string) (int, error) {
 	return numaID, nil
 }
 
-func extractAvailableResources(zone *v1alpha1.TopologyZone) (capacity, allocatable, available v1.ResourceList) {
+func extractAvailableResources(zone *v1alpha1.TopologyZone) (capacity, allocatable, available v1.ResourceList, allocated bool) {
 	used := make(v1.ResourceList)
 	for _, alloc := range zone.Allocations {
 		for resName, quantity := range *alloc.Requests {
@@ -274,8 +277,9 @@ func extractAvailableResources(zone *v1alpha1.TopologyZone) (capacity, allocatab
 				used[resName] = value
 			}
 		}
+		allocated = true
 	}
-	return zone.Resources.Capacity.DeepCopy(), zone.Resources.Allocatable.DeepCopy(), quotav1.SubtractWithNonNegativeResult(*zone.Resources.Allocatable, used)
+	return zone.Resources.Capacity.DeepCopy(), zone.Resources.Allocatable.DeepCopy(), quotav1.SubtractWithNonNegativeResult(*zone.Resources.Allocatable, used), allocated
 }
 
 func minNumaNodeCount(resourceName v1.ResourceName, quantity resource.Quantity, numaNodeMap map[int]NUMANode) int {

--- a/pkg/scheduler/plugins/noderesourcetopology/plugin_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/plugin_test.go
@@ -19,14 +19,14 @@ package noderesourcetopology
 import (
 	"fmt"
 
-	"github.com/kubewharf/katalyst-api/pkg/consts"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	config2 "github.com/kubewharf/katalyst-api/pkg/apis/scheduling/config"
+	"github.com/kubewharf/katalyst-api/pkg/consts"
 )
 
 func MakeTestTm(args *config2.NodeResourceTopologyArgs, h framework.Handle) (framework.Plugin, error) {
@@ -62,6 +62,7 @@ func MakeTestArgs(scoringType config.ScoringStrategyType, alignedResource []stri
 func makePodByResourceList(resources *v1.ResourceList, annotation map[string]string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			UID:         uuid.NewUUID(),
 			Annotations: annotation,
 		},
 		Spec: v1.PodSpec{

--- a/pkg/scheduler/plugins/noderesourcetopology/reserve_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/reserve_test.go
@@ -89,7 +89,8 @@ func TestReserve(t *testing.T) {
 		name            string
 		policy          v1alpha1.TopologyPolicy
 		alignedResource []string
-		pod             *v1.Pod
+		reservePod      *v1.Pod
+		schedulePod     *v1.Pod
 	}
 
 	testCases := []testCase{
@@ -97,7 +98,14 @@ func TestReserve(t *testing.T) {
 			name:            "dedicated + exclusive + single numa",
 			policy:          v1alpha1.TopologyPolicySingleNUMANodeContainerLevel,
 			alignedResource: []string{"cpu", "memory"},
-			pod: makePodByResourceList(&v1.ResourceList{
+			reservePod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+				consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true","numa_exclusive":"true"}`,
+			}),
+			schedulePod: makePodByResourceList(&v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("2"),
 				v1.ResourceMemory: resource.MustParse("4Gi"),
 			}, map[string]string{
@@ -105,39 +113,74 @@ func TestReserve(t *testing.T) {
 				consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true","numa_exclusive":"true"}`,
 			}),
 		},
+		{
+			name:   "reserve dedicated + schedule shared",
+			policy: v1alpha1.TopologyPolicySingleNUMANodeContainerLevel,
+			reservePod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("2"),
+				v1.ResourceMemory: resource.MustParse("4Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+				consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true","numa_exclusive":"true"}`,
+			}),
+			schedulePod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+			}),
+		},
+		{
+			name:   "too much shared requests",
+			policy: v1alpha1.TopologyPolicySingleNUMANodeContainerLevel,
+			reservePod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("6"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+			}),
+			schedulePod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+			}),
+		},
 	}
 
 	c := cache.GetCache()
 	util.SetQoSConfig(generic.NewQoSConfiguration())
 	for _, tc := range testCases {
-		cnr, nodeName := makeTestReserveNode()
-		c.AddOrUpdateCNR(cnr)
+		t.Run(tc.name, func(t *testing.T) {
+			cnr, nodeName := makeTestReserveNode()
+			c.AddOrUpdateCNR(cnr)
 
-		f, err := runtime.NewFramework(nil, nil,
-			runtime.WithSnapshotSharedLister(newTestSharedLister(nil, nil)))
-		assert.NoError(t, err)
-		tm, err := MakeTestTm(MakeTestArgs(config.MostAllocated, tc.alignedResource, "dynamic"), f)
-		assert.NoError(t, err)
+			f, err := runtime.NewFramework(nil, nil,
+				runtime.WithSnapshotSharedLister(newTestSharedLister(nil, nil)))
+			assert.NoError(t, err)
+			tm, err := MakeTestTm(MakeTestArgs(config.MostAllocated, tc.alignedResource, "dynamic"), f)
+			assert.NoError(t, err)
 
-		n := &v1.Node{}
-		n.SetName(nodeName)
-		nodeInfo := framework.NewNodeInfo()
-		nodeInfo.SetNode(n)
+			n := &v1.Node{}
+			n.SetName(nodeName)
+			nodeInfo := framework.NewNodeInfo()
+			nodeInfo.SetNode(n)
 
-		// pod can be allocated on node
-		status := tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.pod, nodeInfo)
-		assert.Nil(t, status)
+			// pod can be allocated on node
+			status := tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.schedulePod, nodeInfo)
+			assert.Nil(t, status)
 
-		tm.(*TopologyMatch).Reserve(context.TODO(), nil, tc.pod, nodeName)
+			tm.(*TopologyMatch).Reserve(context.TODO(), nil, tc.reservePod, nodeName)
 
-		// pod can not be allocated after reserve
-		status = tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.pod, nodeInfo)
-		assert.Equal(t, 2, int(status.Code()))
+			// pod can not be allocated after reserve
+			status = tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.schedulePod, nodeInfo)
+			assert.Equal(t, 2, int(status.Code()))
 
-		tm.(*TopologyMatch).Unreserve(context.TODO(), nil, tc.pod, nodeName)
+			tm.(*TopologyMatch).Unreserve(context.TODO(), nil, tc.reservePod, nodeName)
 
-		// pod can be allocatd again
-		status = tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.pod, nodeInfo)
-		assert.Nil(t, status)
+			// pod can be allocatd again
+			status = tm.(*TopologyMatch).Filter(context.TODO(), nil, tc.schedulePod, nodeInfo)
+			assert.Nil(t, status)
+		})
 	}
 }

--- a/pkg/scheduler/util/qos.go
+++ b/pkg/scheduler/util/qos.go
@@ -46,6 +46,15 @@ func IsDedicatedPod(pod *v1.Pod) bool {
 	return ok
 }
 
+func IsSharedPod(pod *v1.Pod) bool {
+	ok, _ := qosConfig.CheckSharedQoSForPod(pod)
+	return ok
+}
+
+func GetQosLevelForPod(pod *v1.Pod) (string, error) {
+	return qosConfig.GetQoSLevelForPod(pod)
+}
+
 func IsNumaBinding(pod *v1.Pod) bool {
 	if pod == nil {
 		return false


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
when scheduling dedicated pods and shared pods, it is necessary to check whether the shared resources of the node are sufficient for shared pods, because shared pods can not be allocated on the same NUMAs with dedicated pods. And it will not be verified in katalyst-agent.