### PR TITLE
feat(sockmem): keep the values in tcp_mem consistent

### DIFF
--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -396,7 +396,7 @@ func (p *DynamicPolicy) Start() (err error) {
 		general.Infof("setSockMem enabled")
 		err := periodicalhandler.RegisterPeriodicalHandlerWithHealthz(memconsts.SetSockMem,
 			general.HealthzCheckStateNotReady, qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
-			sockmem.SetSockMemLimit, 60*time.Second, healthCheckTolerationTimes)
+			sockmem.SetSockMemLimit, 120*time.Second, healthCheckTolerationTimes)
 		if err != nil {
 			general.Infof("setSockMem failed, err=%v", err)
 		}

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux_test.go
@@ -308,3 +308,26 @@ func TestSetCg1TCPMem(t *testing.T) {
 		t.Error("Expected an error, but got none")
 	}
 }
+
+func TestSetHostTCPMem_NilSockMemConfig(t *testing.T) {
+	t.Parallel()
+	memTotal := uint64(1024) // Sample memory total
+
+	// Call setHostTCPMem with a nil sockMemConfig
+	err := setHostTCPMem(nil, memTotal, nil)
+
+	// Assert that the error is as expected
+	assert.Error(t, err)
+	assert.Equal(t, "sockMemConfig is nil", err.Error())
+}
+
+func TestUpdateHostTCPMem_NilSockMemConfig(t *testing.T) {
+	t.Parallel()
+	tcpMem := []uint64{50, 50, 50}
+	memTotal := uint64(1024) // Sample memory total
+	tcpMemRatio := uint64(50)
+	err := updateTCPMemLimit(tcpMem, memTotal, tcpMemRatio, "/fake/path/tcp_mem")
+
+	// Assert that the error is as expected
+	assert.Error(t, err)
+}


### PR DESCRIPTION
#### What type of PR is this?
Enhancements：ensure consistency in the values of tcp_mem to reduce tcp memory pressure.

#### What this PR does / why we need it:
None

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None