### PR TITLE
feat(sysadvisor): pap - evict first strategy for power control plan

### DIFF
--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+// the limit of dvfs effect a voluntary dvfs plan is allowed
+const voluntaryDVFSEffectMaximum = 10
+
+// dvfsTracker keeps track and accumulates the effect lowering power by means of dvfs
+type dvfsTracker struct {
+	dvfsAccumEffect int
+	inDVFS          bool
+	prevPower       int
+}
+
+func (d *dvfsTracker) getDVFSAllowPercent() int {
+	leftPercentage := voluntaryDVFSEffectMaximum - d.dvfsAccumEffect
+	if leftPercentage < 0 {
+		leftPercentage = 0
+	}
+	return leftPercentage
+}
+
+func (d *dvfsTracker) update(actualWatt, desiredWatt int) {
+	// only accumulate when dvfs is engaged
+	if d.prevPower >= 0 && d.inDVFS {
+		// if actual power is more than previous, likely previous round dvfs took no effect; not to take into account
+		if actualWatt < d.prevPower {
+			dvfsEffect := (d.prevPower - actualWatt) * 100 / d.prevPower
+			d.dvfsAccumEffect += dvfsEffect
+		}
+	}
+
+	d.prevPower = actualWatt
+}
+
+func (d *dvfsTracker) dvfsEnter() {
+	d.inDVFS = true
+}
+
+func (d *dvfsTracker) dvfsExit() {
+	d.inDVFS = false
+}
+
+func (d *dvfsTracker) clear() {
+	d.dvfsAccumEffect = 0
+	d.prevPower = 0
+	d.inDVFS = false
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package strategy
 
+// DVFS: Dynamic Voltage Frequency Scaling, is a technique servers use to manage the power consumption.
 // the limit of dvfs effect a voluntary dvfs plan is allowed
 const voluntaryDVFSEffectMaximum = 10
 

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_dvfsTracker_update(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		dvfsUsed  int
+		indvfs    bool
+		prevPower int
+	}
+	type args struct {
+		actualWatt  int
+		desiredWatt int
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		args            args
+		wantDVFSTracker dvfsTracker
+	}{
+		{
+			name: "not in dvfs, not to accumulate",
+			fields: fields{
+				dvfsUsed:  3,
+				indvfs:    false,
+				prevPower: 100,
+			},
+			args: args{
+				actualWatt:  90,
+				desiredWatt: 85,
+			},
+			wantDVFSTracker: dvfsTracker{
+				dvfsAccumEffect: 3,
+				inDVFS:          false,
+				prevPower:       90,
+			},
+		},
+		{
+			name: "in dvfs, accumulate if lower power is observed",
+			fields: fields{
+				dvfsUsed:  3,
+				indvfs:    true,
+				prevPower: 100,
+			},
+			args: args{
+				actualWatt:  90,
+				desiredWatt: 85,
+			},
+			wantDVFSTracker: dvfsTracker{
+				dvfsAccumEffect: 13,
+				inDVFS:          true,
+				prevPower:       90,
+			},
+		},
+		{
+			name: "in dvfs, not to accumulate if higher power is observed",
+			fields: fields{
+				dvfsUsed:  3,
+				indvfs:    true,
+				prevPower: 100,
+			},
+			args: args{
+				actualWatt:  101,
+				desiredWatt: 85,
+			},
+			wantDVFSTracker: dvfsTracker{
+				dvfsAccumEffect: 3,
+				inDVFS:          true,
+				prevPower:       101,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := &dvfsTracker{
+				dvfsAccumEffect: tt.fields.dvfsUsed,
+				inDVFS:          tt.fields.indvfs,
+				prevPower:       tt.fields.prevPower,
+			}
+			d.update(tt.args.actualWatt, tt.args.desiredWatt)
+			assert.Equal(t, &tt.wantDVFSTracker, d)
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+// threshold of cpu usage that allows voluntary dvfs
+const voluntaryDVFSCPUUsageThreshold = 0.45
+
+type EvictableProber interface {
+	HasEvictablePods() bool
+}
+
+// evictFirstStrategy always attempts to evict low priority pods if any; only after all are exhausted will it resort to DVFS means.
+// besides, it will continue to try the best to meet the alert spec, regardless of the alert update time.
+// alert level has the following meanings in this strategy:
+// P1 - eviction only;
+// P0 - evict if applicable; otherwise conduct DVFS once if needed (DVFS is limited to 10%);
+// S0 - DVFS in urgency (no limit on DVFS)
+type evictFirstStrategy struct {
+	coefficient     exponentialDecay
+	evictableProber EvictableProber
+	dvfsTracker     dvfsTracker
+	metricsReader   metrictypes.MetricsReader
+}
+
+func (e *evictFirstStrategy) OnDVFSReset() {
+	e.dvfsTracker.clear()
+}
+
+func (e *evictFirstStrategy) allowVoluntaryFreqCap() bool {
+	// todo: consider to leverage cpu frequency
+	if e.metricsReader != nil {
+		if cpuUsage, err := e.metricsReader.GetNodeMetric(consts.MetricCPUUsageRatio); err == nil {
+			general.InfofV(6, "pap: cpu usage %v", cpuUsage.Value)
+			if cpuUsage.Value <= voluntaryDVFSCPUUsageThreshold {
+				return false
+			}
+		}
+	}
+
+	return e.dvfsTracker.getDVFSAllowPercent() > 0
+}
+
+func (e *evictFirstStrategy) recommendEvictFirstOp() spec.InternalOp {
+	// always prefer eviction over dvfs if possible
+	if e.evictableProber.HasEvictablePods() {
+		return spec.InternalOpEvict
+	}
+
+	if e.allowVoluntaryFreqCap() {
+		general.InfofV(6, "pap: may have voluntary dvfs")
+		return spec.InternalOpFreqCap
+	}
+
+	general.InfofV(6, "pap: no suitable action at this moment")
+	return spec.InternalOpNoop
+}
+
+func (e *evictFirstStrategy) recommendOp(alert spec.PowerAlert, internalOp spec.InternalOp) spec.InternalOp {
+	if internalOp != spec.InternalOpAuto {
+		return internalOp
+	}
+
+	switch alert {
+	case spec.PowerAlertS0:
+		return spec.InternalOpFreqCap
+	case spec.PowerAlertP0:
+		return e.recommendEvictFirstOp()
+	case spec.PowerAlertP1:
+		return spec.InternalOpEvict
+	default:
+		return spec.InternalOpNoop
+	}
+}
+
+func (e *evictFirstStrategy) adjustTargetForConstraintDVFS(actualWatt, desiredWatt int) (int, error) {
+	leftPercentage := e.dvfsTracker.getDVFSAllowPercent()
+	if leftPercentage <= 0 {
+		return 0, errors.New("no room for dvfs")
+	}
+
+	lowerLimit := (100 - leftPercentage) * actualWatt / 100
+	if lowerLimit > desiredWatt {
+		return lowerLimit, nil
+	}
+	return desiredWatt, nil
+}
+
+func (e *evictFirstStrategy) yieldActionPlan(op, internalOp spec.InternalOp, actualWatt, desiredWatt int, alert spec.PowerAlert, ttl time.Duration) action.PowerAction {
+	switch op {
+	case spec.InternalOpFreqCap:
+		// try to conduct freq capping within the allowed limit if not set for hard dvfs
+		if internalOp != spec.InternalOpFreqCap && !(alert == spec.PowerAlertS0 && internalOp == spec.InternalOpAuto) {
+			var err error
+			desiredWatt, err = e.adjustTargetForConstraintDVFS(actualWatt, desiredWatt)
+			if err != nil {
+				return action.PowerAction{Op: spec.InternalOpNoop, Arg: 0}
+			}
+		}
+		return action.PowerAction{Op: spec.InternalOpFreqCap, Arg: desiredWatt}
+	case spec.InternalOpEvict:
+		return action.PowerAction{
+			Op:  spec.InternalOpEvict,
+			Arg: e.coefficient.calcExcessiveInPercent(desiredWatt, actualWatt, ttl),
+		}
+	default:
+		return action.PowerAction{Op: spec.InternalOpNoop, Arg: 0}
+	}
+}
+
+func (e *evictFirstStrategy) RecommendAction(actualWatt int, desiredWatt int, alert spec.PowerAlert, internalOp spec.InternalOp, ttl time.Duration) action.PowerAction {
+	e.dvfsTracker.update(actualWatt, desiredWatt)
+	general.InfofV(6, "pap: dvfs effect: %d", e.dvfsTracker.dvfsAccumEffect)
+
+	if actualWatt <= desiredWatt {
+		e.dvfsTracker.dvfsExit()
+		return action.PowerAction{Op: spec.InternalOpNoop, Arg: 0}
+	}
+
+	op := e.recommendOp(alert, internalOp)
+	actionPlan := e.yieldActionPlan(op, internalOp, actualWatt, desiredWatt, alert, ttl)
+	if actionPlan.Op == spec.InternalOpFreqCap {
+		e.dvfsTracker.dvfsEnter()
+	} else {
+		e.dvfsTracker.dvfsExit()
+	}
+	return actionPlan
+}
+
+func NewEvictFirstStrategy(prober EvictableProber, metricsReader metrictypes.MetricsReader) PowerActionStrategy {
+	general.Infof("pap: using EvictFirst strategy")
+	return &evictFirstStrategy{
+		coefficient:     exponentialDecay{b: defaultDecayB},
+		evictableProber: prober,
+		dvfsTracker:     dvfsTracker{dvfsAccumEffect: 0},
+		metricsReader:   metricsReader,
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
+)
+
+type mockEvicableProber struct {
+	mock.Mock
+}
+
+func (m *mockEvicableProber) HasEvictablePods() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
+	t.Parallel()
+
+	mockPorberTrue := new(mockEvicableProber)
+	mockPorberTrue.On("HasEvictablePods").Return(true)
+
+	mockPorberFalse := new(mockEvicableProber)
+	mockPorberFalse.On("HasEvictablePods").Return(false)
+
+	type fields struct {
+		coefficient     exponentialDecay
+		evictableProber EvictableProber
+		dvfsUsed        int
+		prevPower       int
+		inDVFS          bool
+	}
+	type args struct {
+		actualWatt  int
+		desiredWatt int
+		alert       spec.PowerAlert
+		internalOp  spec.InternalOp
+		ttl         time.Duration
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		want       action.PowerAction
+		wantInDVFS bool
+	}{
+		{
+			name: "internal op is always respected if exists",
+			fields: fields{
+				coefficient:     exponentialDecay{},
+				evictableProber: nil,
+				dvfsUsed:        0,
+			},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 80,
+				internalOp:  spec.InternalOpFreqCap,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpFreqCap,
+				Arg: 80,
+			},
+			wantInDVFS: true,
+		},
+		{
+			name:   "p2 is noop",
+			fields: fields{},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 80,
+				alert:       spec.PowerAlertP2,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpNoop,
+				Arg: 0,
+			},
+		},
+		{
+			name: "evict first if possible",
+			fields: fields{
+				coefficient:     exponentialDecay{b: defaultDecayB},
+				evictableProber: mockPorberTrue,
+				dvfsUsed:        0,
+			},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 80,
+				alert:       spec.PowerAlertP0,
+				ttl:         time.Minute * 15,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpEvict,
+				Arg: 14,
+			},
+		},
+		{
+			name: "if no evictable and there is room, go for dvfs",
+			fields: fields{
+				evictableProber: mockPorberFalse,
+				dvfsUsed:        0,
+			},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 95,
+				alert:       spec.PowerAlertP0,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpFreqCap,
+				Arg: 95,
+			},
+			wantInDVFS: true,
+		},
+		{
+			name: "if no evictable and there is partial room, go for constrint dvfs",
+			fields: fields{
+				evictableProber: mockPorberFalse,
+				dvfsUsed:        8,
+			},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 95,
+				alert:       spec.PowerAlertP0,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpFreqCap,
+				Arg: 98,
+			},
+			wantInDVFS: true,
+		},
+		{
+			name: "if no evictable and there is no room, noop",
+			fields: fields{
+				evictableProber: mockPorberFalse,
+				dvfsUsed:        10,
+				inDVFS:          true,
+			},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 95,
+				alert:       spec.PowerAlertP0,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpNoop,
+				Arg: 0,
+			},
+			wantInDVFS: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &evictFirstStrategy{
+				coefficient:     tt.fields.coefficient,
+				evictableProber: tt.fields.evictableProber,
+				dvfsTracker:     dvfsTracker{dvfsAccumEffect: tt.fields.dvfsUsed},
+			}
+			if got := e.RecommendAction(tt.args.actualWatt, tt.args.desiredWatt, tt.args.alert, tt.args.internalOp, tt.args.ttl); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RecommendAction() = %v, want %v", got, tt.want)
+			}
+			assert.Equal(t, tt.wantInDVFS, e.dvfsTracker.inDVFS)
+			if tt.fields.evictableProber != nil {
+				mock.AssertExpectationsForObjects(t, tt.fields.evictableProber)
+			}
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/strategy.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/strategy.go
@@ -28,6 +28,7 @@ import (
 const defaultDecayB = math.E / 2
 
 type PowerActionStrategy interface {
+	OnDVFSReset()
 	RecommendAction(currentWatt int,
 		desiredWatt int,
 		alert spec.PowerAlert,
@@ -39,6 +40,8 @@ type PowerActionStrategy interface {
 type ruleBasedPowerStrategy struct {
 	coefficient exponentialDecay
 }
+
+func (p ruleBasedPowerStrategy) OnDVFSReset() {}
 
 func (p ruleBasedPowerStrategy) RecommendAction(actualWatt int,
 	desiredWatt int,

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/strategy.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/strategy.go
@@ -98,11 +98,17 @@ type exponentialDecay struct {
 func (d exponentialDecay) calcExcessiveInPercent(target, curr int, ttl time.Duration) int {
 	// exponential decaying formula: a*b^(-t)
 	a := 100 - target*100/curr
-	decay := math.Pow(d.b, float64(-int(ttl.Minutes())/10))
-	return int(float64(a) * decay)
+	t := int(ttl.Minutes())
+	if t < 0 {
+		t = 0
+	}
+	decay := math.Pow(d.b, float64(-t/10))
+	result := int(float64(a) * decay)
+	if result == 0 {
+		result = 1
+	}
+	return result
 }
-
-var _ PowerActionStrategy = &ruleBasedPowerStrategy{}
 
 func NewRuleBasedPowerStrategy() PowerActionStrategy {
 	return ruleBasedPowerStrategy{coefficient: exponentialDecay{b: defaultDecayB}}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/reader"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
 	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/node"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
@@ -136,6 +137,7 @@ func (p *powerAwareAdvisor) run(ctx context.Context) {
 		if p.inFreqCap {
 			p.inFreqCap = false
 			p.powerCapper.Reset()
+			p.reconciler.OnDVFSReset()
 		}
 		return
 	}
@@ -179,6 +181,7 @@ func NewAdvisor(dryRun bool,
 	podFetcher pod.PodFetcher,
 	reader reader.PowerReader,
 	capper capper.PowerCapper,
+	metricsReader metrictypes.MetricsReader,
 ) PowerAwareAdvisor {
 	return &powerAwareAdvisor{
 		emitter:     emitter,
@@ -186,7 +189,7 @@ func NewAdvisor(dryRun bool,
 		powerReader: reader,
 		podEvictor:  podEvictor,
 		powerCapper: capper,
-		reconciler:  newReconciler(dryRun, emitter, evictor.NewPowerLoadEvict(qosConfig, podFetcher, podEvictor), capper),
+		reconciler:  newReconciler(dryRun, metricsReader, emitter, evictor.NewPowerLoadEvict(qosConfig, podFetcher, podEvictor), capper),
 		inFreqCap:   false,
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/reconciler_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/reconciler_test.go
@@ -55,6 +55,10 @@ func (d *dummyPercentageEvictor) Evict(ctx context.Context, targetPercent int) {
 	d.called = true
 }
 
+func (d *dummyPercentageEvictor) HasEvictablePods() bool {
+	panic("not implemented")
+}
+
 func Test_powerReconciler_Engages_Capper_Evictor(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/sysadvisor/plugin/poweraware/capper/server/service.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/capper/server/service.go
@@ -76,6 +76,10 @@ func (p *powerCapService) Start() error {
 
 	p.started = true
 	p.grpcServer.Run()
+
+	// reset power capping to prevent accumulative effect
+	p.requestReset()
+
 	return nil
 }
 
@@ -153,6 +157,10 @@ func (p *powerCapService) Reset() {
 		return
 	}
 
+	p.requestReset()
+}
+
+func (p *powerCapService) requestReset() {
 	p.capInstruction = capper.PowerCapReset
 	p.notify.Notify()
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/evictor/percentage_evictor_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/evictor/percentage_evictor_test.go
@@ -203,3 +203,42 @@ func Test_getN(t *testing.T) {
 		})
 	}
 }
+
+func Test_getNumToEvict(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		pods          int
+		targetPercent int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "ceiling of target percent times pods",
+			args: args{
+				pods:          1,
+				targetPercent: 2,
+			},
+			want: 1,
+		},
+		{
+			name: "happy path of total intger",
+			args: args{
+				pods:          8,
+				targetPercent: 25,
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := getNumToEvict(tt.args.pods, tt.args.targetPercent); got != tt.want {
+				t.Errorf("getNumToEvict() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
@@ -105,6 +105,7 @@ func NewPowerAwarePlugin(
 		metaServer.PodFetcher,
 		powerReader,
 		powerCapper,
+		metaServer,
 	)
 
 	return newPluginWithAdvisor(pluginName, conf, powerAdvisor)

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware_test.go
@@ -63,7 +63,9 @@ func Test_powerAwarePlugin_Name(t *testing.T) {
 		nil,
 		stubMetaServer.PodFetcher,
 		nil,
-		nil)
+		nil,
+		nil,
+	)
 
 	p, err := newPluginWithAdvisor(expectedName,
 		&config.Configuration{
@@ -126,7 +128,8 @@ func Test_powerAwarePlugin_Init(t *testing.T) {
 				name:   tt.fields.name,
 				dryRun: tt.fields.dryRun,
 				advisor: advisor.NewAdvisor(false, "bar", evictor.NewNoopPodEvictor(), dummyEmitter,
-					tt.fields.nodeFetcher, nil, nil, reader.NewDummyPowerReader(), capper.NewNoopCapper(),
+					tt.fields.nodeFetcher, nil, nil, reader.NewDummyPowerReader(),
+					capper.NewNoopCapper(), nil,
 				),
 			}
 			if err := p.Init(); (err != nil) != tt.wantErr {


### PR DESCRIPTION
#### What type of PR is this?
Features + Enhancements

#### What this PR does / why we need it:
this PR mainly introduces the evict-first strategy which, for power alert P0, would evict low qos pods first if any, and only after they are exhausted will it tries to resort to DVFS(power capping) within the constraint limit. Besides, it keeps yielding suitable action plan as long as the power spec exists.

Its another enhancement is using ceiling math to calculate the number of pods to evict; this is necessary as we need to ensure the low qos pod could be exhausted, otherwise the constraint DVFS plan cannot be yield. 

This ecivt-first strategy is designed to work better with the multi-round governing DC/cluster power alert controller. 
