### PR TITLE
wbt: adding strict mode

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/io_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/io_plugin.go
@@ -34,12 +34,14 @@ type IOOptions struct {
 
 type WritebackThrottlingOption struct {
 	EnableSettingWBT bool
+	WBTStrictMode    bool
 	WBTValueHDD      int
 	WBTValueSSD      int
 }
 
 type IOCostOption struct {
 	EnableSettingIOCost   bool
+	IOCostStrictMode      bool
 	IOCostQoSConfigFile   string
 	IOCostModelConfigFile string
 }
@@ -55,11 +57,13 @@ func NewIOOptions() *IOOptions {
 		PolicyName: "static",
 		WritebackThrottlingOption: WritebackThrottlingOption{
 			EnableSettingWBT: false,
+			WBTStrictMode:    true,
 			WBTValueHDD:      75000,
 			WBTValueSSD:      2000,
 		},
 		IOCostOption: IOCostOption{
 			EnableSettingIOCost:   false,
+			IOCostStrictMode:      true,
 			IOCostQoSConfigFile:   "",
 			IOCostModelConfigFile: "",
 		},
@@ -78,12 +82,16 @@ func (o *IOOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.PolicyName, "The policy io resource plugin should use")
 	fs.BoolVar(&o.EnableSettingWBT, "enable-disk-wbt",
 		o.EnableSettingWBT, "if set it to true, disk wbt related control operations will be executed")
+	fs.BoolVar(&o.WBTStrictMode, "enable-wbt-strict-mode",
+		o.WBTStrictMode, "if set it to true, disk wbt related control operations will be executed strictly")
 	fs.IntVar(&o.WBTValueHDD, "disk-wbt-hdd",
 		o.WBTValueHDD, "writeback throttling value for HDD")
 	fs.IntVar(&o.WBTValueSSD, "disk-wbt-ssd",
 		o.WBTValueSSD, "writeback throttling value for SSD")
 	fs.BoolVar(&o.EnableSettingIOCost, "enable-io-cost",
 		o.EnableSettingIOCost, "if set it to true, io.cost setting will be executed")
+	fs.BoolVar(&o.IOCostStrictMode, "enable-io-cost-strict-mode",
+		o.IOCostStrictMode, "if set it to true, io.cost strict mode setting will be executed")
 	fs.StringVar(&o.IOCostQoSConfigFile, "io-cost-qos-config-file",
 		o.IOCostQoSConfigFile, "the absolute path of io.cost.qos qos config file")
 	fs.StringVar(&o.IOCostModelConfigFile, "io-cost-model-config-file",
@@ -99,9 +107,11 @@ func (o *IOOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 func (o *IOOptions) ApplyTo(conf *qrmconfig.IOQRMPluginConfig) error {
 	conf.PolicyName = o.PolicyName
 	conf.EnableSettingWBT = o.EnableSettingWBT
+	conf.WBTStrictMode = o.WBTStrictMode
 	conf.WBTValueHDD = o.WBTValueHDD
 	conf.WBTValueSSD = o.WBTValueSSD
 	conf.EnableSettingIOCost = o.EnableSettingIOCost
+	conf.IOCostStrictMode = o.IOCostStrictMode
 	conf.IOCostQoSConfigFile = o.IOCostQoSConfigFile
 	conf.IOCostModelConfigFile = o.IOCostModelConfigFile
 	conf.EnableSettingIOWeight = o.EnableSettingIOWeight

--- a/pkg/agent/qrm-plugins/io/handlers/dirtymem/const.go
+++ b/pkg/agent/qrm-plugins/io/handlers/dirtymem/const.go
@@ -21,6 +21,7 @@ const EnableSetDirtyMemPeriodicalHandlerName = "SetDirtyMem"
 const (
 	sysDiskPrefix = "/sys/block"
 	wbtSuffix     = "queue/wbt_lat_usec"
+	mem2G         = 2147483648.0
 )
 
 const (

--- a/pkg/agent/qrm-plugins/io/handlers/dirtymem/wbt_linux.go
+++ b/pkg/agent/qrm-plugins/io/handlers/dirtymem/wbt_linux.go
@@ -45,6 +45,20 @@ func SetWBTLimit(conf *coreconfig.Configuration,
 		general.Errorf("nil metaServer")
 		return
 	}
+
+	if conf.WBTStrictMode {
+		dirty, err := helper.GetNodeMetric(metaServer.MetricsFetcher, emitter, coreconsts.MetricMemDirtySystem)
+		if err != nil {
+			general.Errorf("failed to get dirty memory bytes, err=%v", err)
+			return
+		}
+
+		if dirty > mem2G {
+			general.Infof("dirty memory is too high, skip it. dirty=%v", dirty)
+			return
+		}
+	}
+
 	dir, err := ioutil.ReadDir(sysDiskPrefix)
 	if err != nil {
 		general.Errorf("failed to readdir:%v, err:%v", sysDiskPrefix, err)

--- a/pkg/agent/qrm-plugins/io/handlers/iocost/const.go
+++ b/pkg/agent/qrm-plugins/io/handlers/iocost/const.go
@@ -29,6 +29,8 @@ const (
 	DevModelBcache       DevModel = "bcache"
 	DevModelDeviceMapper DevModel = "dm"
 
+	sysDiskPrefix = "/sys/block"
+
 	IOStatMetricCostVrate = "cost.vrate"
 
 	MetricNameIOCostVrate = "iocost_vrate"

--- a/pkg/config/agent/qrm/io_plugin.go
+++ b/pkg/config/agent/qrm/io_plugin.go
@@ -27,12 +27,14 @@ type IOQRMPluginConfig struct {
 
 type WritebackThrottlingOption struct {
 	EnableSettingWBT bool
+	WBTStrictMode    bool
 	WBTValueHDD      int
 	WBTValueSSD      int
 }
 
 type IOCostOption struct {
 	EnableSettingIOCost   bool
+	IOCostStrictMode      bool
 	IOCostQoSConfigFile   string
 	IOCostModelConfigFile string
 }


### PR DESCRIPTION
adding a strict mode to prevent a potential kernel deadlock bug

#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
adding a strict mode to prevent a potential kernel deadlock bug

#### Which issue(s) this PR fixes:
When dirty memory is in the dirty throttling stage, and mq-deadline is set. I suspect that setting wbt at this time will cause a blk_mq_freeze_queue deadlock problem. 
It's high suspected, but not confirmed.

#### Special notes for your reviewer:
none