### PR TITLE
chore(config):Ignore deprecated lint

### DIFF
--- a/pkg/config/agent/dynamic/adminqos/eviction/system_load_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/system_load_eviction.go
@@ -44,8 +44,10 @@ func NewSystemLoadEvictionPluginConfiguration() *SystemLoadEvictionPluginConfigu
 
 func (l *SystemLoadEvictionPluginConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
 	if aqc := conf.AdminQoSConfiguration; aqc != nil && aqc.Spec.Config.EvictionConfig != nil &&
-		aqc.Spec.Config.EvictionConfig.SystemLoadPressureEvictionConfig != nil {
-		config := aqc.Spec.Config.EvictionConfig.SystemLoadPressureEvictionConfig
+		// SystemLoadPressureEvictionConfig is legacy config, we'll remove it in the future. For now,
+		// we ignore the static check for this two line to prevent lint fails.
+		aqc.Spec.Config.EvictionConfig.SystemLoadPressureEvictionConfig != nil { // nolint:staticcheck
+		config := aqc.Spec.Config.EvictionConfig.SystemLoadPressureEvictionConfig // nolint:staticcheck
 		if config.SoftThreshold != nil {
 			l.SoftThreshold = *config.SoftThreshold
 		}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements

#### What this PR does / why we need it:
The `SystemLoadPressureEvictionConfig` is deprecated in new version API, it will be kept for some versions before it eventually is removed. To prevent lint fail, ignore this two lines.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
