### PR TITLE
add selector_container for model output

### DIFF
--- a/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/model.go
+++ b/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/model.go
@@ -80,6 +80,10 @@ func (p *MetricSyncerPod) modelMetric() {
 							Key: fmt.Sprintf("%s%s", data.CustomMetricLabelSelectorPrefixKey, "valid_break_line"),
 							Val: fmt.Sprintf("%v", validBreakLine),
 						},
+						metrics.MetricTag{
+							Key: fmt.Sprintf("%scontainer", data.CustomMetricLabelSelectorPrefixKey),
+							Val: containerName,
+						},
 					)...)
 			})
 


### PR DESCRIPTION
Adding selector_container for model output. It could help data metrics puller distinguish sidecar/primary containers.