### PR TITLE
refine getUtilBasedHeadroom

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/assembler_common_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/assembler_common_test.go
@@ -144,6 +144,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					for i := 0; i < 10; i++ {
 						store.SetCPUMetric(i, pkgconsts.MetricCPUUsageRatio, utilmetric.MetricData{Value: 0.3, Time: &now})
 					}
+					store.SetCgroupMetric("/kubepods/besteffort", pkgconsts.MetricCPUUsageCgroup, utilmetric.MetricData{Value: 3, Time: &now})
 				},
 				setMetaCache: func(cache *metacache.MetaCacheImp) {
 					err := cache.SetPoolInfo(state.PoolNameReclaim, &types.PoolInfo{
@@ -196,6 +197,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					for i := 0; i < 10; i++ {
 						store.SetCPUMetric(i, pkgconsts.MetricCPUUsageRatio, utilmetric.MetricData{Value: 0.3, Time: &now})
 					}
+					store.SetCgroupMetric("/kubepods/besteffort", pkgconsts.MetricCPUUsageCgroup, utilmetric.MetricData{Value: 6, Time: &now})
 					store.SetContainerMetric("pod1", "container1", metric_consts.MetricCPUUsageContainer, metric_util.MetricData{Value: 4})
 				},
 				setMetaCache: func(cache *metacache.MetaCacheImp) {
@@ -217,7 +219,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					})
 				},
 			},
-			want: *resource.NewQuantity(13, resource.DecimalSI),
+			want: *resource.NewQuantity(10, resource.DecimalSI),
 		},
 		{
 			name: "disable util based",
@@ -251,6 +253,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					for i := 0; i < 10; i++ {
 						store.SetCPUMetric(i, pkgconsts.MetricCPUUsageRatio, utilmetric.MetricData{Value: 0.3, Time: &now})
 					}
+					store.SetCgroupMetric("/kubepods/besteffort", pkgconsts.MetricCPUUsageCgroup, utilmetric.MetricData{Value: 3, Time: &now})
 				},
 				setMetaCache: func(cache *metacache.MetaCacheImp) {
 					err := cache.SetPoolInfo(state.PoolNameReclaim, &types.PoolInfo{
@@ -296,6 +299,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					for i := 0; i < 10; i++ {
 						store.SetCPUMetric(i, pkgconsts.MetricCPUUsageRatio, utilmetric.MetricData{Time: &now})
 					}
+					store.SetCgroupMetric("/kubepods/besteffort", pkgconsts.MetricCPUUsageCgroup, utilmetric.MetricData{Value: 0, Time: &now})
 				},
 				setMetaCache: func(cache *metacache.MetaCacheImp) {
 					err := cache.SetPoolInfo(state.PoolNameReclaim, &types.PoolInfo{
@@ -341,6 +345,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					for i := 0; i < 96; i++ {
 						store.SetCPUMetric(i, pkgconsts.MetricCPUUsageRatio, utilmetric.MetricData{Value: 0.9, Time: &now})
 					}
+					store.SetCgroupMetric("/kubepods/besteffort", pkgconsts.MetricCPUUsageCgroup, utilmetric.MetricData{Value: 9, Time: &now})
 				},
 				setMetaCache: func(cache *metacache.MetaCacheImp) {
 					err := cache.SetPoolInfo(state.PoolNameReclaim, &types.PoolInfo{
@@ -388,6 +393,7 @@ func TestHeadroomAssemblerCommon_GetHeadroom(t *testing.T) {
 					for i := 0; i < 96; i++ {
 						store.SetCPUMetric(i, pkgconsts.MetricCPUUsageRatio, utilmetric.MetricData{Value: 0.3, Time: &now})
 					}
+					store.SetCgroupMetric("/kubepods/besteffort", pkgconsts.MetricCPUUsageCgroup, utilmetric.MetricData{Value: 28.8, Time: &now})
 				},
 				setMetaCache: func(cache *metacache.MetaCacheImp) {
 					err := cache.SetPoolInfo(state.PoolNameReclaim, &types.PoolInfo{

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/estimation_canonical.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/estimation_canonical.go
@@ -217,6 +217,8 @@ func EstimateUtilBasedCapacity(options UtilBasedCapacityOptions, resourceSupply,
 		oversold = resourceSupply * (options.MaxUtilization - currentUtilization)
 	}
 
+	// TODO: consider cpu PSI
+
 	result = math.Max(lastCapacityResult+oversold, resourceSupply)
 	result = math.Min(result, resourceSupply*options.MaxOversoldRate)
 	if options.MaxCapacity > 0 {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
when allow_shared_cores_overlap_reclaimed = true, the workloads of reclaim pool
    include shared_cores and reclaimed_cores, so resource supply for reclaimed_cores
    should consider shared_cores.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
