### PR TITLE
feat: add MaxNodeUtilizationPercent in ReclaimedResourceConfiguration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -161,6 +161,7 @@ require (
 )
 
 replace (
+	github.com/kubewharf/katalyst-api => github.com/WangZzzhe/katalyst-api v0.0.0-20240828081900-5e532fa0166c
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/WangZzzhe/katalyst-api v0.0.0-20240828081900-5e532fa0166c h1:IlDjOO40SUWMITcOf9/f2enNXzD/BVMt/UtV6nNY4T4=
+github.com/WangZzzhe/katalyst-api v0.0.0-20240828081900-5e532fa0166c/go.mod h1:Y2IeIorxQamF2a3oa0+URztl5QCSty6Jj3zD83R8J9k=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -568,8 +570,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.1-0.20240820031712-7c1239991078 h1:CSBXQOe0AzlWcGaww8uqOUDu+/4bL3hVNBz86oziOis=
-github.com/kubewharf/katalyst-api v0.5.1-0.20240820031712-7c1239991078/go.mod h1:Y2IeIorxQamF2a3oa0+URztl5QCSty6Jj3zD83R8J9k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.9 h1:jOTYZt7h/J7I8xQMKMUcJjKf5UFBv37jHWvNp5VRFGc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.9/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -626,5 +627,8 @@ func (p *CPUPressureLoadEviction) checkPressureWithAdvisedThreshold() bool {
 	// for now, we consider ReservedResourceForAllocate as downgrading or manual intervention configuration,
 	// when it's set to a value greater than zero, fall back to static threshold
 	dynamicConfiguration := p.dynamicConf.GetDynamicConfiguration()
-	return dynamicConfiguration.EnableReclaim && dynamicConfiguration.ReservedResourceForAllocate.Cpu().Value() == 0
+	reservedResourceForAllocate := dynamicConfiguration.GetReservedResourceForAllocate(v1.ResourceList{
+		v1.ResourceCPU: *resource.NewQuantity(int64(p.metaServer.NumCPUs), resource.DecimalSI),
+	})
+	return dynamicConfiguration.EnableReclaim && reservedResourceForAllocate.Cpu().Value() == 0
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_helper.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
@@ -174,7 +175,10 @@ func (cra *cpuResourceAdvisor) updateNumasAvailableResource() {
 }
 
 func (cra *cpuResourceAdvisor) getNumasReservedForAllocate(numas machine.CPUSet) float64 {
-	reserved := cra.conf.GetDynamicConfiguration().ReservedResourceForAllocate[v1.ResourceCPU]
+	reserved := cra.conf.GetDynamicConfiguration().GetReservedResourceForAllocate(v1.ResourceList{
+		v1.ResourceCPU: *resource.NewQuantity(int64(cra.metaServer.NumCPUs), resource.DecimalSI),
+	})[v1.ResourceCPU]
+
 	return float64(reserved.Value()*int64(numas.Size())) / float64(cra.metaServer.NumNUMANodes)
 }
 

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/assembler_common.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/assembler_common.go
@@ -77,7 +77,9 @@ func (ha *HeadroomAssemblerCommon) GetHeadroom() (resource.Quantity, error) {
 		return *resource.NewQuantity(0, resource.DecimalSI), nil
 	}
 
-	reserved := ha.conf.GetDynamicConfiguration().ReservedResourceForAllocate[v1.ResourceCPU]
+	reserved := ha.conf.GetDynamicConfiguration().GetReservedResourceForAllocate(v1.ResourceList{
+		v1.ResourceCPU: *resource.NewQuantity(int64(ha.metaServer.NumCPUs), resource.DecimalSI),
+	})[v1.ResourceCPU]
 	headroomTotal := 0.0
 	emptyNUMAs := ha.metaServer.CPUDetails.NUMANodes()
 	exclusiveNUMAs := machine.NewCPUSet()

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor.go
@@ -205,8 +205,9 @@ func (ra *memoryResourceAdvisor) update() error {
 		return fmt.Errorf("meta reader has not synced")
 	}
 
-	reservedForAllocate := ra.conf.GetDynamicConfiguration().
-		ReservedResourceForAllocate[v1.ResourceMemory]
+	reservedForAllocate := ra.conf.GetDynamicConfiguration().GetReservedResourceForAllocate(v1.ResourceList{
+		v1.ResourceMemory: *resource.NewQuantity(int64(ra.metaServer.MemoryCapacity), resource.BinarySI),
+	})[v1.ResourceMemory]
 
 	for _, headroomPolicy := range ra.headroomPolices {
 		// capacity and reserved can both be adjusted dynamically during running process

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/provisioner/memory_provisioner.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/provisioner/memory_provisioner.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/memoryadvisor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
@@ -96,8 +97,9 @@ func (m *memoryProvisioner) initializeMemoryProvisioner() error {
 }
 
 func (m *memoryProvisioner) Reconcile(status *types.MemoryPressureStatus) (err error) {
-	reservedForAllocate := m.conf.GetDynamicConfiguration().
-		ReservedResourceForAllocate[v1.ResourceMemory]
+	reservedForAllocate := m.conf.GetDynamicConfiguration().GetReservedResourceForAllocate(v1.ResourceList{
+		v1.ResourceMemory: *resource.NewQuantity(int64(m.metaServer.MemoryCapacity), resource.BinarySI),
+	})[v1.ResourceMemory]
 	m.policy.SetEssentials(
 		types.ResourceEssentials{
 			EnableReclaim:       m.conf.GetDynamicConfiguration().EnableReclaim,

--- a/pkg/config/agent/dynamic/adminqos/reclaimedresource/reclaimedresource_base_test.go
+++ b/pkg/config/agent/dynamic/adminqos/reclaimedresource/reclaimedresource_base_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reclaimedresource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetReservedResourceForAllocate(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name             string
+		config           *ReclaimedResourceConfiguration
+		nodeResourceList v1.ResourceList
+		expectRes        v1.ResourceList
+	}{
+		{
+			name: "MaxNodeUtilizationPercent not set",
+			config: &ReclaimedResourceConfiguration{
+				ReservedResourceForAllocate: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			nodeResourceList: map[v1.ResourceName]resource.Quantity{},
+			expectRes: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		{
+			name: "MaxNodeUtilizationPercent set, only get cpu",
+			config: &ReclaimedResourceConfiguration{
+				ReservedResourceForAllocate: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				MaxNodeUtilizationPercent: map[v1.ResourceName]int64{
+					v1.ResourceCPU:    60,
+					v1.ResourceMemory: 80,
+				},
+			},
+			nodeResourceList: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("32"),
+			},
+			expectRes: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("12800m"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		{
+			name: "MaxNodeUtilizationPercent set, only get memory",
+			config: &ReclaimedResourceConfiguration{
+				ReservedResourceForAllocate: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				MaxNodeUtilizationPercent: map[v1.ResourceName]int64{
+					v1.ResourceCPU:    60,
+					v1.ResourceMemory: 80,
+				},
+			},
+			nodeResourceList: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceMemory: resource.MustParse("100Gi"),
+			},
+			expectRes: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("20Gi"),
+			},
+		},
+		{
+			name: "MaxNodeUtilizationPercent only cpu set",
+			config: &ReclaimedResourceConfiguration{
+				ReservedResourceForAllocate: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				MaxNodeUtilizationPercent: map[v1.ResourceName]int64{
+					v1.ResourceMemory: 80,
+				},
+			},
+			nodeResourceList: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("32"),
+			},
+			expectRes: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+		{
+			name: "MaxNodeUtilizationPercent value not supported",
+			config: &ReclaimedResourceConfiguration{
+				ReservedResourceForAllocate: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				MaxNodeUtilizationPercent: map[v1.ResourceName]int64{
+					v1.ResourceCPU:    120,
+					v1.ResourceMemory: 0,
+				},
+			},
+			nodeResourceList: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("32"),
+				v1.ResourceMemory: resource.MustParse("100Gi"),
+			},
+			expectRes: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:    resource.MustParse("4"),
+				v1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := tc.config.GetReservedResourceForAllocate(tc.nodeResourceList)
+			assert.Equal(t, len(tc.expectRes), len(res))
+			for resource, quantity := range res {
+				expectQuan, ok := tc.expectRes[resource]
+				assert.True(t, ok)
+
+				assert.True(t, quantity.Equal(expectQuan))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
Add parameter MaxNodeUtilizationPercent，which will be converted to reservedForAllocated to limit the total amount of reclaimed resources.

PR should be updated after https://github.com/kubewharf/katalyst-api/pull/85 is merged
