### PR TITLE
spd support cnc cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,13 @@ jobs:
           fi
       - name: Upload coverage to Codecov
         if: ${{ (env.NEED_TO_CHECK == 'true') || (github.event_name != 'pull_request') }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: unittest
           file: coverage.txt
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
 
   license:

--- a/cmd/katalyst-controller/app/options/spd.go
+++ b/cmd/katalyst-controller/app/options/spd.go
@@ -30,6 +30,7 @@ type SPDOptions struct {
 	ResyncPeriod           time.Duration
 	SPDWorkloadGVResources []string
 	SPDPodLabelIndexerKeys []string
+	EnableCNCCache         bool
 	IndicatorPlugins       []string
 	BaselinePercent        map[string]int64
 }
@@ -38,6 +39,7 @@ type SPDOptions struct {
 func NewSPDOptions() *SPDOptions {
 	return &SPDOptions{
 		ResyncPeriod:    time.Second * 30,
+		EnableCNCCache:  true,
 		BaselinePercent: map[string]int64{},
 	}
 }
@@ -53,6 +55,8 @@ func (o *SPDOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"SPDWorkloadGVResources should be in the format of `resource.version.group.com` like 'deployments.v1.apps'.")
 	fs.StringSliceVar(&o.SPDPodLabelIndexerKeys, "spd-pod-label-indexers", o.SPDPodLabelIndexerKeys, ""+
 		"A list of pod label keys to be used as indexers for pod informer")
+	fs.BoolVar(&o.EnableCNCCache, "spd-enable-cnc-cache", o.EnableCNCCache, ""+
+		"Whether enable cnc cache to reduce agent api-server remote request")
 	fs.StringSliceVar(&o.IndicatorPlugins, "spd-indicator-plugins", o.IndicatorPlugins,
 		"A list of indicator plugins to be used")
 	fs.StringToInt64Var(&o.BaselinePercent, "spd-qos-baseline-percent", o.BaselinePercent, ""+
@@ -64,6 +68,7 @@ func (o *SPDOptions) ApplyTo(c *controller.SPDConfig) error {
 	c.ReSyncPeriod = o.ResyncPeriod
 	c.SPDWorkloadGVResources = o.SPDWorkloadGVResources
 	c.SPDPodLabelIndexerKeys = o.SPDPodLabelIndexerKeys
+	c.EnableCNCCache = o.EnableCNCCache
 	c.IndicatorPlugins = o.IndicatorPlugins
 	c.BaselinePercent = o.BaselinePercent
 	return nil

--- a/pkg/config/controller/spd.go
+++ b/pkg/config/controller/spd.go
@@ -27,6 +27,9 @@ type SPDConfig struct {
 	// SPDPodLabelIndexerKeys are used
 	SPDPodLabelIndexerKeys []string
 
+	// EnableCNCCache is to sync spd cnc target config
+	EnableCNCCache bool
+
 	IndicatorPlugins []string
 
 	BaselinePercent map[string]int64

--- a/pkg/consts/spd.go
+++ b/pkg/consts/spd.go
@@ -18,5 +18,6 @@ package consts
 
 // ServiceProfileDescriptorAnnotationKeyConfigHash defines const variables for spd annotations about config hash.
 const (
-	ServiceProfileDescriptorAnnotationKeyConfigHash = "spd.katalyst.kubewharf.io/config.hash"
+	ServiceProfileDescriptorAnnotationKeyConfigHash    = "spd.katalyst.kubewharf.io/config.hash"
+	ServiceProfileDescriptorAnnotationKeyLastFetchTime = "spd.katalyst.kubewharf.io/lastFetchTime"
 )

--- a/pkg/controller/kcc/util/kcct.go
+++ b/pkg/controller/kcc/util/kcct.go
@@ -144,23 +144,6 @@ func FindMatchedKCCTargetConfigForNode(cnc *apisv1alpha1.CustomNodeConfig, targe
 	return kccTargetList[0], nil
 }
 
-// ClearUnNeededConfigForNode delete those un-needed configurations from CNC status
-func ClearUnNeededConfigForNode(cnc *apisv1alpha1.CustomNodeConfig, needToDelete func(metav1.GroupVersionResource) bool) {
-	if cnc == nil {
-		return
-	}
-
-	katalystCustomConfigList := make([]apisv1alpha1.TargetConfig, 0, len(cnc.Status.KatalystCustomConfigList))
-	for _, config := range cnc.Status.KatalystCustomConfigList {
-		if needToDelete(config.ConfigType) {
-			continue
-		}
-		katalystCustomConfigList = append(katalystCustomConfigList, config)
-	}
-
-	cnc.Status.KatalystCustomConfigList = katalystCustomConfigList
-}
-
 // filterAvailableKCCTargetConfigs returns those available configurations from kcc target list
 func filterAvailableKCCTargetConfigs(kccTargetList []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	availableKCCTargetList := make([]*unstructured.Unstructured, 0, len(kccTargetList))

--- a/pkg/controller/lifecycle/agent-healthz/handler/handler_generic.go
+++ b/pkg/controller/lifecycle/agent-healthz/handler/handler_generic.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/controller/lifecycle/agent-healthz/helper"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
 const AgentHandlerGeneric = "generic"
@@ -129,7 +130,7 @@ func (g *GenericAgentHandler) GetCNRTaintInfo(nodeName string) (*helper.CNRTaint
 // getNodeReclaimedPods returns reclaimed pods contained in the given node,
 // only those nodes with reclaimed pods should be triggered with eviction/taint logic for generic agents
 func (g *GenericAgentHandler) getNodeReclaimedPods(node *corev1.Node) (names []string) {
-	pods, err := helper.GetPodsAssignedToNode(node.Name, g.podIndexer)
+	pods, err := native.GetPodsAssignedToNode(node.Name, g.podIndexer)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to list pods from node %q: %v", node.Name, err))
 		return

--- a/pkg/controller/lifecycle/agent-healthz/healthz_controller.go
+++ b/pkg/controller/lifecycle/agent-healthz/healthz_controller.go
@@ -123,18 +123,8 @@ func NewHealthzController(ctx context.Context,
 
 	ec.podListerSynced = podInformer.Informer().HasSynced
 	podIndexer := podInformer.Informer().GetIndexer()
-	if err := podInformer.Informer().AddIndexers(cache.Indexers{
-		helper.NodeNameKeyIndex: func(obj interface{}) ([]string, error) {
-			pod, ok := obj.(*corev1.Pod)
-			if !ok {
-				return []string{}, nil
-			}
-			if len(pod.Spec.NodeName) == 0 {
-				return []string{}, nil
-			}
-			return []string{pod.Spec.NodeName}, nil
-		},
-	}); err != nil {
+
+	if err := native.AddNodeNameIndexerForPod(podInformer); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/lifecycle/agent-healthz/helper/healthz_check.go
+++ b/pkg/controller/lifecycle/agent-healthz/helper/healthz_check.go
@@ -202,7 +202,7 @@ func (h *HealthzHelper) syncHeartBeatMap() {
 	currentNodes := sets.String{}
 	for _, node := range nodes {
 		baseTags := []metrics.MetricTag{{Key: metricsTagKeyNodeName, Val: node.Name}}
-		pods, err := GetPodsAssignedToNode(node.Name, h.podIndexer)
+		pods, err := native.GetPodsAssignedToNode(node.Name, h.podIndexer)
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("unable to list pods from node %q: %v", node.Name, err))
 			continue

--- a/pkg/controller/lifecycle/cnr_test.go
+++ b/pkg/controller/lifecycle/cnr_test.go
@@ -158,7 +158,7 @@ func TestCNRLifecycle_Run(t *testing.T) {
 			// test recreate
 			err = cl.client.InternalClient.NodeV1alpha1().CustomNodeResources().Delete(context.Background(), tt.fields.node.Name, metav1.DeleteOptions{})
 			assert.NoError(t, err)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1 * time.Second)
 
 			gotCNR, err = cl.cnrLister.Get(tt.fields.node.Name)
 			assert.NoError(t, err)

--- a/pkg/controller/spd/cnc.go
+++ b/pkg/controller/spd/cnc.go
@@ -399,7 +399,11 @@ func (c *cncCacheController) getSPDMapForCNC(cnc *configapis.CustomNodeConfig) (
 
 	spdMap := make(map[string]*apiworkload.ServiceProfileDescriptor)
 	for _, pod := range podList {
-		spd, err := util.GetSPDForPod(pod, c.podIndexer, c.workloadGVKLister, c.spdLister)
+		if native.PodIsTerminated(pod) {
+			continue
+		}
+
+		spd, err := util.GetSPDForPod(pod, c.spdIndexer, c.workloadGVKLister, c.spdLister)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, err
 		}

--- a/pkg/controller/spd/cnc.go
+++ b/pkg/controller/spd/cnc.go
@@ -403,7 +403,7 @@ func (c *cncCacheController) getSPDMapForCNC(cnc *configapis.CustomNodeConfig) (
 			continue
 		}
 
-		spd, err := util.GetSPDForPod(pod, c.spdIndexer, c.workloadGVKLister, c.spdLister)
+		spd, err := util.GetSPDForPod(pod, c.spdIndexer, c.workloadGVKLister, c.spdLister, false)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, err
 		}

--- a/pkg/controller/spd/cnc.go
+++ b/pkg/controller/spd/cnc.go
@@ -1,0 +1,458 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	configapis "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	apiworkload "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
+	configinformers "github.com/kubewharf/katalyst-api/pkg/client/informers/externalversions/config/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/client/informers/externalversions/workload/v1alpha1"
+	configlisters "github.com/kubewharf/katalyst-api/pkg/client/listers/config/v1alpha1"
+	apiListers "github.com/kubewharf/katalyst-api/pkg/client/listers/workload/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/client/control"
+	"github.com/kubewharf/katalyst-core/pkg/config/controller"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+const (
+	metricsNameSyncCNCCacheCost        = "sync_cnc_cache_cost"
+	metricsNameClearUnusedCNCCacheCost = "clear_unused_cnc_cache_cost"
+
+	cncWorkerCount = 1
+)
+
+type cncCacheController struct {
+	ctx  context.Context
+	conf *controller.SPDConfig
+
+	cncControl control.CNCControl
+
+	spdIndexer cache.Indexer
+	podIndexer cache.Indexer
+
+	podLister         corelisters.PodLister
+	spdLister         apiListers.ServiceProfileDescriptorLister
+	cncLister         configlisters.CustomNodeConfigLister
+	workloadGVKLister map[schema.GroupVersionKind]cache.GenericLister
+	workloadLister    map[schema.GroupVersionResource]cache.GenericLister
+
+	cncSyncQueue workqueue.RateLimitingInterface
+
+	metricsEmitter metrics.MetricEmitter
+}
+
+func newCNCCacheController(ctx context.Context,
+	podInformer coreinformers.PodInformer,
+	cncInformer configinformers.CustomNodeConfigInformer,
+	spdInformer v1alpha1.ServiceProfileDescriptorInformer,
+	workloadGVKLister map[schema.GroupVersionKind]cache.GenericLister,
+	workloadLister map[schema.GroupVersionResource]cache.GenericLister,
+	cncControl control.CNCControl,
+	metricsEmitter metrics.MetricEmitter,
+	conf *controller.SPDConfig) (*cncCacheController, error) {
+
+	c := &cncCacheController{
+		ctx:               ctx,
+		conf:              conf,
+		cncControl:        cncControl,
+		spdIndexer:        spdInformer.Informer().GetIndexer(),
+		podIndexer:        podInformer.Informer().GetIndexer(),
+		podLister:         podInformer.Lister(),
+		cncLister:         cncInformer.Lister(),
+		spdLister:         spdInformer.Lister(),
+		workloadGVKLister: workloadGVKLister,
+		workloadLister:    workloadLister,
+		cncSyncQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "spd-cnc"),
+		metricsEmitter:    metricsEmitter,
+	}
+
+	// if cnc cache is disabled all the event handler is not need,
+	// and it will clear all cnc spd config
+	if !c.conf.EnableCNCCache {
+		return c, nil
+	}
+	general.Infof("cnc cache is enable")
+
+	// build index: node ---> pod
+	err := native.AddNodeNameIndexerForPod(podInformer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add node name index for pod: %v", err)
+	}
+
+	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addPod,
+		UpdateFunc: c.updatePod,
+	})
+
+	cncInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addCNC,
+		UpdateFunc: c.updateCNC,
+	})
+
+	spdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addSPD,
+		UpdateFunc: c.updateSPD,
+	})
+
+	return c, nil
+}
+
+func (c *cncCacheController) Run() {
+	defer c.cncSyncQueue.ShutDown()
+
+	if c.conf.EnableCNCCache {
+		for i := 0; i < cncWorkerCount; i++ {
+			go wait.Until(c.cncWorker, time.Second, c.ctx.Done())
+		}
+	}
+
+	go wait.Until(c.clearUnusedConfig, time.Hour*1, c.ctx.Done())
+
+	<-c.ctx.Done()
+}
+
+func (c *cncCacheController) cncWorker() {
+	for c.processNextCNC() {
+	}
+}
+
+func (c *cncCacheController) processNextCNC() bool {
+	key, quit := c.cncSyncQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.cncSyncQueue.Done(key)
+
+	err := c.syncCNC(key.(string))
+	if err == nil {
+		c.cncSyncQueue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("sync %q failed with %v", key, err))
+	c.cncSyncQueue.AddRateLimited(key)
+
+	return true
+}
+
+func (c *cncCacheController) syncCNC(key string) error {
+	klog.V(5).Infof("[spd] syncing cnc [%v]", key)
+	begin := time.Now()
+	defer func() {
+		costs := time.Since(begin)
+		klog.V(5).Infof("[spd] finished sync cnc %q (%v)", key, costs)
+		_ = c.metricsEmitter.StoreInt64(metricsNameSyncCNCCacheCost, costs.Microseconds(),
+			metrics.MetricTypeNameRaw, metrics.MetricTag{Key: "name", Val: key})
+	}()
+
+	cnc, err := c.cncLister.Get(key)
+	if err != nil {
+		general.Errorf("failed to get cnc [%v]", key)
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	spdMap, err := c.getSPDMapForCNC(cnc)
+	if err != nil {
+		return err
+	}
+
+	setCNC := func(cnc *configapis.CustomNodeConfig) {
+		for _, spd := range spdMap {
+			applySPDTargetConfigToCNC(cnc, spd)
+		}
+
+		sort.SliceStable(cnc.Status.ServiceProfileConfigList, func(i, j int) bool {
+			if cnc.Status.ServiceProfileConfigList[i].ConfigNamespace == cnc.Status.ServiceProfileConfigList[j].ConfigNamespace {
+				return cnc.Status.ServiceProfileConfigList[i].ConfigName < cnc.Status.ServiceProfileConfigList[j].ConfigName
+			}
+			return cnc.Status.ServiceProfileConfigList[i].ConfigNamespace < cnc.Status.ServiceProfileConfigList[j].ConfigNamespace
+		})
+	}
+
+	_, err = c.patchCNC(cnc, setCNC)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *cncCacheController) clearUnusedConfig() {
+	begin := time.Now()
+	defer func() {
+		costs := time.Since(begin)
+		general.Infof("finished (%v)", costs)
+		_ = c.metricsEmitter.StoreInt64(metricsNameClearUnusedCNCCacheCost, costs.Microseconds(),
+			metrics.MetricTypeNameRaw)
+	}()
+
+	cncList, err := c.cncLister.List(labels.Everything())
+	if err != nil {
+		general.Errorf("clear unused config list all custom node config failed")
+		return
+	}
+
+	// func for clear cnc config if spd config not exists or cnc cache is disabled
+	setFunc := func(cnc *configapis.CustomNodeConfig) {
+		spdMap := make(map[string]*apiworkload.ServiceProfileDescriptor)
+		// if disable cnc cache, it will clear all cnc spd configs
+		if c.conf.EnableCNCCache {
+			spdMap, err = c.getSPDMapForCNC(cnc)
+			if err != nil {
+				general.Errorf("get spd map for cnc %s failed, %v", cnc.Name, err)
+				return
+			}
+		}
+
+		cnc.Status.ServiceProfileConfigList = util.RemoveUnusedTargetConfig(cnc.Status.ServiceProfileConfigList,
+			func(config configapis.TargetConfig) bool {
+				spdKey := native.GenerateNamespaceNameKey(config.ConfigNamespace, config.ConfigName)
+				if _, ok := spdMap[spdKey]; !ok {
+					return true
+				}
+				return false
+			})
+	}
+
+	clearCNCConfigs := func(i int) {
+		cnc := cncList[i]
+		_, err = c.patchCNC(cnc, setFunc)
+		if err != nil {
+			general.Errorf("patch cnc %s failed", cnc.GetName())
+			return
+		}
+	}
+
+	// parallelize to clear cnc configs
+	workqueue.ParallelizeUntil(c.ctx, 16, len(cncList), clearCNCConfigs)
+}
+
+func (c *cncCacheController) addPod(obj interface{}) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		general.Errorf("cannot convert obj to *core.Pod")
+		return
+	}
+
+	c.enqueueCNCForPod(pod)
+}
+
+func (c *cncCacheController) updatePod(oldObj interface{}, newObj interface{}) {
+	oldPod, ok := oldObj.(*v1.Pod)
+	if !ok {
+		general.Errorf("cannot convert obj to *core.Pod")
+		return
+	}
+
+	newPod, ok := newObj.(*v1.Pod)
+	if !ok {
+		general.Errorf("cannot convert obj to *core.Pod")
+		return
+	}
+
+	if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
+		c.enqueueCNCForPod(newPod)
+	}
+}
+
+func (c *cncCacheController) addSPD(obj interface{}) {
+	spd, ok := obj.(*apiworkload.ServiceProfileDescriptor)
+	if !ok {
+		general.Errorf("cannot convert obj to *apiworkload.ServiceProfileDescriptor")
+		return
+	}
+	c.enqueueCNCForSPD(spd)
+}
+
+func (c *cncCacheController) updateSPD(oldObj, newObj interface{}) {
+	oldSPD, ok := oldObj.(*apiworkload.ServiceProfileDescriptor)
+	if !ok {
+		general.Errorf("cannot convert obj to *apiworkload.ServiceProfileDescriptor")
+		return
+	}
+
+	newSPD, ok := newObj.(*apiworkload.ServiceProfileDescriptor)
+	if !ok {
+		general.Errorf("cannot convert obj to *apiworkload.ServiceProfileDescriptor")
+		return
+	}
+
+	if util.GetSPDHash(oldSPD) != util.GetSPDHash(newSPD) {
+		c.enqueueCNCForSPD(newSPD)
+	}
+}
+
+func (c *cncCacheController) addCNC(obj interface{}) {
+	cnc, ok := obj.(*configapis.CustomNodeConfig)
+	if !ok {
+		general.Errorf("cannot convert obj to *configapis.CustomNodeConfig")
+		return
+	}
+
+	c.enqueueCNC(cnc)
+}
+
+func (c *cncCacheController) updateCNC(oldObj interface{}, newObj interface{}) {
+	oldCNC, ok := oldObj.(*configapis.CustomNodeConfig)
+	if !ok {
+		general.Errorf("cannot convert obj to *configapis.CustomNodeConfig")
+		return
+	}
+
+	newCNC, ok := newObj.(*configapis.CustomNodeConfig)
+	if !ok {
+		general.Errorf("cannot convert obj to *configapis.CustomNodeConfig")
+		return
+	}
+
+	if !apiequality.Semantic.DeepEqual(oldCNC.Status.ServiceProfileConfigList,
+		newCNC.Status.ServiceProfileConfigList) {
+		c.enqueueCNC(newCNC)
+	}
+}
+
+func (c *cncCacheController) enqueueCNCForSPD(spd *apiworkload.ServiceProfileDescriptor) {
+	if util.GetSPDHash(spd) == "" {
+		return
+	}
+
+	podList, err := util.GetPodListForSPD(spd, c.podIndexer, c.conf.SPDPodLabelIndexerKeys,
+		c.workloadLister, c.podLister)
+	if err != nil {
+		return
+	}
+
+	for _, pod := range podList {
+		if pod == nil {
+			continue
+		}
+
+		c.enqueueCNCForPod(pod)
+	}
+}
+
+func (c *cncCacheController) enqueueCNCForPod(pod *v1.Pod) {
+	if pod.Spec.NodeName == "" {
+		return
+	}
+
+	cnc, err := c.cncLister.Get(pod.Spec.NodeName)
+	if err != nil {
+		return
+	}
+
+	c.enqueueCNC(cnc)
+}
+
+func (c *cncCacheController) enqueueCNC(cnc *configapis.CustomNodeConfig) {
+	if cnc == nil {
+		general.Warningf("trying to enqueue a nil cnc")
+		return
+	}
+
+	c.cncSyncQueue.Add(cnc.Name)
+}
+
+func (c *cncCacheController) getSPDMapForCNC(cnc *configapis.CustomNodeConfig) (map[string]*apiworkload.ServiceProfileDescriptor, error) {
+	podList, err := native.GetPodsAssignedToNode(cnc.Name, c.podIndexer)
+	if err != nil {
+		return nil, err
+	}
+
+	spdMap := make(map[string]*apiworkload.ServiceProfileDescriptor)
+	for _, pod := range podList {
+		spd, err := util.GetSPDForPod(pod, c.podIndexer, c.workloadGVKLister, c.spdLister)
+		if err != nil && !errors.IsNotFound(err) {
+			return nil, err
+		}
+
+		if spd == nil {
+			continue
+		}
+
+		spdKey := native.GenerateUniqObjectNameKey(spd)
+		spdMap[spdKey] = spd
+	}
+
+	return spdMap, nil
+}
+
+func (c *cncCacheController) patchCNC(cnc *configapis.CustomNodeConfig, setFunc func(*configapis.CustomNodeConfig)) (*configapis.CustomNodeConfig, error) {
+	cncCopy := cnc.DeepCopy()
+	setFunc(cncCopy)
+	if apiequality.Semantic.DeepEqual(cnc, cncCopy) {
+		return cnc, nil
+	}
+
+	general.Infof("cnc %s config changed need to patch", cnc.GetName())
+	return c.cncControl.PatchCNCStatus(c.ctx, cnc.Name, cnc, cncCopy)
+}
+
+func applySPDTargetConfigToCNC(cnc *configapis.CustomNodeConfig,
+	spd *apiworkload.ServiceProfileDescriptor) {
+	if cnc == nil || spd == nil {
+		return
+	}
+
+	idx := 0
+	serviceProfileConfigList := cnc.Status.ServiceProfileConfigList
+	// find target config
+	for ; idx < len(serviceProfileConfigList); idx++ {
+		if serviceProfileConfigList[idx].ConfigNamespace == spd.Namespace &&
+			serviceProfileConfigList[idx].ConfigName == spd.Name {
+			break
+		}
+	}
+
+	targetConfig := configapis.TargetConfig{
+		ConfigNamespace: spd.Namespace,
+		ConfigName:      spd.Name,
+		Hash:            util.GetSPDHash(spd),
+	}
+
+	// update target config if the spd config is already existed
+	if idx < len(serviceProfileConfigList) {
+		serviceProfileConfigList[idx] = targetConfig
+	} else {
+		serviceProfileConfigList = append(serviceProfileConfigList, targetConfig)
+		cnc.Status.ServiceProfileConfigList = serviceProfileConfigList
+	}
+}

--- a/pkg/controller/spd/cnc_test.go
+++ b/pkg/controller/spd/cnc_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+
+	apis "github.com/kubewharf/katalyst-api/pkg/apis/autoscaling/v1alpha1"
+	configapi "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	apiworkload "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	katalystbase "github.com/kubewharf/katalyst-core/cmd/base"
+	"github.com/kubewharf/katalyst-core/pkg/config/controller"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+)
+
+func Test_cncCacheController_Run(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		pod            *v1.Pod
+		workload       *appsv1.StatefulSet
+		spd            *apiworkload.ServiceProfileDescriptor
+		cnc            *configapi.CustomNodeConfig
+		enableCNCCache bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantCNC *configapi.CustomNodeConfig
+	}{
+		{
+			name: "update cnc spd config when cnc cache enable",
+			fields: fields{
+				pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "apps/v1",
+								Kind:       "StatefulSet",
+								Name:       "sts1",
+							},
+						},
+						Annotations: map[string]string{
+							consts.PodAnnotationSPDNameKey: "spd1",
+						},
+						Labels: map[string]string{
+							"workload": "sts1",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
+				},
+				workload: &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sts1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"workload": "sts1",
+							},
+						},
+						Template: v1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"katalyst.kubewharf.io/qos_level": "dedicated_cores",
+								},
+							},
+							Spec: v1.PodSpec{},
+						},
+					},
+				},
+				spd: &apiworkload.ServiceProfileDescriptor{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "sts1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "apps/v1",
+								Kind:       "StatefulSet",
+								Name:       "sts1",
+							},
+						},
+					},
+					Spec: apiworkload.ServiceProfileDescriptorSpec{
+						TargetRef: apis.CrossVersionObjectReference{
+							Kind:       stsGVK.Kind,
+							Name:       "sts1",
+							APIVersion: stsGVK.GroupVersion().String(),
+						},
+						BaselinePercent: pointer.Int32(100),
+					},
+					Status: apiworkload.ServiceProfileDescriptorStatus{
+						AggMetrics: []apiworkload.AggPodMetrics{},
+					},
+				},
+				cnc: &configapi.CustomNodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				},
+				enableCNCCache: true,
+			},
+			wantCNC: &configapi.CustomNodeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: configapi.CustomNodeConfigStatus{
+					ServiceProfileConfigList: []configapi.TargetConfig{
+						{
+							ConfigNamespace: "default",
+							ConfigName:      "sts1",
+							Hash:            "51131be1b092",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "clear cnc spd config when cnc cache disable",
+			fields: fields{
+				pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod1",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "apps/v1",
+								Kind:       "StatefulSet",
+								Name:       "sts1",
+							},
+						},
+						Annotations: map[string]string{
+							consts.PodAnnotationSPDNameKey: "spd1",
+						},
+						Labels: map[string]string{
+							"workload": "sts1",
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node1",
+					},
+				},
+				workload: &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sts1",
+						Namespace: "default",
+						Annotations: map[string]string{
+							consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"workload": "sts1",
+							},
+						},
+						Template: v1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"katalyst.kubewharf.io/qos_level": "dedicated_cores",
+								},
+							},
+							Spec: v1.PodSpec{},
+						},
+					},
+				},
+				spd: &apiworkload.ServiceProfileDescriptor{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "sts1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "apps/v1",
+								Kind:       "StatefulSet",
+								Name:       "sts1",
+							},
+						},
+					},
+					Spec: apiworkload.ServiceProfileDescriptorSpec{
+						TargetRef: apis.CrossVersionObjectReference{
+							Kind:       stsGVK.Kind,
+							Name:       "sts1",
+							APIVersion: stsGVK.GroupVersion().String(),
+						},
+						BaselinePercent: pointer.Int32(100),
+					},
+					Status: apiworkload.ServiceProfileDescriptorStatus{
+						AggMetrics: []apiworkload.AggPodMetrics{},
+					},
+				},
+				cnc: &configapi.CustomNodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+					Status: configapi.CustomNodeConfigStatus{
+						ServiceProfileConfigList: []configapi.TargetConfig{
+							{
+								ConfigNamespace: "default",
+								ConfigName:      "sts1",
+								Hash:            "51131be1b092",
+							},
+						},
+					},
+				},
+				enableCNCCache: false,
+			},
+			wantCNC: &configapi.CustomNodeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+				},
+				Status: configapi.CustomNodeConfigStatus{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spdConfig := &controller.SPDConfig{
+				EnableCNCCache:         tt.fields.enableCNCCache,
+				SPDWorkloadGVResources: []string{"statefulsets.v1.apps"},
+			}
+			genericConfig := &generic.GenericConfiguration{}
+			controllerConf := &controller.GenericControllerConfiguration{
+				DynamicGVResources: []string{"statefulsets.v1.apps"},
+			}
+
+			ctx := context.TODO()
+			controlCtx, err := katalystbase.GenerateFakeGenericContext([]runtime.Object{tt.fields.pod},
+				[]runtime.Object{tt.fields.spd, tt.fields.cnc}, []runtime.Object{tt.fields.workload})
+			assert.NoError(t, err)
+
+			spdController, err := NewSPDController(ctx, controlCtx, genericConfig, controllerConf,
+				spdConfig, generic.NewQoSConfiguration(), struct{}{})
+			assert.NoError(t, err)
+
+			controlCtx.StartInformer(ctx)
+			go spdController.Run()
+			synced := cache.WaitForCacheSync(ctx.Done(), spdController.syncedFunc...)
+			assert.True(t, synced)
+			time.Sleep(1 * time.Second)
+
+			newCNC, err := controlCtx.Client.InternalClient.ConfigV1alpha1().CustomNodeConfigs().
+				Get(ctx, tt.fields.cnc.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantCNC, newCNC)
+		})
+	}
+}

--- a/pkg/controller/spd/spd_test.go
+++ b/pkg/controller/spd/spd_test.go
@@ -18,6 +18,7 @@ package spd
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -33,11 +34,11 @@ import (
 
 	apis "github.com/kubewharf/katalyst-api/pkg/apis/autoscaling/v1alpha1"
 	apiworkload "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
-	"github.com/kubewharf/katalyst-api/pkg/consts"
 	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 	katalystbase "github.com/kubewharf/katalyst-core/cmd/base"
 	"github.com/kubewharf/katalyst-core/pkg/config/controller"
 	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
 	indicator_plugin "github.com/kubewharf/katalyst-core/pkg/controller/spd/indicator-plugin"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
@@ -76,7 +77,7 @@ func TestSPDController_Run(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							consts.PodAnnotationSPDNameKey: "spd1",
+							apiconsts.PodAnnotationSPDNameKey: "spd1",
 						},
 						Labels: map[string]string{
 							"workload": "sts1",
@@ -147,7 +148,7 @@ func TestSPDController_Run(t *testing.T) {
 						Name:      "sts1",
 						Namespace: "default",
 						Annotations: map[string]string{
-							consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+							apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 						},
 					},
 					Spec: appsv1.StatefulSetSpec{
@@ -177,7 +178,7 @@ func TestSPDController_Run(t *testing.T) {
 					Name:      "sts1",
 					Namespace: "default",
 					Annotations: map[string]string{
-						consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+						apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 					},
 				},
 				Spec: appsv1.StatefulSetSpec{
@@ -200,6 +201,9 @@ func TestSPDController_Run(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "sts1",
+					Annotations: map[string]string{
+						consts.ServiceProfileDescriptorAnnotationKeyConfigHash: "51131be1b092",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "apps/v1",
@@ -232,7 +236,7 @@ func TestSPDController_Run(t *testing.T) {
 						Name:      "sts1",
 						Namespace: "default",
 						Annotations: map[string]string{
-							consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+							apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 						},
 					},
 					Spec: appsv1.StatefulSetSpec{
@@ -260,7 +264,7 @@ func TestSPDController_Run(t *testing.T) {
 					Name:      "sts1",
 					Namespace: "default",
 					Annotations: map[string]string{
-						consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+						apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 					},
 				},
 				Spec: appsv1.StatefulSetSpec{
@@ -281,6 +285,9 @@ func TestSPDController_Run(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "sts1",
+					Annotations: map[string]string{
+						consts.ServiceProfileDescriptorAnnotationKeyConfigHash: "51131be1b092",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "apps/v1",
@@ -313,7 +320,7 @@ func TestSPDController_Run(t *testing.T) {
 						Name:      "sts1",
 						Namespace: "default",
 						Annotations: map[string]string{
-							consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+							apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 						},
 					},
 					Spec: appsv1.StatefulSetSpec{
@@ -341,7 +348,7 @@ func TestSPDController_Run(t *testing.T) {
 					Name:      "sts1",
 					Namespace: "default",
 					Annotations: map[string]string{
-						consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+						apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 					},
 				},
 				Spec: appsv1.StatefulSetSpec{
@@ -362,6 +369,9 @@ func TestSPDController_Run(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "sts1",
+					Annotations: map[string]string{
+						consts.ServiceProfileDescriptorAnnotationKeyConfigHash: "a62e4c90e3ed",
+					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "apps/v1",
@@ -471,7 +481,7 @@ func TestIndicatorUpdater(t *testing.T) {
 			Name:      "sts1",
 			Namespace: "default",
 			Annotations: map[string]string{
-				consts.WorkloadAnnotationSPDEnableKey: consts.WorkloadAnnotationSPDEnabled,
+				apiconsts.WorkloadAnnotationSPDEnableKey: apiconsts.WorkloadAnnotationSPDEnabled,
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -487,7 +497,7 @@ func TestIndicatorUpdater(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       "default",
 			Name:            "spd1",
-			ResourceVersion: "0",
+			ResourceVersion: "1",
 		},
 		Spec: apiworkload.ServiceProfileDescriptorSpec{
 			TargetRef: apis.CrossVersionObjectReference{
@@ -557,9 +567,12 @@ func TestIndicatorUpdater(t *testing.T) {
 				{
 					Name: "TestExtended",
 					Indicators: runtime.RawExtension{
-						Object: &apiworkload.TestExtendedIndicators{
-							Indicators: &apiworkload.TestIndicators{},
-						},
+						Raw: func() []byte {
+							data, _ := json.Marshal(&apiworkload.TestExtendedIndicators{
+								Indicators: &apiworkload.TestIndicators{},
+							})
+							return data
+						}(),
 					},
 				},
 			},

--- a/pkg/metaserver/spd/cache.go
+++ b/pkg/metaserver/spd/cache.go
@@ -102,7 +102,7 @@ func (s *Cache) GetNextFetchRemoteTime(key string, now time.Time, skipBackoff bo
 
 	info, ok := s.spdInfo[key]
 	if ok && info != nil {
-		if info.penaltyForFetchingRemoteTime > 0 {
+		if !skipBackoff && info.penaltyForFetchingRemoteTime > 0 {
 			return info.lastFetchRemoteTime.Add(info.penaltyForFetchingRemoteTime)
 		}
 

--- a/pkg/metaserver/spd/fetcher_test.go
+++ b/pkg/metaserver/spd/fetcher_test.go
@@ -212,7 +212,8 @@ func Test_spdManager_GetSPD(t *testing.T) {
 				t.Errorf("GetSPD() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want.Spec, got.Spec)
+			require.Equal(t, tt.want.Status, got.Status)
 
 			// second GetSPD from local cache
 			got, err = s.GetSPD(ctx, tt.args.pod.ObjectMeta)
@@ -220,7 +221,8 @@ func Test_spdManager_GetSPD(t *testing.T) {
 				t.Errorf("GetSPD() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.want.Spec, got.Spec)
+			require.Equal(t, tt.want.Status, got.Status)
 		})
 	}
 }

--- a/pkg/util/cnc.go
+++ b/pkg/util/cnc.go
@@ -14,29 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package helper
+package util
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
+	configapi "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
 )
 
-const NodeNameKeyIndex = "spec.nodeName"
-
-// GetPodsAssignedToNode returns pods that belong to this node by indexer
-func GetPodsAssignedToNode(nodeName string, podIndexer cache.Indexer) ([]*corev1.Pod, error) {
-	objs, err := podIndexer.ByIndex(NodeNameKeyIndex, nodeName)
-	if err != nil {
-		return nil, err
+// RemoveUnusedTargetConfig delete those unused configurations from CNC status
+func RemoveUnusedTargetConfig(configList []configapi.TargetConfig, needToDelete func(config configapi.TargetConfig) bool) []configapi.TargetConfig {
+	if len(configList) == 0 {
+		return configList
 	}
 
-	pods := make([]*corev1.Pod, 0, len(objs))
-	for _, obj := range objs {
-		pod, ok := obj.(*corev1.Pod)
-		if !ok {
+	resultConfigList := make([]configapi.TargetConfig, 0, len(configList))
+	for _, config := range configList {
+		if needToDelete(config) {
 			continue
 		}
-		pods = append(pods, pod)
+		resultConfigList = append(resultConfigList, config)
 	}
-	return pods, nil
+
+	return resultConfigList
 }

--- a/pkg/util/native/object.go
+++ b/pkg/util/native/object.go
@@ -161,7 +161,7 @@ func GetUnstructuredSelector(object *unstructured.Unstructured) (labels.Selector
 		return selector, nil
 	}
 
-	val, ok, err := unstructured.NestedFieldCopy(object.UnstructuredContent(), objectFieldsForLabelSelector...)
+	val, ok, err := unstructured.NestedFieldNoCopy(object.UnstructuredContent(), objectFieldsForLabelSelector...)
 	if err != nil {
 		return nil, err
 	} else if !ok || val == nil {

--- a/pkg/util/native/pod_finder.go
+++ b/pkg/util/native/pod_finder.go
@@ -130,7 +130,7 @@ func GetPodsAssignedToNode(nodeName string, podIndexer cache.Indexer) ([]*core.P
 // AddNodeNameIndexerForPod add node name index for pod informer
 func AddNodeNameIndexerForPod(podInformer v1.PodInformer) error {
 	if _, ok := podInformer.Informer().GetIndexer().GetIndexers()[nodeNameKeyIndex]; !ok {
-		return podInformer.Informer().AddIndexers(cache.Indexers{
+		return podInformer.Informer().GetIndexer().AddIndexers(cache.Indexers{
 			nodeNameKeyIndex: func(obj interface{}) ([]string, error) {
 				pod, ok := obj.(*core.Pod)
 				if !ok {

--- a/pkg/util/spd_test.go
+++ b/pkg/util/spd_test.go
@@ -143,7 +143,7 @@ func TestGetSPDForPod(t *testing.T) {
 	}
 	_ = spdInformer.Informer().GetStore().Add(spd)
 
-	s, err := GetSPDForPod(pod1, spdInformer.Informer().GetIndexer(), workloadInformers, spdInformer.Lister())
+	s, err := GetSPDForPod(pod1, spdInformer.Informer().GetIndexer(), workloadInformers, spdInformer.Lister(), true)
 	assert.NoError(t, err)
 	assert.Equal(t, spd, s)
 
@@ -151,7 +151,7 @@ func TestGetSPDForPod(t *testing.T) {
 		apiconsts.PodAnnotationSPDNameKey: spd.Name,
 	}
 
-	s, err = GetSPDForPod(pod1, spdInformer.Informer().GetIndexer(), workloadInformers, spdInformer.Lister())
+	s, err = GetSPDForPod(pod1, spdInformer.Informer().GetIndexer(), workloadInformers, spdInformer.Lister(), true)
 	assert.NoError(t, err)
 	assert.Equal(t, spd, s)
 
@@ -169,7 +169,7 @@ func TestGetSPDForPod(t *testing.T) {
 		},
 	}
 
-	s, err = GetSPDForPod(pod2, spdInformer.Informer().GetIndexer(), workloadInformers, spdInformer.Lister())
+	s, err = GetSPDForPod(pod2, spdInformer.Informer().GetIndexer(), workloadInformers, spdInformer.Lister(), true)
 	assert.Nil(t, s)
 	assert.Error(t, err)
 }

--- a/pkg/webhook/mutating/pod/spd_ref_mutator.go
+++ b/pkg/webhook/mutating/pod/spd_ref_mutator.go
@@ -63,7 +63,7 @@ func (s *WebhookPodSPDReferenceMutator) MutatePod(pod *core.Pod, namespace strin
 	}
 
 	pod.Namespace = namespace
-	spd, err := katalystutil.GetSPDForPod(pod, s.spdIndexer, s.workloadLister, s.spdLister)
+	spd, err := katalystutil.GetSPDForPod(pod, s.spdIndexer, s.workloadLister, s.spdLister, true)
 	if err != nil || spd == nil {
 		klog.Warningf("didn't to find spd of pod %v/%v, err: %v", pod.Namespace, pod.Name, err)
 		return false, nil


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features
#### What this PR does / why we need it:
To minimize high query-per-second (QPS) rates from agents to the API server, we implement a Custom Node Config (CNC) to store Service Profile Descriptor (SPD) information needed by the node, acting as an SPD cache. Agents periodically fetch the CNC, and will only attempt to update the local SPD cache from the API server if there's a mismatch between the hash of the local cache's SPD and the SPD information in the CNC.
