### PR TITLE
util(cgroup): relax constraints

### DIFF
--- a/pkg/util/cgroup/manager/v1/fs_linux.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux.go
@@ -45,7 +45,7 @@ func NewManager() *manager {
 }
 
 func (m *manager) ApplyMemory(absCgroupPath string, data *common.MemoryData) error {
-	if data.LimitInBytes > 0 {
+	if data.LimitInBytes != 0 {
 		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.limit_in_bytes", strconv.FormatInt(data.LimitInBytes, 10)); err != nil {
 			return err
 		} else if applied {

--- a/pkg/util/cgroup/manager/v2/fs_linux.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux.go
@@ -48,7 +48,7 @@ func NewManager() *manager {
 }
 
 func (m *manager) ApplyMemory(absCgroupPath string, data *common.MemoryData) error {
-	if data.LimitInBytes > 0 {
+	if data.LimitInBytes != 0 {
 		if err, applied, oldData := common.WriteFileIfChange(absCgroupPath, "memory.max", numToStr(data.LimitInBytes)); err != nil {
 			return err
 		} else if applied {


### PR DESCRIPTION
-1 is valid for memory.limit_in_bytes

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
