### PR TITLE
fix: fix nil panic when update tideNodePool fail in Tide.Reconcile

### DIFF
--- a/pkg/controller/tide/tide.go
+++ b/pkg/controller/tide/tide.go
@@ -338,11 +338,12 @@ func (t *Tide) Reconcile(ctx context.Context, tideNodePool *apis.TideNodePool) e
 	// Add finalizer first
 	if !controllerutil.ContainsFinalizer(tideNodePool, NodePoolFinalizer) && tideNodePool.DeletionTimestamp.IsZero() {
 		controllerutil.AddFinalizer(tideNodePool, NodePoolFinalizer)
-		tideNodePool, err := t.client.InternalClient.TideV1alpha1().TideNodePools().Update(ctx, tideNodePool, metav1.UpdateOptions{})
+		newTideNodePool, err := t.client.InternalClient.TideV1alpha1().TideNodePools().Update(ctx, tideNodePool, metav1.UpdateOptions{})
 		if err != nil {
 			klog.ErrorS(err, "fail to add finalizer", "rule", tideNodePool.Name)
 			return err
 		}
+		tideNodePool = newTideNodePool
 	}
 	// process deletion
 	if !tideNodePool.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:

https://github.com/kubewharf/katalyst-core/blob/5c0c031d5c172cbe6e176b5ab6499c63a7063f14/pkg/controller/tide/tide.go#L334-L346

When TideNodePool update failed, tideNodePool is set to be nil,  and logging `tideNodePool.Name` will panic.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
