### PR TITLE
make malachite server port configurable

### DIFF
--- a/cmd/katalyst-agent/app/options/metaserver/metric.go
+++ b/cmd/katalyst-agent/app/options/metaserver/metric.go
@@ -26,7 +26,10 @@ import (
 
 const defaultMetricInsurancePeriod = 0 * time.Second
 
-const defaultRodanServerPort = 9102
+const (
+	defaultRodanServerPort     = 9102
+	defaultMalachiteServerPort = 9002
+)
 
 type MetricFetcherOptions struct {
 	MetricInsurancePeriod time.Duration
@@ -42,10 +45,12 @@ type MetricFetcherOptions struct {
 }
 
 type (
-	MalachiteOptions struct{}
-	CgroupOptions    struct{}
-	KubeletOptions   struct{}
-	RodanOptions     struct {
+	MalachiteOptions struct {
+		ServerPort int
+	}
+	CgroupOptions  struct{}
+	KubeletOptions struct{}
+	RodanOptions   struct {
 		ServerPort int
 	}
 )
@@ -58,9 +63,11 @@ func NewMetricFetcherOptions() *MetricFetcherOptions {
 		DefaultInterval:         time.Second * 5,
 		ProvisionerIntervalSecs: make(map[string]int),
 
-		MalachiteOptions: &MalachiteOptions{},
-		CgroupOptions:    &CgroupOptions{},
-		KubeletOptions:   &KubeletOptions{},
+		MalachiteOptions: &MalachiteOptions{
+			ServerPort: defaultMalachiteServerPort,
+		},
+		CgroupOptions:  &CgroupOptions{},
+		KubeletOptions: &KubeletOptions{},
 		RodanOptions: &RodanOptions{
 			ServerPort: defaultRodanServerPort,
 		},
@@ -83,6 +90,8 @@ func (o *MetricFetcherOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 
 	fs.IntVar(&o.RodanOptions.ServerPort, "rodan-server-port", o.RodanOptions.ServerPort,
 		"The rodan metric provisioner server port")
+	fs.IntVar(&o.MalachiteOptions.ServerPort, "malachite-server-port", o.MalachiteOptions.ServerPort,
+		"The malachite metric provisioner server port")
 }
 
 // ApplyTo fills up config with options
@@ -97,6 +106,7 @@ func (o *MetricFetcherOptions) ApplyTo(c *metaserver.MetricConfiguration) error 
 	}
 
 	c.RodanServerPort = o.RodanOptions.ServerPort
+	c.MalachiteServerPort = o.MalachiteOptions.ServerPort
 
 	return nil
 }

--- a/pkg/config/agent/metaserver/agent.go
+++ b/pkg/config/agent/metaserver/agent.go
@@ -42,7 +42,9 @@ type MetricConfiguration struct {
 	*RodanMetricConfiguration
 }
 
-type MalachiteMetricConfiguration struct{}
+type MalachiteMetricConfiguration struct {
+	MalachiteServerPort int
+}
 
 type CgroupMetricConfiguration struct{}
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	malachiteServicePort = 9002
-
 	CgroupResource     = "cgroup/groups"
 	CgroupPathParamKey = "cgroup_user_path"
 
@@ -53,7 +51,7 @@ type MalachiteClient struct {
 	fetcher pod.PodFetcher
 }
 
-func NewMalachiteClient(fetcher pod.PodFetcher) *MalachiteClient {
+func NewMalachiteClient(fetcher pod.PodFetcher, malachiteServerPort int) *MalachiteClient {
 	urls := make(map[string]string)
 	for _, path := range []string{
 		CgroupResource,
@@ -62,7 +60,7 @@ func NewMalachiteClient(fetcher pod.PodFetcher) *MalachiteClient {
 		SystemComputeResource,
 		SystemMemoryResource,
 	} {
-		urls[path] = fmt.Sprintf("http://localhost:%d/api/v1/%s", malachiteServicePort, path)
+		urls[path] = fmt.Sprintf("http://localhost:%d/api/v1/%s", malachiteServerPort, path)
 	}
 
 	return &MalachiteClient{

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_cgroup_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_cgroup_test.go
@@ -132,7 +132,7 @@ func TestGetCgroupStats(t *testing.T) {
 	}))
 	defer server.Close()
 
-	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{})
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, 9002)
 	malachiteClient.SetURL(map[string]string{
 		CgroupResource: server.URL,
 	})

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_pod_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_pod_test.go
@@ -153,7 +153,7 @@ func TestGetPodContainerStats(t *testing.T) {
 	}
 	fetcher := &pod.PodFetcherStub{PodList: pods}
 
-	malachiteClient := NewMalachiteClient(fetcher)
+	malachiteClient := NewMalachiteClient(fetcher, 9002)
 	malachiteClient.SetURL(map[string]string{
 		CgroupResource: server.URL,
 	})

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_system_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_system_test.go
@@ -88,7 +88,7 @@ func TestGetSystemComputeStats(t *testing.T) {
 	server := getSystemTestServer(data)
 	defer server.Close()
 
-	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{})
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, 9002)
 	malachiteClient.SetURL(map[string]string{
 		SystemComputeResource: server.URL,
 	})
@@ -109,7 +109,7 @@ func TestGetSystemMemoryStats(t *testing.T) {
 	server := getSystemTestServer(data)
 	defer server.Close()
 
-	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{})
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, 9002)
 	malachiteClient.SetURL(map[string]string{
 		SystemMemoryResource: server.URL,
 	})
@@ -130,7 +130,7 @@ func TestGetSystemIOStats(t *testing.T) {
 	server := getSystemTestServer(data)
 	defer server.Close()
 
-	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{})
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, 9002)
 	malachiteClient.SetURL(map[string]string{
 		SystemIOResource: server.URL,
 	})
@@ -151,7 +151,7 @@ func TestGetSystemNetStats(t *testing.T) {
 	server := getSystemTestServer(data)
 	defer server.Close()
 
-	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{})
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, 9002)
 	malachiteClient.SetURL(map[string]string{
 		SystemNetResource: server.URL,
 	})
@@ -171,7 +171,7 @@ func TestGetSystemNonExistStats(t *testing.T) {
 	server := getSystemTestServer([]byte{})
 	defer server.Close()
 
-	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{})
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, 9002)
 	_, err := malachiteClient.getSystemStats(100)
 	assert.ErrorContains(t, err, "unknown")
 }

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -54,11 +54,11 @@ const (
 )
 
 // NewMalachiteMetricsProvisioner returns the default implementation of MetricsFetcher.
-func NewMalachiteMetricsProvisioner(baseConf *global.BaseConfiguration, _ *metaserver.MetricConfiguration,
+func NewMalachiteMetricsProvisioner(baseConf *global.BaseConfiguration, metricsConf *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter, fetcher pod.PodFetcher, metricStore *utilmetric.MetricStore,
 ) types.MetricsProvisioner {
 	return &MalachiteMetricsProvisioner{
-		malachiteClient: client.NewMalachiteClient(fetcher),
+		malachiteClient: client.NewMalachiteClient(fetcher, metricsConf.MalachiteServerPort),
 		metricStore:     metricStore,
 		emitter:         emitter,
 		baseConf:        baseConf,

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -44,7 +44,11 @@ func Test_noneExistMetricsProvisioner(t *testing.T) {
 			GeneralRelativeCgroupPaths:  []string{"d1", "d2"},
 			OptionalRelativeCgroupPaths: []string{"d3", "d4"},
 		},
-	}, &metaserver.MetricConfiguration{}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store)
+	}, &metaserver.MetricConfiguration{
+		MalachiteMetricConfiguration: &metaserver.MalachiteMetricConfiguration{
+			MalachiteServerPort: 9002,
+		},
+	}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store)
 
 	fakeSystemCompute := &malachitetypes.SystemComputeData{
 		CPU: []malachitetypes.CPU{


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
malachite metrics provisoner using default port(9002) that may be used by others, by overriding the Rocket config file, but not katalyst.

#### Which issue(s) this PR fixes:
make malachite server port configurable
#### Special notes for your reviewer:
