### PR TITLE
feat (sysadvisor): get power data served by metric store sourced from malachite realtime metric server

### DIFF
--- a/cmd/katalyst-agent/app/options/metaserver/metric.go
+++ b/cmd/katalyst-agent/app/options/metaserver/metric.go
@@ -56,7 +56,7 @@ func NewMetricFetcherOptions() *MetricFetcherOptions {
 		MetricProvisions:      []string{metaserver.MetricProvisionerMalachite, metaserver.MetricProvisionerKubelet},
 
 		DefaultInterval:         time.Second * 5,
-		ProvisionerIntervalSecs: make(map[string]int),
+		ProvisionerIntervalSecs: map[string]int{metaserver.MetricProvisionerMalachiteRealtime: 1},
 
 		MalachiteOptions: &MalachiteOptions{},
 		CgroupOptions:    &CgroupOptions{},

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	// 8 seconds between actions since RAPL/HSMP capping needs 4-6 seconds to stabilize itself
-	intervalSpecFetch = time.Second * 8
+	// 9 seconds between actions since RAPL/HSMP capping needs 4-6 seconds to stabilize itself
+	// and malachite realtime metric server imposes delay of up to 2 seconds
+	intervalSpecFetch = time.Second * 9
 
 	metricPowerAwareCurrentPowerInWatt = "power_current_watt"
 	metricPowerAwareDesiredPowerInWatt = "power_desired_watt"

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
@@ -94,9 +94,7 @@ func NewPowerAwarePlugin(
 		}
 	}
 
-	// todo: use the power usage data from malachite
-	// we may temporarily have a local reader on top of ipmi (in dev branch), before malachite is ready
-	powerReader := reader.NewDummyPowerReader()
+	powerReader := reader.NewMetricStorePowerReader(metaServer)
 
 	powerAdvisor := advisor.NewAdvisor(conf.PowerAwarePluginConfiguration.DryRun,
 		conf.PowerAwarePluginConfiguration.AnnotationKeyPrefix,

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+// malachite realtime power metric server imposes delay of up to 2 seconds coupled with sampling interval of 1 sec
+const powerTolerationTime = 3 * time.Second
+
+type nodeMetricGetter interface {
+	GetNodeMetric(metricName string) (utilmetric.MetricData, error)
+}
+
+type metricStorePowerReader struct {
+	nodeMetricGetter
+}
+
+func (m *metricStorePowerReader) Init() error {
+	return nil
+}
+
+func isDataFresh(data utilmetric.MetricData, now time.Time) bool {
+	if data.Time == nil {
+		return false
+	}
+	return now.Before(data.Time.Add(powerTolerationTime))
+}
+
+func (m *metricStorePowerReader) Get(ctx context.Context) (int, error) {
+	return m.get(ctx, time.Now())
+}
+
+func (m *metricStorePowerReader) get(ctx context.Context, now time.Time) (int, error) {
+	data, err := m.GetNodeMetric(consts.MetricTotalPowerUsedWatts)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get metric from metric store")
+	}
+
+	if !isDataFresh(data, now) {
+		return 0, errors.New("power data in metric store is stale")
+	}
+
+	return int(data.Value), nil
+}
+
+func (m *metricStorePowerReader) Cleanup() {}
+
+func NewMetricStorePowerReader(nodeMetricGetter nodeMetricGetter) PowerReader {
+	return &metricStorePowerReader{
+		nodeMetricGetter: nodeMetricGetter,
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+func Test_metricStorePowerReader_get(t *testing.T) {
+	t.Parallel()
+
+	setTime := time.Date(2024, 11, 11, 8, 30, 10, 0, time.UTC)
+	dummyMetricStore := utilmetric.NewMetricStore()
+	dummyMetricStore.SetNodeMetric("total.power.used.watts", utilmetric.MetricData{
+		Value: 999,
+		Time:  &setTime,
+	})
+
+	type fields struct {
+		metricStore *utilmetric.MetricStore
+	}
+	type args struct {
+		ctx context.Context
+		now time.Time
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				metricStore: dummyMetricStore,
+			},
+			args: args{
+				ctx: context.TODO(),
+				now: time.Date(2024, 11, 11, 8, 30, 11, 0, time.UTC),
+			},
+			want:    999,
+			wantErr: false,
+		},
+		{
+			name: "stale data",
+			fields: fields{
+				metricStore: dummyMetricStore,
+			},
+			args: args{
+				ctx: context.TODO(),
+				now: time.Date(2024, 11, 11, 8, 30, 13, 0, time.UTC),
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "no such metric in store",
+			fields: fields{
+				metricStore: utilmetric.NewMetricStore(),
+			},
+			args: args{
+				ctx: context.TODO(),
+				now: time.Date(2024, 11, 11, 8, 30, 13, 0, time.UTC),
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewMetricStorePowerReader(tt.fields.metricStore).(*metricStorePowerReader)
+			got, err := m.get(tt.args.ctx, tt.args.now)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("get() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/agent/metaserver/agent.go
+++ b/pkg/config/agent/metaserver/agent.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	MetricProvisionerMalachite = "malachite"
-	MetricProvisionerCgroup    = "cgroup"
-	MetricProvisionerKubelet   = "kubelet"
-	MetricProvisionerRodan     = "rodan"
+	MetricProvisionerMalachite         = "malachite"
+	MetricProvisionerMalachiteRealtime = "malachite_realtime"
+	MetricProvisionerCgroup            = "cgroup"
+	MetricProvisionerKubelet           = "kubelet"
+	MetricProvisionerRodan             = "rodan"
 )
 
 type MetricConfiguration struct {

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -131,6 +131,11 @@ const (
 	MetricsNodeFsInodesUsed = "used.inodes.fs.node"
 )
 
+// System Power metrics
+const (
+	MetricTotalPowerUsedWatts = "total.power.used.watts"
+)
+
 // Image filesystem metrics
 const (
 	MetricsImageFsAvailable  = "available.rootfs.system"

--- a/pkg/metaserver/agent/metric/metric_provisoner.go
+++ b/pkg/metaserver/agent/metric/metric_provisoner.go
@@ -33,6 +33,7 @@ import (
 
 func init() {
 	RegisterProvisioners(metaserver.MetricProvisionerMalachite, malachite.NewMalachiteMetricsProvisioner)
+	RegisterProvisioners(metaserver.MetricProvisionerMalachiteRealtime, malachite.NewMalachiteRealtimeMetricsProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerKubelet, kubelet.NewKubeletSummaryProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerCgroup, cgroup.NewCGroupMetricsProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerRodan, rodan.NewRodanMetricsProvisioner)

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
@@ -33,6 +33,8 @@ const (
 	SystemNetResource     = "system/network"
 	SystemMemoryResource  = "system/memory"
 	SystemComputeResource = "system/compute"
+
+	RealtimePowerResource = "realtime/power"
 )
 
 type SystemResourceKind int
@@ -61,6 +63,7 @@ func NewMalachiteClient(fetcher pod.PodFetcher) *MalachiteClient {
 		SystemNetResource,
 		SystemComputeResource,
 		SystemMemoryResource,
+		RealtimePowerResource,
 	} {
 		urls[path] = fmt.Sprintf("http://localhost:%d/api/v1/%s", malachiteServicePort, path)
 	}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_power.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_power.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+)
+
+func (c *MalachiteClient) GetPowerData() (*types.PowerData, error) {
+	payload, err := c.getRealtimePowerPayload(RealtimePowerResource)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp := &types.MalachitePowerResponse{}
+	if err := json.Unmarshal(payload, rsp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal system compute stats raw data, err %s", err)
+	}
+
+	if rsp.Status != 0 {
+		return nil, fmt.Errorf("system compute stats status is not ok, %d", rsp.Status)
+	}
+
+	return &rsp.Data, nil
+}
+
+func (c *MalachiteClient) getRealtimePowerPayload(resource string) ([]byte, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	url, ok := c.urls[resource]
+	if !ok {
+		return nil, fmt.Errorf("no url for %v", resource)
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to http.NewRequest, url: %s, err %s", url, err)
+	}
+
+	rsp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to http.DefaultClient.Do, url: %s, err %s", req.URL, err)
+	}
+
+	defer func() { _ = rsp.Body.Close() }()
+	if rsp.StatusCode != 200 {
+		return nil, fmt.Errorf("invalid http response status code %d, url: %s", rsp.StatusCode, req.URL)
+	}
+
+	return ioutil.ReadAll(rsp.Body)
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_power_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_power_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+)
+
+func TestMalachiteClient_GetPower(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		respBody   string
+		statusCode int
+		want       *types.PowerData
+		wantErr    assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path",
+			respBody: `{
+				"status":0,
+				"data":{
+					"sensors":{
+						"total_power":384.0,
+						"cpu_power":196.0,
+						"mem_power":132.0,
+						"fan_power":16.0,
+						"hdd_power":null,
+						"psu0_pout":null,
+						"psu0_pin":null,
+						"psu1_pout":null,
+						"psu1_pin":null,
+						"cpu0_temp":44.0,
+						"cpu1_temp":43.0,
+						"psu0_temp":56.0,
+						"psu1_temp":54.0,
+						"update_time":1731430097
+					}
+				}
+			}`,
+			statusCode: 200,
+			want: &types.PowerData{
+				Sensors: types.SensorData{
+					TotalPowerWatt: 384.0,
+					UpdateTime:     1731430097,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name:       "invalid payload format is error",
+			respBody:   "invalid payload",
+			statusCode: 200,
+			want:       nil,
+			wantErr:    assert.Error,
+		},
+		{
+			name:       "http status code other than 200 is error",
+			respBody:   "{}",
+			statusCode: 502,
+			want:       nil,
+			wantErr:    assert.Error,
+		},
+		{
+			name:       "payload status not 0 is error",
+			respBody:   `{"status":4}`,
+			statusCode: 200,
+			want:       nil,
+			wantErr:    assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.respBody))
+			}))
+			defer s.Close()
+
+			c := &MalachiteClient{
+				urls: map[string]string{"realtime/power": s.URL},
+			}
+			got, err := c.GetPowerData()
+			if !tt.wantErr(t, err, fmt.Sprintf("GetPowerData()")) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetPowerData()")
+		})
+	}
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner.go
@@ -80,7 +80,7 @@ func (m *MalachiteRealtimeMetricsProvisioner) Run(ctx context.Context) {
 func (m *MalachiteRealtimeMetricsProvisioner) checkMalachiteHealthy() bool {
 	_, err := m.malachiteClient.GetPowerData()
 	if err != nil {
-		klog.Errorf("[malachite] malachite realtime is unhealthy: %v", err)
+		klog.Errorf("[malachite_realtime] malachite realtime is unhealthy: %v", err)
 		_ = m.emitter.StoreInt64(metricsNamMalachiteRealtimeUnHealthy, 1, metrics.MetricTypeNameRaw)
 		return false
 	}
@@ -89,7 +89,7 @@ func (m *MalachiteRealtimeMetricsProvisioner) checkMalachiteHealthy() bool {
 }
 
 func (m *MalachiteRealtimeMetricsProvisioner) sample(ctx context.Context) {
-	klog.V(4).Infof("[malachite] heartbeat")
+	klog.V(4).Infof("[malachite_realtime] heartbeat")
 
 	if !m.checkMalachiteHealthy() {
 		_ = general.UpdateHealthzState(malachiteRealtimeProvisionerHealthCheckName, general.HealthzCheckStateNotReady, "malachite realtime is not healthy")

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package malachite
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/client"
+	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+const (
+	metricsNamMalachiteRealtimeUnHealthy        = "malachite_realtime_unhealthy"
+	malachiteRealtimeProvisionerHealthCheckName = "malachite_realtime_provisioner_sample"
+	malachiteRealtimeProvisionTolerationTime    = 5 * time.Second
+	metricsNameMalachiteGetRealtimePowerFailed  = "malachite_get_realtime_power_failed"
+)
+
+func NewMalachiteRealtimeMetricsProvisioner(baseConf *global.BaseConfiguration, metricConf *metaserver.MetricConfiguration,
+	emitter metrics.MetricEmitter, fetcher pod.PodFetcher, metricStore *utilmetric.MetricStore,
+) types.MetricsProvisioner {
+	inner := &MalachiteMetricsProvisioner{
+		malachiteClient: client.NewMalachiteClient(fetcher),
+		metricStore:     metricStore,
+		emitter:         emitter,
+		baseConf:        baseConf,
+	}
+
+	return &MalachiteRealtimeMetricsProvisioner{
+		malachiteClient:             inner.malachiteClient,
+		MalachiteMetricsProvisioner: inner,
+	}
+}
+
+type powerDataGetter interface {
+	GetPowerData() (*malachitetypes.PowerData, error)
+}
+
+type MalachiteRealtimeMetricsProvisioner struct {
+	malachiteClient powerDataGetter
+	*MalachiteMetricsProvisioner
+}
+
+func (m *MalachiteRealtimeMetricsProvisioner) Run(ctx context.Context) {
+	m.startOnce.Do(func() {
+		general.RegisterHeartbeatCheck(malachiteProvisionerHealthCheckName,
+			malachiteRealtimeProvisionTolerationTime,
+			general.HealthzCheckStateNotReady,
+			malachiteRealtimeProvisionTolerationTime)
+	})
+	m.sample(ctx)
+}
+
+func (m *MalachiteRealtimeMetricsProvisioner) checkMalachiteHealthy() bool {
+	_, err := m.malachiteClient.GetPowerData()
+	if err != nil {
+		klog.Errorf("[malachite] malachite realtime is unhealthy: %v", err)
+		_ = m.emitter.StoreInt64(metricsNamMalachiteRealtimeUnHealthy, 1, metrics.MetricTypeNameRaw)
+		return false
+	}
+
+	return true
+}
+
+func (m *MalachiteRealtimeMetricsProvisioner) sample(ctx context.Context) {
+	klog.V(4).Infof("[malachite] heartbeat")
+
+	if !m.checkMalachiteHealthy() {
+		_ = general.UpdateHealthzState(malachiteRealtimeProvisionerHealthCheckName, general.HealthzCheckStateNotReady, "malachite realtime is not healthy")
+		return
+	}
+	errList := make([]error, 0)
+
+	// Update system data
+	if err := m.updateSystemTotalPower(); err != nil {
+		errList = append(errList, err)
+	}
+
+	_ = general.UpdateHealthzStateByError(malachiteRealtimeProvisionerHealthCheckName, errors.NewAggregate(errList))
+}
+
+func (m *MalachiteRealtimeMetricsProvisioner) updateSystemTotalPower() error {
+	errList := make([]error, 0)
+	powerData, err := m.malachiteClient.GetPowerData()
+	if err != nil {
+		errList = append(errList, err)
+		klog.Errorf("[malachite] get system compute stats failed, err %v", err)
+		_ = m.emitter.StoreInt64(metricsNameMalachiteGetRealtimePowerFailed, 1, metrics.MetricTypeNameCount,
+			metrics.MetricTag{Key: "kind", Val: "power"})
+	} else {
+		m.processSystemPowerData(powerData)
+	}
+
+	return errors.NewAggregate(errList)
+}
+
+func (m *MalachiteRealtimeMetricsProvisioner) processSystemPowerData(data *malachitetypes.PowerData) {
+	if data == nil {
+		return
+	}
+
+	updateTime := time.Unix(data.Sensors.UpdateTime, 0)
+	m.metricStore.SetNodeMetric(consts.MetricTotalPowerUsedWatts,
+		utilmetric.MetricData{Value: data.Sensors.TotalPowerWatt, Time: &updateTime})
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package malachite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+func TestMalachiteRealtimeMetricsProvisioner_processSystemPowerData(t *testing.T) {
+	t.Parallel()
+
+	testTimestamp := time.Date(2024, 11, 12, 0, 0, 0, 0, time.Local)
+	testUnixTime := testTimestamp.Unix()
+
+	type fields struct {
+		MalachiteMetricsProvisioner *MalachiteMetricsProvisioner
+	}
+	type args struct {
+		data *malachitetypes.PowerData
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    utilmetric.MetricData
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				MalachiteMetricsProvisioner: &MalachiteMetricsProvisioner{
+					metricStore: utilmetric.NewMetricStore(),
+				},
+			},
+			args: args{
+				data: &malachitetypes.PowerData{
+					Sensors: malachitetypes.SensorData{
+						TotalPowerWatt: 123,
+						UpdateTime:     testUnixTime,
+					},
+				},
+			},
+			want: utilmetric.MetricData{
+				Value: float64(123),
+				Time:  &testTimestamp,
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "negative case of nil input",
+			fields: fields{
+				MalachiteMetricsProvisioner: &MalachiteMetricsProvisioner{
+					metricStore: utilmetric.NewMetricStore(),
+				},
+			},
+			args: args{
+				data: nil,
+			},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &MalachiteRealtimeMetricsProvisioner{
+				MalachiteMetricsProvisioner: tt.fields.MalachiteMetricsProvisioner,
+			}
+			m.processSystemPowerData(tt.args.data)
+			saved, err := tt.fields.MalachiteMetricsProvisioner.metricStore.GetNodeMetric("total.power.used.watts")
+			if !tt.wantErr(t, err) {
+				return
+			}
+			assert.Equal(t, tt.want, saved)
+		})
+	}
+}
+
+type mockPowerDataGetter struct {
+	mock.Mock
+}
+
+func (m *mockPowerDataGetter) GetPowerData() (*malachitetypes.PowerData, error) {
+	args := m.Called()
+	return args.Get(0).(*malachitetypes.PowerData), args.Error(1)
+}
+
+func TestMalachiteRealtimeMetricsProvisioner_Run(t *testing.T) {
+	t.Parallel()
+
+	mockPowerDataClient := new(mockPowerDataGetter)
+	mockPowerDataClient.On("GetPowerData").Return(
+		&malachitetypes.PowerData{Sensors: malachitetypes.SensorData{TotalPowerWatt: 345, UpdateTime: 77777}},
+		nil,
+	)
+
+	type fields struct {
+		malachiteClient             *mockPowerDataGetter
+		MalachiteMetricsProvisioner *MalachiteMetricsProvisioner
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				malachiteClient: mockPowerDataClient,
+				MalachiteMetricsProvisioner: &MalachiteMetricsProvisioner{
+					emitter:     &metrics.DummyMetrics{},
+					metricStore: utilmetric.NewMetricStore(),
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &MalachiteRealtimeMetricsProvisioner{
+				malachiteClient:             tt.fields.malachiteClient,
+				MalachiteMetricsProvisioner: tt.fields.MalachiteMetricsProvisioner,
+			}
+			m.Run(tt.args.ctx)
+			tt.fields.malachiteClient.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/power.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/power.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+type MalachitePowerResponse struct {
+	Status int       `json:"status"`
+	Data   PowerData `json:"data"`
+}
+
+type PowerData struct {
+	Sensors SensorData `json:"sensors"`
+}
+
+type SensorData struct {
+	TotalPowerWatt float64 `json:"total_power"`
+	UpdateTime     int64   `json:"update_time"`
+}


### PR DESCRIPTION
#### What type of PR is this?
Feature: power aware advisor uses realtime power data originally from malachite. It has 3 major parts:
* malachite client method to get power stats from metric service path realtime/power;
* malachite_realtime provisioner which samples (in higher frequency) using malachite client and saves power metric in metric store;
* a power reader adapted to get power data out of metric store; 

#### What this PR does / why we need it:
part of power node agent, it is needed for power aware plugin to get the current power usage and hence identify whether further measures required to limit the power consumption comparing with the desired power target.

#### Which issue(s) this PR fixes:
NA
