### PR TITLE
fix reclaimed-large-pod.yaml in examples

### DIFF
--- a/examples/reclaimed-large-pod.yaml
+++ b/examples/reclaimed-large-pod.yaml
@@ -57,7 +57,7 @@ spec:
       resources:
         requests:
           resource.katalyst.kubewharf.io/reclaimed_millicpu: 24k
-          resource.katalyst.kubewharf.io/reclaimed_memory": 48Gi
+          resource.katalyst.kubewharf.io/reclaimed_memory: 48Gi
         limits:
           resource.katalyst.kubewharf.io/reclaimed_millicpu: 24k
           resource.katalyst.kubewharf.io/reclaimed_memory: 48Gi


### PR DESCRIPTION
#### What type of PR is this?
Others

#### What this PR does / why we need it:
As the [katalyst docs](https://gokatalyst.io/docs/getting-started/colocation-quick-start/) description, katalyst provides a yaml to create  reclaimed-large-pod, but the yaml has a format error that caused the pod creation to fail.

<img width="1408" alt="image" src="https://github.com/kubewharf/katalyst-core/assets/13435258/78d8c046-f1a2-4a39-83de-cf46d21b4992">

Test result after fixed:

<img width="1072" alt="image" src="https://github.com/kubewharf/katalyst-core/assets/13435258/480ece05-9694-4d46-aab1-79997a70634b">


#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
