### PR TITLE
topology adapter support configure custom kubelet resource plugin state file

### DIFF
--- a/cmd/katalyst-agent/app/options/reporter/kubelet_plugin.go
+++ b/cmd/katalyst-agent/app/options/reporter/kubelet_plugin.go
@@ -22,15 +22,17 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/reporter"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
 )
 
 type KubeletPluginOptions struct {
-	PodResourcesServerEndpoints []string
-	KubeletResourcePluginPaths  []string
-	EnableReportTopologyPolicy  bool
-	ResourceNameToZoneTypeMap   map[string]string
-	NeedValidationResources     []string
-	EnablePodResourcesFilter    bool
+	PodResourcesServerEndpoints    []string
+	KubeletResourcePluginPaths     []string
+	KubeletResourcePluginStateFile string
+	EnableReportTopologyPolicy     bool
+	ResourceNameToZoneTypeMap      map[string]string
+	NeedValidationResources        []string
+	EnablePodResourcesFilter       bool
 }
 
 func NewKubeletPluginOptions() *KubeletPluginOptions {
@@ -41,8 +43,9 @@ func NewKubeletPluginOptions() *KubeletPluginOptions {
 		KubeletResourcePluginPaths: []string{
 			pluginapi.ResourcePluginPath,
 		},
-		EnableReportTopologyPolicy: false,
-		ResourceNameToZoneTypeMap:  make(map[string]string),
+		KubeletResourcePluginStateFile: consts.KubeletQoSResourceManagerCheckpoint,
+		EnableReportTopologyPolicy:     false,
+		ResourceNameToZoneTypeMap:      make(map[string]string),
 		NeedValidationResources: []string{
 			string(v1.ResourceCPU),
 			string(v1.ResourceMemory),
@@ -58,6 +61,8 @@ func (o *KubeletPluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"the endpoint of pod resource api server")
 	fs.StringSliceVar(&o.KubeletResourcePluginPaths, "kubelet-resource-plugin-path", o.KubeletResourcePluginPaths,
 		"the path of kubelet resource plugin")
+	fs.StringVar(&o.KubeletResourcePluginStateFile, "kubelet-resource-plugin-state-file", o.KubeletResourcePluginStateFile,
+		"the state file of kubelet resource plugin")
 	fs.BoolVar(&o.EnableReportTopologyPolicy, "enable-report-topology-policy", o.EnableReportTopologyPolicy,
 		"whether to report topology policy")
 	fs.StringToStringVar(&o.ResourceNameToZoneTypeMap, "resource-name-to-zone-type-map", o.ResourceNameToZoneTypeMap,
@@ -71,6 +76,7 @@ func (o *KubeletPluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 func (o *KubeletPluginOptions) ApplyTo(c *reporter.KubeletPluginConfiguration) error {
 	c.PodResourcesServerEndpoints = o.PodResourcesServerEndpoints
 	c.KubeletResourcePluginPaths = o.KubeletResourcePluginPaths
+	c.KubeletResourcePluginStateFile = o.KubeletResourcePluginStateFile
 	c.EnableReportTopologyPolicy = o.EnableReportTopologyPolicy
 	c.ResourceNameToZoneTypeMap = o.ResourceNameToZoneTypeMap
 	c.NeedValidationResources = o.NeedValidationResources

--- a/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin.go
+++ b/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin.go
@@ -97,8 +97,8 @@ func NewKubeletReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaser
 	}
 
 	topologyStatusAdapter, err := topology.NewPodResourcesServerTopologyAdapter(metaServer, conf.QoSConfiguration,
-		conf.PodResourcesServerEndpoints, conf.KubeletResourcePluginPaths, conf.ResourceNameToZoneTypeMap,
-		nil, p.getNumaInfo, podResourcesFilter, podresources.GetV1Client,
+		conf.PodResourcesServerEndpoints, conf.KubeletResourcePluginPaths, conf.KubeletResourcePluginStateFile,
+		conf.ResourceNameToZoneTypeMap, nil, p.getNumaInfo, podResourcesFilter, podresources.GetV1Client,
 		conf.NeedValidationResources)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/resourcemanager/fetcher/kubelet/topology/topology_adapter_test.go
+++ b/pkg/agent/resourcemanager/fetcher/kubelet/topology/topology_adapter_test.go
@@ -2969,7 +2969,7 @@ func Test_podResourcesServerTopologyAdapterImpl_Run(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	notifier := make(chan struct{}, 1)
 	p, _ := NewPodResourcesServerTopologyAdapter(testMetaServer, generic.NewQoSConfiguration(),
-		endpoints, kubeletResourcePluginPath, nil,
+		endpoints, kubeletResourcePluginPath, pkgconsts.KubeletQoSResourceManagerCheckpoint, nil,
 		nil, getNumaInfo, nil, podresources.GetV1Client, []string{"cpu", "memory"})
 	err = p.Run(ctx, func() {})
 	assert.NoError(t, err)

--- a/pkg/config/agent/reporter/kubelet_plugin.go
+++ b/pkg/config/agent/reporter/kubelet_plugin.go
@@ -17,12 +17,13 @@ limitations under the License.
 package reporter
 
 type KubeletPluginConfiguration struct {
-	PodResourcesServerEndpoints []string
-	KubeletResourcePluginPaths  []string
-	EnableReportTopologyPolicy  bool
-	ResourceNameToZoneTypeMap   map[string]string
-	NeedValidationResources     []string
-	EnablePodResourcesFilter    bool
+	PodResourcesServerEndpoints    []string
+	KubeletResourcePluginPaths     []string
+	KubeletResourcePluginStateFile string
+	EnableReportTopologyPolicy     bool
+	ResourceNameToZoneTypeMap      map[string]string
+	NeedValidationResources        []string
+	EnablePodResourcesFilter       bool
 }
 
 func NewKubeletPluginConfiguration() *KubeletPluginConfiguration {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
The topology adapter can use not only the native resource plugin state file but also other files, such as the QRM resource plugin state file, when the native resource plugin state file is unavailable.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
