### PR TITLE
fix(reporter): fix race condition regarding orm and reporter start order

### DIFF
--- a/pkg/util/general/file.go
+++ b/pkg/util/general/file.go
@@ -17,6 +17,7 @@ limitations under the License.
 package general
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -110,6 +111,28 @@ func GetOneExistPath(paths []string) string {
 		}
 	}
 	return ""
+}
+
+// GetOneExistPathUntilExist returns a path until one provided path exists
+func GetOneExistPathUntilExist(paths []string, checkInterval,
+	timeoutDuration time.Duration,
+) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	defer cancel()
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("timeout reached while waiting for an existing path")
+		case <-ticker.C:
+			if p := GetOneExistPath(paths); p != "" {
+				return p, nil
+			}
+		}
+	}
 }
 
 // IsPathExists is to check this path whether exists

--- a/pkg/util/kubelet/podresources/client.go
+++ b/pkg/util/kubelet/podresources/client.go
@@ -18,14 +18,106 @@ package podresources
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/klog/v2"
 	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/kubelet/util"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
+
+const (
+	podResourcesClientTimeout              = 10 * time.Second
+	podResourcesClientMaxMsgSize           = 1024 * 1024 * 16
+	checkPodResourcesSocketInterval        = 100 * time.Millisecond
+	checkPodResourcesSocketTimeoutDuration = 10 * time.Second
+)
+
+var errNotInitialized = errors.New("pod resources client not initialized")
+
+type podResourcesClient struct {
+	sync.RWMutex
+
+	isInitialized bool
+	client        v1.PodResourcesListerClient
+}
+
+// EndpointAutoDiscoveryPodResourcesClient returns a podResourcesClient and a channel that can be used to close the connection.
+func EndpointAutoDiscoveryPodResourcesClient(endpoints []string, getClientFunc GetClientFunc) (*podResourcesClient,
+	chan struct{},
+) {
+	p := &podResourcesClient{}
+	closeChan := make(chan struct{})
+	var (
+		err          error
+		conn         *grpc.ClientConn
+		existingPath string
+	)
+
+	go func() {
+		// Attempt to get the first existing path
+		existingPath, err = general.GetOneExistPathUntilExist(endpoints, checkPodResourcesSocketInterval,
+			checkPodResourcesSocketTimeoutDuration)
+		if err != nil {
+			klog.Errorf("failed to find an existing pod resources socket: %v", err)
+			return
+		}
+
+		p.Lock()
+		// Attempt to create a client and a connection
+		p.client, conn, err = getClientFunc(existingPath, podResourcesClientTimeout, podResourcesClientMaxMsgSize)
+		if err != nil {
+			klog.Errorf("failed to create podResources client, connect error: %v", err)
+			return
+		}
+
+		p.isInitialized = true
+		p.Unlock()
+
+		// Wait for close signal to close the connection
+		<-closeChan
+		if err = conn.Close(); err != nil {
+			klog.Errorf("pod resource connection close failed: %v", err)
+			return
+		}
+	}()
+
+	return p, closeChan
+}
+
+// List wraps the List method of v1.PodResourcesListerClient
+func (p *podResourcesClient) List(ctx context.Context, in *v1.ListPodResourcesRequest,
+	opts ...grpc.CallOption,
+) (*v1.ListPodResourcesResponse, error) {
+	p.RLock()
+	defer p.RUnlock()
+
+	if !p.isInitialized {
+		return nil, errNotInitialized
+	}
+
+	return p.client.List(ctx, in, opts...)
+}
+
+// GetAllocatableResources wraps the GetAllocatableResources method of v1.PodResourcesListerClient
+func (p *podResourcesClient) GetAllocatableResources(ctx context.Context, in *v1.AllocatableResourcesRequest,
+	opts ...grpc.CallOption,
+) (*v1.AllocatableResourcesResponse, error) {
+	p.RLock()
+	defer p.RUnlock()
+
+	if !p.isInitialized {
+		return nil, errNotInitialized
+	}
+
+	return p.client.GetAllocatableResources(ctx, in, opts...)
+}
 
 // GetClientFunc is a function to get a client for the PodResourcesLister grpc service.
 type GetClientFunc func(socket string, connectionTimeout time.Duration, maxMsgSize int) (v1.PodResourcesListerClient, *grpc.ClientConn, error)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes

#### What this PR does / why we need it:
Fix race condition regarding orm and reporter start order.

In ORM mode, kubelet reporter plugin get topology info from ORM's out-of-band PodResources API, rather than kubelet's native PodResources API. If reporter starts before ORM, it can not get the socket of PodResources Server.

Error log:
```
E0807 17:58:09.245252       1 manager.go:403] GetReportContentResponse from kubelet-reporter-plugin Endpoint failed with error: get numa topology status from adapter failed: list pod from pod resource server failed: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix: missing address"
```

So I extracted the PodResources client to a common util and added a retry mechanism.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
