### PR TITLE
system_cores support set specific pool

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
@@ -337,7 +337,10 @@ func (p *CPUPressureLoadEviction) collectMetrics(_ context.Context) {
 		for containerName, containerEntry := range entry {
 			if containerEntry == nil || containerEntry.IsPool {
 				continue
-			} else if containerEntry.OwnerPool == state.EmptyOwnerPoolName || p.skipPools.Has(p.configTranslator.Translate(containerEntry.OwnerPool)) {
+			} else if containerEntry.OwnerPool == state.EmptyOwnerPoolName ||
+				p.skipPools.Has(p.configTranslator.Translate(containerEntry.OwnerPool)) ||
+				// skip pod with system pool
+				state.IsSystemPool(containerEntry.OwnerPool) {
 				general.Infof("skip collecting metric for pod: %s, container: %s with owner pool name: %s",
 					podUID, containerName, containerEntry.OwnerPool)
 				continue

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
@@ -425,7 +425,7 @@ func (p *CPUPressureLoadEviction) checkSharedPressureByPoolSize(pod2Pool PodPool
 // accumulateSharedPoolsLimit calculates the cpu core limit used by shared core pool,
 // and it equals: machine-core - cores-for-dedicated-pods - reserved-cores-reclaim-pods - reserved-cores-system-pods.
 func (p *CPUPressureLoadEviction) accumulateSharedPoolsLimit() int {
-	availableCPUSet := p.state.GetMachineState().GetFilteredAvailableCPUSet(p.systemReservedCPUs, nil, state.CheckNUMABinding)
+	availableCPUSet := p.state.GetMachineState().GetFilteredAvailableCPUSet(p.systemReservedCPUs, nil, state.CheckSharedOrDedicatedNUMABinding)
 
 	coreNumReservedForReclaim := p.dynamicConf.GetDynamicConfiguration().MinReclaimedResourceForAllocate[v1.ResourceCPU]
 	if coreNumReservedForReclaim.Value() > int64(p.metaServer.NumCPUs) {
@@ -434,7 +434,7 @@ func (p *CPUPressureLoadEviction) accumulateSharedPoolsLimit() int {
 	reservedForReclaim := machine.GetCoreNumReservedForReclaim(int(coreNumReservedForReclaim.Value()), p.metaServer.NumNUMANodes)
 
 	reservedForReclaimInSharedNuma := 0
-	sharedCoresNUMAs := p.state.GetMachineState().GetFilteredNUMASet(state.CheckNUMABinding)
+	sharedCoresNUMAs := p.state.GetMachineState().GetFilteredNUMASet(state.CheckSharedOrDedicatedNUMABinding)
 	for _, numaID := range sharedCoresNUMAs.ToSliceInt() {
 		reservedForReclaimInSharedNuma += reservedForReclaim[numaID]
 	}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -212,6 +212,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		consts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresAllocationHandler,
 		consts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresAllocationHandler,
 		consts.PodAnnotationQoSLevelReclaimedCores: policyImplement.reclaimedCoresAllocationHandler,
+		consts.PodAnnotationQoSLevelSystemCores:    policyImplement.systemCoresAllocationHandler,
 	}
 
 	// register hint providers for pods with different QoS level
@@ -219,6 +220,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		consts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresHintHandler,
 		consts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresHintHandler,
 		consts.PodAnnotationQoSLevelReclaimedCores: policyImplement.reclaimedCoresHintHandler,
+		consts.PodAnnotationQoSLevelSystemCores:    policyImplement.systemCoresHintHandler,
 	}
 
 	if err := policyImplement.cleanPools(); err != nil {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -428,7 +428,7 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 	// pooledCPUs is the total available cpu cores minus those that are reserved
 	pooledCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
 		func(ai *state.AllocationInfo) bool {
-			return state.CheckDedicated(ai) || state.CheckNUMABinding(ai)
+			return state.CheckDedicated(ai) || state.CheckSharedNUMABinding(ai)
 		},
 		state.CheckDedicatedNUMABinding)
 	pooledCPUsTopologyAwareAssignments, err := machine.GetNumaAwareAssignments(p.machineInfo.CPUTopology, pooledCPUs)
@@ -1069,7 +1069,7 @@ func (p *DynamicPolicy) initReclaimPool() error {
 		machineState := p.state.GetMachineState()
 		availableCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
 			func(ai *state.AllocationInfo) bool {
-				return state.CheckDedicated(ai) || state.CheckNUMABinding(ai)
+				return state.CheckDedicated(ai) || state.CheckSharedNUMABinding(ai)
 			},
 			state.CheckDedicatedNUMABinding).Difference(noneResidentCPUs)
 
@@ -1184,7 +1184,7 @@ func (p *DynamicPolicy) checkNormalShareCoresCpuResource(req *pluginapi.Resource
 
 	machineState := p.state.GetMachineState()
 	pooledCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
-		state.CheckDedicated, state.CheckNUMABinding)
+		state.CheckDedicated, state.CheckSharedOrDedicatedNUMABinding)
 
 	general.Infof("[checkNormalShareCoresCpuResource] node cpu allocated: %d, allocatable: %d", shareCoresAllocatedInt, pooledCPUs.Size())
 	if shareCoresAllocatedInt > pooledCPUs.Size() {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -70,7 +70,7 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 
 	machineState := p.state.GetMachineState()
 	pooledCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
-		state.CheckDedicated, state.CheckNUMABinding)
+		state.CheckDedicated, state.CheckSharedOrDedicatedNUMABinding)
 
 	if pooledCPUs.IsEmpty() {
 		general.Errorf("pod: %s/%s, container: %s get empty pooledCPUs", req.PodNamespace, req.PodName, req.ContainerName)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
@@ -165,7 +165,7 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingHintHandler(_ context.Conte
 
 	// if hints exists in extra state-file, prefer to use them
 	if hints == nil {
-		availableNUMAs := machineState.GetFilteredNUMASet(state.CheckNUMABinding)
+		availableNUMAs := machineState.GetFilteredNUMASet(state.CheckSharedOrDedicatedNUMABinding)
 
 		var extraErr error
 		hints, extraErr = util.GetHintsFromExtraStateFile(req.PodName, string(v1.ResourceCPU), p.extraStateFileAbsPath, availableNUMAs)
@@ -794,8 +794,8 @@ func (p *DynamicPolicy) calculateHintsForNUMABindingSharedCores(reqInt int, podE
 	machineState state.NUMANodeMap,
 	req *pluginapi.ResourceRequest,
 ) (map[string]*pluginapi.ListOfTopologyHints, error) {
-	nonBindingNUMAsCPUQuantity := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs, nil, state.CheckNUMABinding).Size()
-	nonBindingNUMAs := machineState.GetFilteredNUMASet(state.CheckNUMABinding)
+	nonBindingNUMAsCPUQuantity := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs, nil, state.CheckSharedOrDedicatedNUMABinding).Size()
+	nonBindingNUMAs := machineState.GetFilteredNUMASet(state.CheckSharedOrDedicatedNUMABinding)
 	nonBindingSharedRequestedQuantity := state.GetNonBindingSharedRequestedQuantityFromPodEntries(podEntries, nil, p.getContainerRequestedCores)
 
 	reqAnnotations := req.Annotations

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -193,6 +193,27 @@ func (ai *AllocationInfo) GetSpecifiedNUMABindingPoolName() (string, error) {
 	return GetNUMAPoolName(specifiedPoolName, numaSet.ToSliceNoSortUInt64()[0]), nil
 }
 
+func (ai *AllocationInfo) GetSpecifiedSystemPoolName() (string, error) {
+	if !CheckSystem(ai) {
+		return EmptyOwnerPoolName, fmt.Errorf("GetSpecifiedSystemPoolName only for system_cores")
+	}
+
+	specifiedPoolName := ai.GetSpecifiedPoolName()
+	if specifiedPoolName == EmptyOwnerPoolName {
+		return PoolNamePrefixSystem, nil
+	}
+
+	return fmt.Sprintf("%s%s%s", PoolNamePrefixSystem, "-", specifiedPoolName), nil
+}
+
+func CheckSystem(ai *AllocationInfo) bool {
+	if ai == nil {
+		return false
+	}
+
+	return ai.QoSLevel == consts.PodAnnotationQoSLevelSystemCores
+}
+
 // CheckMainContainer returns true if the AllocationInfo is for main container
 func (ai *AllocationInfo) CheckMainContainer() bool {
 	if ai == nil {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -326,6 +326,16 @@ func CheckSharedNUMABinding(ai *AllocationInfo) bool {
 	return CheckShared(ai) && CheckNUMABinding(ai)
 }
 
+// CheckSharedOrDedicatedNUMABinding returns true if the AllocationInfo is for pod with
+// shared-qos or dedicated-qos and numa-binding enhancement
+func CheckSharedOrDedicatedNUMABinding(ai *AllocationInfo) bool {
+	if ai == nil {
+		return false
+	}
+
+	return CheckSharedNUMABinding(ai) || CheckDedicatedNUMABinding(ai)
+}
+
 // CheckDedicatedPool returns true if the AllocationInfo is for a container in the dedicated pool
 func CheckDedicatedPool(ai *AllocationInfo) bool {
 	if ai == nil {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util.go
@@ -38,6 +38,7 @@ const (
 	PoolNameDedicated       = "dedicated"
 	PoolNameReserve         = "reserve"
 	PoolNamePrefixIsolation = "isolation"
+	PoolNamePrefixSystem    = "system"
 
 	// PoolNameFallback is not a real pool, and is a union of
 	// all none-reclaimed pools to put pod should have been isolated
@@ -195,9 +196,15 @@ func IsIsolationPool(poolName string) bool {
 	return strings.HasPrefix(poolName, PoolNamePrefixIsolation)
 }
 
+func IsSystemPool(poolName string) bool {
+	return strings.HasPrefix(poolName, PoolNamePrefixSystem)
+}
+
 func GetPoolType(poolName string) string {
 	if IsIsolationPool(poolName) {
 		return PoolNamePrefixIsolation
+	} else if IsSystemPool(poolName) {
+		return PoolNamePrefixSystem
 	}
 	switch poolName {
 	case PoolNameReclaim, PoolNameDedicated, PoolNameReserve, PoolNameFallback:
@@ -215,6 +222,8 @@ func GetSpecifiedPoolName(qosLevel, cpusetEnhancementValue string) string {
 			return cpusetEnhancementValue
 		}
 		return PoolNameShare
+	case apiconsts.PodAnnotationQoSLevelSystemCores:
+		return cpusetEnhancementValue
 	case apiconsts.PodAnnotationQoSLevelReclaimedCores:
 		return PoolNameReclaim
 	case apiconsts.PodAnnotationQoSLevelDedicatedCores:

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util.go
@@ -475,7 +475,7 @@ func GenerateMachineStateFromPodEntriesByPolicy(topology *machine.CPUTopology, p
 					// only modify allocated and default properties in NUMA node state if the policy is dynamic and the entry indicates numa_binding.
 					// shared_cores with numa_binding also contributes to numaNodeState.AllocatedCPUSet,
 					// it's convenient that we can skip NUMA with AllocatedCPUSet > 0 when allocating CPUs for dedicated_cores with numa_binding.
-					if CheckNUMABinding(allocationInfo) {
+					if CheckSharedOrDedicatedNUMABinding(allocationInfo) {
 						allocatedCPUsInNumaNode = allocatedCPUsInNumaNode.Union(allocationInfo.OriginalTopologyAwareAssignments[int(numaNode)])
 					}
 				case cpuconsts.CPUResourcePluginPolicyNameNative:

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/util_test.go
@@ -552,6 +552,14 @@ func TestGetSpecifiedPoolName(t *testing.T) {
 			},
 			want: PoolNameReclaim,
 		},
+		{
+			name: "system_cores with empty cpusetEnhancementValue",
+			args: args{
+				qosLevel:               consts.PodAnnotationQoSLevelSystemCores,
+				cpusetEnhancementValue: "reserve",
+			},
+			want: "reserve",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/util.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/util.go
@@ -44,7 +44,7 @@ func generateMachineStateFromPodEntries(topology *machine.CPUTopology, podEntrie
 // because qos level and annotations will change after we support customized updater of enhancements and qos level
 func updateAllocationInfoByReq(req *pluginapi.ResourceRequest, allocationInfo *state.AllocationInfo) error {
 	if req == nil {
-		return fmt.Errorf("updateAllocationInfoByReq got ni l req")
+		return fmt.Errorf("updateAllocationInfoByReq got nil req")
 	} else if allocationInfo == nil {
 		return nil
 	}

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -230,12 +230,14 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		apiconsts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresAllocationHandler,
 		apiconsts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresAllocationHandler,
 		apiconsts.PodAnnotationQoSLevelReclaimedCores: policyImplement.reclaimedCoresAllocationHandler,
+		apiconsts.PodAnnotationQoSLevelSystemCores:    policyImplement.systemCoresAllocationHandler,
 	}
 
 	policyImplement.hintHandlers = map[string]util.HintHandler{
 		apiconsts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresHintHandler,
 		apiconsts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresHintHandler,
 		apiconsts.PodAnnotationQoSLevelReclaimedCores: policyImplement.reclaimedCoresHintHandler,
+		apiconsts.PodAnnotationQoSLevelSystemCores:    policyImplement.systemCoresHintHandler,
 	}
 
 	policyImplement.asyncLimitedWorkersMap = map[string]*asyncworker.AsyncLimitedWorkers{

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -1144,7 +1144,7 @@ func (p *DynamicPolicy) checkNormalShareCoresResource(req *pluginapi.ResourceReq
 
 	machineState := p.state.GetMachineState()
 	resourceState := machineState[v1.ResourceMemory]
-	numaWithoutNUMABindingPods := resourceState.GetNUMANodesWithoutNUMABindingPods()
+	numaWithoutNUMABindingPods := resourceState.GetNUMANodesWithoutSharedOrDedicatedNUMABindingPods()
 	numaAllocatableWithoutNUMABindingPods := uint64(0)
 	for _, numaID := range numaWithoutNUMABindingPods.ToSliceInt() {
 		numaAllocatableWithoutNUMABindingPods += resourceState[numaID].Allocatable

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
@@ -49,6 +49,14 @@ func (p *DynamicPolicy) sharedCoresAllocationHandler(ctx context.Context,
 	}
 }
 
+func (p *DynamicPolicy) systemCoresAllocationHandler(_ context.Context, req *pluginapi.ResourceRequest) (*pluginapi.ResourceAllocationResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("systemCoresAllocationHandler got nil request")
+	}
+
+	return p.allocateAllNUMAs(req, apiconsts.PodAnnotationQoSLevelSystemCores)
+}
+
 func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 	req *pluginapi.ResourceRequest,
 ) (*pluginapi.ResourceAllocationResponse, error) {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
@@ -54,7 +54,17 @@ func (p *DynamicPolicy) systemCoresAllocationHandler(_ context.Context, req *plu
 		return nil, fmt.Errorf("systemCoresAllocationHandler got nil request")
 	}
 
-	return p.allocateAllNUMAs(req, apiconsts.PodAnnotationQoSLevelSystemCores)
+	switch req.Annotations[apiconsts.PodAnnotationMemoryEnhancementNumaBinding] {
+	case apiconsts.PodAnnotationMemoryEnhancementNumaBindingEnable:
+		resourcesMachineState := p.state.GetMachineState()
+		defaultSystemCoresNUMAs := p.getDefaultSystemCoresNUMAs(resourcesMachineState[v1.ResourceMemory])
+		// allocate system_cores pod with NUMA binding
+		// todo: currently we only set cpuset.mems for system_cores pods with numa binding to NUMAs without NUMA exclusive pod,
+		// 		in the future, we set them according to their cpuset_pool annotation.
+		return p.allocateTargetNUMAs(req, apiconsts.PodAnnotationQoSLevelSystemCores, defaultSystemCoresNUMAs)
+	default:
+		return p.allocateTargetNUMAs(req, apiconsts.PodAnnotationQoSLevelSystemCores, p.topology.CPUDetails.NUMANodes())
+	}
 }
 
 func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
@@ -74,7 +84,7 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 	// 	we will support adjusting cpuset.mems for reclaimed_cores dynamically according to memory advisor.
 	// Notice: before supporting dynamic adjustment, not to hybrid reclaimed_cores
 	//  with dedicated_cores numa_binding containers.
-	return p.allocateAllNUMAs(req, apiconsts.PodAnnotationQoSLevelReclaimedCores)
+	return p.allocateTargetNUMAs(req, apiconsts.PodAnnotationQoSLevelReclaimedCores, p.topology.CPUDetails.NUMANodes())
 }
 
 func (p *DynamicPolicy) dedicatedCoresAllocationHandler(ctx context.Context,
@@ -366,20 +376,19 @@ func (p *DynamicPolicy) allocateNUMAsWithoutNUMABindingPods(_ context.Context,
 	return resp, nil
 }
 
-// allocateAllNUMAs returns all numa node as allocation results,
+// allocateTargetNUMAs returns target numa nodes as allocation results,
 // and it will store the allocation in states.
-func (p *DynamicPolicy) allocateAllNUMAs(req *pluginapi.ResourceRequest,
-	qosLevel string,
+func (p *DynamicPolicy) allocateTargetNUMAs(req *pluginapi.ResourceRequest,
+	qosLevel string, targetNUMAs machine.CPUSet,
 ) (*pluginapi.ResourceAllocationResponse, error) {
 	if !pluginapi.SupportedKatalystQoSLevels.Has(qosLevel) {
 		return nil, fmt.Errorf("invalid qosLevel: %s", qosLevel)
 	}
 
-	allNUMAs := p.topology.CPUDetails.NUMANodes()
 	allocationInfo := p.state.GetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName)
-	if allocationInfo != nil && !allocationInfo.NumaAllocationResult.Equals(allNUMAs) {
+	if allocationInfo != nil && !allocationInfo.NumaAllocationResult.Equals(targetNUMAs) {
 		general.Infof("pod: %s/%s, container: %s change cpuset.mems from: %s to %s",
-			req.PodNamespace, req.PodName, req.ContainerName, allocationInfo.NumaAllocationResult.String(), allNUMAs.String())
+			req.PodNamespace, req.PodName, req.ContainerName, allocationInfo.NumaAllocationResult.String(), targetNUMAs.String())
 	}
 
 	allocationInfo = &state.AllocationInfo{
@@ -391,7 +400,7 @@ func (p *DynamicPolicy) allocateAllNUMAs(req *pluginapi.ResourceRequest,
 		ContainerIndex:       req.ContainerIndex,
 		PodRole:              req.PodRole,
 		PodType:              req.PodType,
-		NumaAllocationResult: allNUMAs.Clone(),
+		NumaAllocationResult: targetNUMAs.Clone(),
 		Labels:               general.DeepCopyMap(req.Labels),
 		Annotations:          general.DeepCopyMap(req.Annotations),
 		QoSLevel:             qosLevel,
@@ -427,88 +436,14 @@ func (p *DynamicPolicy) adjustAllocationEntries() error {
 	machineState := resourcesMachineState[v1.ResourceMemory]
 	podEntries := podResourceEntries[v1.ResourceMemory]
 
-	numaWithoutNUMABindingPods := machineState.GetNUMANodesWithoutNUMABindingPods()
-	general.Infof("numaWithoutNUMABindingPods: %s", numaWithoutNUMABindingPods.String())
-
 	// for numaSetChangedContainers, we should reset their allocation info and
 	// trigger necessary Knob actions (like dropping caches or migrate memory
 	// to make sure already-allocated memory cooperate with the new numaset)
-	numaSetChangedContainers := make(map[string]map[string]bool)
-	for podUID, containerEntries := range podEntries {
-		for containerName, allocationInfo := range containerEntries {
-			if allocationInfo == nil {
-				general.Errorf("pod: %s, container: %s has nil allocationInfo", podUID, containerName)
-				continue
-			} else if containerName == "" {
-				general.Errorf("pod: %s has empty containerName entry", podUID)
-				continue
-			} else if allocationInfo.CheckNumaBinding() {
-				// not to adjust NUMA binding containers
-				continue
-			} else if allocationInfo.QoSLevel == apiconsts.PodAnnotationQoSLevelReclaimedCores {
-				// todo: consider strategy here after supporting cpuset.mems dynamic adjustment
-				continue
-			}
-
-			// todo: currently we only set cpuset.mems to NUMAs without NUMA binding for pods isn't NUMA binding
-			//  when cgroup memory policy becomes ready, we will allocate quantity for each pod meticulously.
-			if !allocationInfo.NumaAllocationResult.IsSubsetOf(numaWithoutNUMABindingPods) {
-				if numaSetChangedContainers[podUID] == nil {
-					numaSetChangedContainers[podUID] = make(map[string]bool)
-				}
-				numaSetChangedContainers[podUID][containerName] = true
-			}
-
-			if !allocationInfo.NumaAllocationResult.Equals(numaWithoutNUMABindingPods) {
-				general.Infof("pod: %s/%s, container: %s change cpuset.mems from: %s to %s",
-					allocationInfo.PodNamespace, allocationInfo.PodName, allocationInfo.ContainerName,
-					allocationInfo.NumaAllocationResult.String(), numaWithoutNUMABindingPods.String())
-			}
-
-			allocationInfo.NumaAllocationResult = numaWithoutNUMABindingPods.Clone()
-			allocationInfo.TopologyAwareAllocations = nil
-		}
-	}
-
-	// TODO: optimize this logic someday:
-	//	only for refresh memory request for old inplace update resized pods.
-	for podUID, containerEntries := range podEntries {
-		for containerName, allocationInfo := range containerEntries {
-			if allocationInfo == nil {
-				general.Errorf("pod: %s, container: %s has nil allocationInfo", podUID, containerName)
-				continue
-			} else if containerName == "" {
-				general.Errorf("pod: %s has empty containerName entry", podUID)
-				continue
-			} else if allocationInfo.QoSLevel != apiconsts.PodAnnotationQoSLevelSharedCores {
-				continue
-			}
-			if allocationInfo.QoSLevel == apiconsts.PodAnnotationQoSLevelSharedCores {
-				if allocationInfo.CheckNumaBinding() {
-					if allocationInfo.CheckSideCar() {
-						continue
-					}
-
-					if len(allocationInfo.TopologyAwareAllocations) != 1 {
-						general.Errorf("pod: %s/%s, container: %s topologyAwareAllocations length is not 1: %v",
-							allocationInfo.PodNamespace, allocationInfo.PodName, allocationInfo.ContainerName, allocationInfo.TopologyAwareAllocations)
-						continue
-					}
-
-					// update AggregatedQuantity && TopologyAwareAllocations for snb
-					allocationInfo.AggregatedQuantity = p.getContainerRequestedMemoryBytes(allocationInfo)
-					for numaId, quantity := range allocationInfo.TopologyAwareAllocations {
-						if quantity != allocationInfo.AggregatedQuantity {
-							allocationInfo.TopologyAwareAllocations[numaId] = allocationInfo.AggregatedQuantity
-						}
-					}
-				} else {
-					// update AggregatedQuantity for normal share cores
-					allocationInfo.AggregatedQuantity = p.getContainerRequestedMemoryBytes(allocationInfo)
-				}
-			}
-		}
-	}
+	numaSetChangedContainers := make(map[string]map[string]*state.AllocationInfo)
+	p.adjustAllocationEntriesForSharedCores(numaSetChangedContainers, podEntries, machineState)
+	p.adjustAllocationEntriesForDedicatedCores(numaSetChangedContainers, podEntries, machineState)
+	p.adjustAllocationEntriesForSystemCores(numaSetChangedContainers, podEntries, machineState)
+	// todo: adjust allocation entries for reclaimed cores
 
 	resourcesMachineState, err := state.GenerateMachineStateFromPodEntries(p.state.GetMachineInfo(), podResourceEntries, p.state.GetReservedMemory())
 	if err != nil {
@@ -518,47 +453,9 @@ func (p *DynamicPolicy) adjustAllocationEntries() error {
 	p.state.SetPodResourceEntries(podResourceEntries)
 	p.state.SetMachineState(resourcesMachineState)
 
-	movePagesWorkers, ok := p.asyncLimitedWorkersMap[memoryPluginAsyncWorkTopicMovePage]
-	if !ok {
-		return fmt.Errorf("asyncLimitedWorkers for %s not found", memoryPluginAsyncWorkTopicMovePage)
-	}
-
-	// drop cache and migrate pages for containers whose numaset changed
-	for podUID, containers := range numaSetChangedContainers {
-		for containerName := range containers {
-			containerID, err := p.metaServer.GetContainerID(podUID, containerName)
-			if err != nil {
-				general.Errorf("get container id of pod: %s container: %s failed with error: %v", podUID, containerName, err)
-				continue
-			}
-
-			container, err := p.metaServer.GetContainerSpec(podUID, containerName)
-			if err != nil || container == nil {
-				general.Errorf("get container spec for pod: %s, container: %s failed with error: %v", podUID, containerName, err)
-				continue
-			}
-
-			if !numaWithoutNUMABindingPods.IsEmpty() {
-				movePagesWorkName := util.GetContainerAsyncWorkName(podUID, containerName,
-					memoryPluginAsyncWorkTopicMovePage)
-				// start a asynchronous work to migrate pages for containers whose numaset changed and doesn't require numa_binding
-				err = movePagesWorkers.AddWork(
-					&asyncworker.Work{
-						Name: movePagesWorkName,
-						UID:  uuid.NewUUID(),
-						Fn:   MovePagesForContainer,
-						Params: []interface{}{
-							podUID, containerID,
-							p.topology.CPUDetails.NUMANodes(),
-							numaWithoutNUMABindingPods.Clone(),
-						},
-						DeliveredAt: time.Now(),
-					}, asyncworker.DuplicateWorkPolicyOverride)
-				if err != nil {
-					general.Errorf("add work: %s pod: %s container: %s failed with error: %v", movePagesWorkName, podUID, containerName, err)
-				}
-			}
-		}
+	err = p.migratePagesForNUMASetChangedContainers(numaSetChangedContainers)
+	if err != nil {
+		return fmt.Errorf("migratePagesForNUMASetChangedContainers failed with error: %v", err)
 	}
 
 	return nil
@@ -770,4 +667,193 @@ func packAllocationResponse(allocationInfo *state.AllocationInfo, req *pluginapi
 		Labels:      general.DeepCopyMap(req.Labels),
 		Annotations: general.DeepCopyMap(req.Annotations),
 	}, nil
+}
+
+func (p *DynamicPolicy) adjustAllocationEntriesForSharedCores(numaSetChangedContainers map[string]map[string]*state.AllocationInfo,
+	podEntries state.PodEntries, machineState state.NUMANodeMap,
+) {
+	numaWithoutNUMABindingPods := machineState.GetNUMANodesWithoutNUMABindingPods()
+	general.Infof("numaWithoutNUMABindingPods: %s", numaWithoutNUMABindingPods.String())
+
+	for podUID, containerEntries := range podEntries {
+		for containerName, allocationInfo := range containerEntries {
+			if allocationInfo == nil {
+				general.Errorf("pod: %s, container: %s has nil allocationInfo", podUID, containerName)
+				continue
+			} else if containerName == "" {
+				general.Errorf("pod: %s has empty containerName entry", podUID)
+				continue
+			} else if allocationInfo.QoSLevel != apiconsts.PodAnnotationQoSLevelSharedCores {
+				// not to adjust NUMA binding containers
+				continue
+			}
+
+			if !allocationInfo.CheckNumaBinding() {
+				// update container to target numa set for normal share cores
+				p.updateNUMASetChangedContainers(numaSetChangedContainers, allocationInfo, numaWithoutNUMABindingPods)
+
+				// update AggregatedQuantity for normal share cores
+				allocationInfo.AggregatedQuantity = p.getContainerRequestedMemoryBytes(allocationInfo)
+			} else {
+				// memory of sidecar in snb pod is belonged to main container so we don't need to adjust it
+				if allocationInfo.CheckSideCar() {
+					continue
+				}
+
+				if len(allocationInfo.TopologyAwareAllocations) != 1 {
+					general.Errorf("pod: %s/%s, container: %s topologyAwareAllocations length is not 1: %v",
+						allocationInfo.PodNamespace, allocationInfo.PodName, allocationInfo.ContainerName, allocationInfo.TopologyAwareAllocations)
+					continue
+				}
+
+				// only for refresh memory request for old inplace update resized pods.
+				// update AggregatedQuantity && TopologyAwareAllocations for snb
+				allocationInfo.AggregatedQuantity = p.getContainerRequestedMemoryBytes(allocationInfo)
+				for numaId, quantity := range allocationInfo.TopologyAwareAllocations {
+					if quantity != allocationInfo.AggregatedQuantity {
+						allocationInfo.TopologyAwareAllocations[numaId] = allocationInfo.AggregatedQuantity
+					}
+				}
+			}
+		}
+	}
+}
+
+func (p *DynamicPolicy) adjustAllocationEntriesForDedicatedCores(numaSetChangedContainers map[string]map[string]*state.AllocationInfo,
+	podEntries state.PodEntries, machineState state.NUMANodeMap,
+) {
+	numaWithoutNUMABindingPods := machineState.GetNUMANodesWithoutNUMABindingPods()
+	general.Infof("numaWithoutNUMABindingPods: %s", numaWithoutNUMABindingPods.String())
+
+	for podUID, containerEntries := range podEntries {
+		for containerName, allocationInfo := range containerEntries {
+			if allocationInfo == nil {
+				general.Errorf("pod: %s, container: %s has nil allocationInfo", podUID, containerName)
+				continue
+			} else if containerName == "" {
+				general.Errorf("pod: %s has empty containerName entry", podUID)
+				continue
+			} else if allocationInfo.QoSLevel != apiconsts.PodAnnotationQoSLevelDedicatedCores {
+				continue
+			}
+
+			if !allocationInfo.CheckNumaBinding() {
+				// not to adjust NUMA binding containers
+				// update container to target numa set for normal share cores
+				p.updateNUMASetChangedContainers(numaSetChangedContainers, allocationInfo, numaWithoutNUMABindingPods)
+			}
+		}
+	}
+}
+
+// adjustAllocationEntriesForSystemCores adjusts the allocation entries for system cores pods.
+func (p *DynamicPolicy) adjustAllocationEntriesForSystemCores(numaSetChangedContainers map[string]map[string]*state.AllocationInfo,
+	podEntries state.PodEntries, machineState state.NUMANodeMap,
+) {
+	defaultSystemCoresNUMAs := p.getDefaultSystemCoresNUMAs(machineState)
+
+	for podUID, containerEntries := range podEntries {
+		for containerName, allocationInfo := range containerEntries {
+			if allocationInfo == nil {
+				general.Errorf("pod: %s, container: %s has nil allocationInfo", podUID, containerName)
+				continue
+			} else if containerName == "" {
+				general.Errorf("pod: %s has empty containerName entry", podUID)
+				continue
+			} else if allocationInfo.QoSLevel != apiconsts.PodAnnotationQoSLevelSystemCores {
+				continue
+			}
+
+			if allocationInfo.CheckNumaBinding() {
+				// update container to target numa set for system_cores pod with NUMA binding
+				// todo: currently we only update cpuset.mems for system_cores pods to NUMAs without NUMA binding and NUMA exclusive pod, in the future,
+				//      we will update cpuset.mems for system_cores according to their cpuset_pool annotation.
+				p.updateNUMASetChangedContainers(numaSetChangedContainers, allocationInfo, defaultSystemCoresNUMAs)
+			}
+		}
+	}
+}
+
+func (p *DynamicPolicy) updateNUMASetChangedContainers(numaSetChangedContainers map[string]map[string]*state.AllocationInfo,
+	allocationInfo *state.AllocationInfo, targetNumaSet machine.CPUSet,
+) {
+	if numaSetChangedContainers == nil || allocationInfo == nil {
+		return
+	}
+
+	// todo: currently we only set cpuset.mems to NUMAs without NUMA binding for pods isn't NUMA binding
+	//  when cgroup memory policy becomes ready, we will allocate quantity for each pod meticulously.
+	if !allocationInfo.NumaAllocationResult.IsSubsetOf(targetNumaSet) {
+		if numaSetChangedContainers[allocationInfo.PodUid] == nil {
+			numaSetChangedContainers[allocationInfo.PodUid] = make(map[string]*state.AllocationInfo)
+		}
+		numaSetChangedContainers[allocationInfo.PodUid][allocationInfo.ContainerName] = allocationInfo
+	}
+
+	if !allocationInfo.NumaAllocationResult.Equals(targetNumaSet) {
+		general.Infof("pod: %s/%s, container: %s change cpuset.mems from: %s to %s",
+			allocationInfo.PodNamespace, allocationInfo.PodName, allocationInfo.ContainerName,
+			allocationInfo.NumaAllocationResult.String(), targetNumaSet.String())
+	}
+
+	allocationInfo.NumaAllocationResult = targetNumaSet.Clone()
+	allocationInfo.TopologyAwareAllocations = nil
+}
+
+func (p *DynamicPolicy) migratePagesForNUMASetChangedContainers(numaSetChangedContainers map[string]map[string]*state.AllocationInfo) error {
+	movePagesWorkers, ok := p.asyncLimitedWorkersMap[memoryPluginAsyncWorkTopicMovePage]
+	if !ok {
+		return fmt.Errorf("asyncLimitedWorkers for %s not found", memoryPluginAsyncWorkTopicMovePage)
+	}
+
+	// drop cache and migrate pages for containers whose numaset changed
+	for podUID, containers := range numaSetChangedContainers {
+		for containerName, allocationInfo := range containers {
+			containerID, err := p.metaServer.GetContainerID(podUID, containerName)
+			if err != nil {
+				general.Errorf("get container id of pod: %s container: %s failed with error: %v", podUID, containerName, err)
+				continue
+			}
+
+			container, err := p.metaServer.GetContainerSpec(podUID, containerName)
+			if err != nil || container == nil {
+				general.Errorf("get container spec for pod: %s, container: %s failed with error: %v", podUID, containerName, err)
+				continue
+			}
+
+			if !allocationInfo.NumaAllocationResult.IsEmpty() {
+				movePagesWorkName := util.GetContainerAsyncWorkName(podUID, containerName,
+					memoryPluginAsyncWorkTopicMovePage)
+				// start a asynchronous work to migrate pages for containers whose numaset changed and doesn't require numa_binding
+				err = movePagesWorkers.AddWork(
+					&asyncworker.Work{
+						Name: movePagesWorkName,
+						UID:  uuid.NewUUID(),
+						Fn:   MovePagesForContainer,
+						Params: []interface{}{
+							podUID, containerID,
+							p.topology.CPUDetails.NUMANodes(),
+							allocationInfo.NumaAllocationResult.Clone(),
+						},
+						DeliveredAt: time.Now(),
+					}, asyncworker.DuplicateWorkPolicyOverride)
+				if err != nil {
+					general.Errorf("add work: %s pod: %s container: %s failed with error: %v", movePagesWorkName, podUID, containerName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// getDefaultSystemCoresNUMAs returns the default system cores NUMAs.
+func (p *DynamicPolicy) getDefaultSystemCoresNUMAs(machineState state.NUMANodeMap) machine.CPUSet {
+	numaNodesWithoutNUMABindingAndNUMAExclusivePods := machineState.GetNUMANodesWithoutNUMABindingAndNUMAExclusivePods()
+	general.Infof("numaNodesWithoutNUMABindingAndNUMAExclusivePods: %s", numaNodesWithoutNUMABindingAndNUMAExclusivePods.String())
+	if numaNodesWithoutNUMABindingAndNUMAExclusivePods.IsEmpty() {
+		// if there is no numa nodes without NUMA binding and NUMA exclusive pods, we will use all numa nodes.
+		return p.topology.CPUDetails.NUMANodes()
+	}
+	return numaNodesWithoutNUMABindingAndNUMAExclusivePods
 }

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_hint_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_hint_handlers.go
@@ -71,6 +71,17 @@ func (p *DynamicPolicy) sharedCoresHintHandler(ctx context.Context,
 		})
 }
 
+func (p *DynamicPolicy) systemCoresHintHandler(_ context.Context, req *pluginapi.ResourceRequest) (*pluginapi.ResourceHintsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("got nil request")
+	}
+
+	return util.PackResourceHintsResponse(req, string(v1.ResourceMemory),
+		map[string]*pluginapi.ListOfTopologyHints{
+			string(v1.ResourceMemory): nil, // indicates that there is no numa preference
+		})
+}
+
 func (p *DynamicPolicy) reclaimedCoresHintHandler(ctx context.Context,
 	req *pluginapi.ResourceRequest,
 ) (*pluginapi.ResourceHintsResponse, error) {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_hint_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_hint_handlers.go
@@ -172,7 +172,7 @@ func (p *DynamicPolicy) numaBindingHintHandler(_ context.Context,
 
 	// if hints exists in extra state-file, prefer to use them
 	if hints == nil {
-		availableNUMAs := resourcesMachineState[v1.ResourceMemory].GetNUMANodesWithoutNUMABindingPods()
+		availableNUMAs := resourcesMachineState[v1.ResourceMemory].GetNUMANodesWithoutSharedOrDedicatedNUMABindingPods()
 
 		var extraErr error
 		hints, extraErr = util.GetHintsFromExtraStateFile(req.PodName, string(v1.ResourceMemory),

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
@@ -1772,13 +1772,13 @@ func TestGetResourcesAllocation(t *testing.T) {
 	as.NotNil(resp1.PodResources[req.PodUid])
 	as.NotNil(resp1.PodResources[req.PodUid].ContainerResources[testName])
 	as.NotNil(resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
-	as.Equal(resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)], &pluginapi.ResourceAllocationInfo{
+	as.Equal(&pluginapi.ResourceAllocationInfo{
 		OciPropertyName:   util.OCIPropertyNameCPUSetMems,
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 1073741824,
 		AllocationResult:  machine.NewCPUSet(0, 1, 2, 3).String(),
-	})
+	}, resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
 
 	// test for reclaimed_cores
 	req = &pluginapi.ResourceRequest{
@@ -1809,13 +1809,13 @@ func TestGetResourcesAllocation(t *testing.T) {
 	as.NotNil(resp2.PodResources[req.PodUid])
 	as.NotNil(resp2.PodResources[req.PodUid].ContainerResources[testName])
 	as.NotNil(resp2.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
-	as.Equal(resp2.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)], &pluginapi.ResourceAllocationInfo{
+	as.Equal(&pluginapi.ResourceAllocationInfo{
 		OciPropertyName:   util.OCIPropertyNameCPUSetMems,
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 0,
 		AllocationResult:  machine.NewCPUSet(0, 1, 2, 3).String(),
-	})
+	}, resp2.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
 
 	os.RemoveAll(tmpDir)
 	dynamicPolicy, err = getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, tmpDir)
@@ -1855,13 +1855,13 @@ func TestGetResourcesAllocation(t *testing.T) {
 	as.NotNil(resp3.PodResources[req.PodUid])
 	as.NotNil(resp3.PodResources[req.PodUid].ContainerResources[testName])
 	as.NotNil(resp3.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
-	as.Equal(resp3.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)], &pluginapi.ResourceAllocationInfo{
+	as.Equal(&pluginapi.ResourceAllocationInfo{
 		OciPropertyName:   util.OCIPropertyNameCPUSetMems,
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 7516192768,
 		AllocationResult:  machine.NewCPUSet(0).String(),
-	})
+	}, resp3.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
 
 	// test for system_cores with cpuset_pool reserve
 	req = &pluginapi.ResourceRequest{
@@ -1897,13 +1897,56 @@ func TestGetResourcesAllocation(t *testing.T) {
 	as.NotNil(resp4.PodResources[req.PodUid])
 	as.NotNil(resp4.PodResources[req.PodUid].ContainerResources[testName])
 	as.NotNil(resp4.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
-	as.Equal(resp4.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)], &pluginapi.ResourceAllocationInfo{
+	as.Equal(&pluginapi.ResourceAllocationInfo{
 		OciPropertyName:   util.OCIPropertyNameCPUSetMems,
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 0,
 		AllocationResult:  machine.NewCPUSet(0, 1, 2, 3).String(),
-	})
+	}, resp4.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
+
+	// test for system_cores with cpuset_pool reserve and with numa binding
+	req = &pluginapi.ResourceRequest{
+		PodUid:         string(uuid.NewUUID()),
+		PodNamespace:   testName,
+		PodName:        testName,
+		ContainerName:  testName,
+		ContainerType:  pluginapi.ContainerType_MAIN,
+		ContainerIndex: 0,
+		ResourceName:   string(v1.ResourceMemory),
+		Hint: &pluginapi.TopologyHint{
+			Nodes:     []uint64{0},
+			Preferred: true,
+		},
+		ResourceRequests: map[string]float64{
+			string(v1.ResourceMemory): 2147483648,
+		},
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelSystemCores,
+			consts.PodAnnotationCPUEnhancementKey:    `{"cpuset_pool": "reserve"}`,
+			consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding": "true"}`,
+		},
+		Labels: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+		},
+	}
+
+	_, err = dynamicPolicy.Allocate(context.Background(), req)
+	as.Nil(err)
+
+	resp5, err := dynamicPolicy.GetResourcesAllocation(context.Background(), &pluginapi.GetResourcesAllocationRequest{})
+	as.Nil(err)
+
+	as.NotNil(resp5.PodResources[req.PodUid])
+	as.NotNil(resp5.PodResources[req.PodUid].ContainerResources[testName])
+	as.NotNil(resp5.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
+	as.Equal(&pluginapi.ResourceAllocationInfo{
+		OciPropertyName:   util.OCIPropertyNameCPUSetMems,
+		IsNodeResource:    false,
+		IsScalarResource:  true,
+		AllocatedQuantity: 0,
+		AllocationResult:  machine.NewCPUSet(1, 2, 3).String(),
+	}, resp5.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
 }
 
 func TestGetReadonlyState(t *testing.T) {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
@@ -142,12 +142,14 @@ func getTestDynamicPolicyWithInitialization(topology *machine.CPUTopology, machi
 		consts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresAllocationHandler,
 		consts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresAllocationHandler,
 		consts.PodAnnotationQoSLevelReclaimedCores: policyImplement.reclaimedCoresAllocationHandler,
+		consts.PodAnnotationQoSLevelSystemCores:    policyImplement.systemCoresAllocationHandler,
 	}
 
 	policyImplement.hintHandlers = map[string]util.HintHandler{
 		consts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresHintHandler,
 		consts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresHintHandler,
 		consts.PodAnnotationQoSLevelReclaimedCores: policyImplement.reclaimedCoresHintHandler,
+		consts.PodAnnotationQoSLevelSystemCores:    policyImplement.systemCoresHintHandler,
 	}
 
 	policyImplement.asyncWorkers = asyncworker.NewAsyncWorkers(memoryPluginAsyncWorkersName, policyImplement.emitter)
@@ -1101,6 +1103,44 @@ func TestGetTopologyHints(t *testing.T) {
 			},
 		},
 		{
+			description: "req for system_cores main container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:         string(uuid.NewUUID()),
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   string(v1.ResourceMemory),
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceMemory): 1073741824,
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+			},
+			expectedResp: &pluginapi.ResourceHintsResponse{
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   string(v1.ResourceMemory),
+				ResourceHints: map[string]*pluginapi.ListOfTopologyHints{
+					string(v1.ResourceMemory): nil,
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+			},
+		},
+		{
 			description: "req for dedicated_cores with numa_binding & numa_exclusive main container",
 			req: &pluginapi.ResourceRequest{
 				PodUid:         string(uuid.NewUUID()),
@@ -1821,6 +1861,48 @@ func TestGetResourcesAllocation(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 7516192768,
 		AllocationResult:  machine.NewCPUSet(0).String(),
+	})
+
+	// test for system_cores with cpuset_pool reserve
+	req = &pluginapi.ResourceRequest{
+		PodUid:         string(uuid.NewUUID()),
+		PodNamespace:   testName,
+		PodName:        testName,
+		ContainerName:  testName,
+		ContainerType:  pluginapi.ContainerType_MAIN,
+		ContainerIndex: 0,
+		ResourceName:   string(v1.ResourceMemory),
+		Hint: &pluginapi.TopologyHint{
+			Nodes:     []uint64{0},
+			Preferred: true,
+		},
+		ResourceRequests: map[string]float64{
+			string(v1.ResourceMemory): 2147483648,
+		},
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:       consts.PodAnnotationQoSLevelSystemCores,
+			consts.PodAnnotationCPUEnhancementKey: `{"cpuset_pool": "reserve"}`,
+		},
+		Labels: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+		},
+	}
+
+	_, err = dynamicPolicy.Allocate(context.Background(), req)
+	as.Nil(err)
+
+	resp4, err := dynamicPolicy.GetResourcesAllocation(context.Background(), &pluginapi.GetResourcesAllocationRequest{})
+	as.Nil(err)
+
+	as.NotNil(resp4.PodResources[req.PodUid])
+	as.NotNil(resp4.PodResources[req.PodUid].ContainerResources[testName])
+	as.NotNil(resp4.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)])
+	as.Equal(resp4.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceMemory)], &pluginapi.ResourceAllocationInfo{
+		OciPropertyName:   util.OCIPropertyNameCPUSetMems,
+		IsNodeResource:    false,
+		IsScalarResource:  true,
+		AllocatedQuantity: 0,
+		AllocationResult:  machine.NewCPUSet(0, 1, 2, 3).String(),
 	})
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
In certain situations, a pod with the system_cores QoS level should be bound to specific CPU pools, such as the reserve pool, to prevent impact on critical pools.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
