### PR TITLE
fix: convert memory by quantity.Value in overcommit controller

### DIFF
--- a/pkg/controller/overcommit/node/node_test.go
+++ b/pkg/controller/overcommit/node/node_test.go
@@ -608,7 +608,7 @@ func TestNodeOvercommitResource(t *testing.T) {
 				},
 			},
 			expectRes:    "18720m",
-			expectMemRes: "35109737398272m",
+			expectMemRes: "35109737398",
 		},
 		{
 			name:          "guaranteed cpu none",
@@ -635,7 +635,7 @@ func TestNodeOvercommitResource(t *testing.T) {
 				},
 			},
 			expectRes:    "18720m",
-			expectMemRes: "35109737398272m",
+			expectMemRes: "35109737398",
 		},
 		{
 			name:          "wrong guaranteed cpu",
@@ -713,6 +713,30 @@ func TestNodeOvercommitResource(t *testing.T) {
 			},
 			expectRes:    "",
 			expectMemRes: "",
+		},
+		{
+			name:          "large memory allocatable",
+			cpuOvercommit: "1.2",
+			memOvercommit: "2",
+			kcnr: &v1alpha12.CustomNodeResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testNode1",
+					Annotations: map[string]string{},
+				},
+			},
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testNode1",
+					Annotations: map[string]string{
+						"katalyst.kubewharf.io/original_allocatable_cpu":    "15600m",
+						"katalyst.kubewharf.io/original_capacity_cpu":       "16000m",
+						"katalyst.kubewharf.io/original_allocatable_memory": "1Ei",
+						"katalyst.kubewharf.io/original_capacity_memory":    "1Ei",
+					},
+				},
+			},
+			expectRes:    "18720m",
+			expectMemRes: "2Ei",
 		},
 	}
 

--- a/pkg/util/native/resources.go
+++ b/pkg/util/native/resources.go
@@ -283,6 +283,9 @@ func MultiplyMilliQuantity(quantity resource.Quantity, y float64) resource.Quant
 	if 0 == y {
 		return *resource.NewMilliQuantity(0, quantity.Format)
 	}
+	if 1 == y {
+		return quantity
+	}
 
 	milliValue := quantity.MilliValue()
 	if 0 == milliValue {
@@ -297,6 +300,9 @@ func MultiplyMilliQuantity(quantity resource.Quantity, y float64) resource.Quant
 func MultiplyQuantity(quantity resource.Quantity, y float64) resource.Quantity {
 	if 0 == y {
 		return *resource.NewQuantity(0, quantity.Format)
+	}
+	if 1 == y {
+		return quantity
 	}
 
 	value := quantity.Value()


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
Memory value overflow when node patch a large memory allocatable in status, eg. '1Ei'.
Convert memory value by quantity.Value which can cover larger values than MilliValue.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
