### PR TITLE
fix(sysadvisor): fix provision logic of dedicated_cores region

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_test.go
@@ -828,8 +828,8 @@ func TestAdvisorUpdate(t *testing.T) {
 			wantInternalCalculationResult: types.InternalCPUCalculationResult{
 				PoolEntries: map[string]map[int]int{
 					commonstate.PoolNameReserve: {-1: 2},
-					commonstate.PoolNameShare:   {-1: 84},
-					commonstate.PoolNameReclaim: {-1: 8},
+					commonstate.PoolNameShare:   {-1: 82},
+					commonstate.PoolNameReclaim: {-1: 10},
 					"isolation-pod1":            {-1: 2},
 				},
 			},
@@ -959,8 +959,8 @@ func TestAdvisorUpdate(t *testing.T) {
 			wantInternalCalculationResult: types.InternalCPUCalculationResult{
 				PoolEntries: map[string]map[int]int{
 					commonstate.PoolNameReserve: {-1: 2},
-					commonstate.PoolNameShare:   {-1: 90},
-					commonstate.PoolNameReclaim: {-1: 4},
+					commonstate.PoolNameShare:   {-1: 88},
+					commonstate.PoolNameReclaim: {-1: 6},
 				},
 			},
 			wantHeadroom: resource.Quantity{},
@@ -1074,8 +1074,8 @@ func TestAdvisorUpdate(t *testing.T) {
 			wantInternalCalculationResult: types.InternalCPUCalculationResult{
 				PoolEntries: map[string]map[int]int{
 					commonstate.PoolNameReserve: {-1: 2},
-					commonstate.PoolNameShare:   {-1: 90},
-					commonstate.PoolNameReclaim: {-1: 4},
+					commonstate.PoolNameShare:   {-1: 88},
+					commonstate.PoolNameReclaim: {-1: 6},
 				},
 			},
 			wantHeadroom: resource.Quantity{},

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/provisionassembler/assembler_common_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/provisionassembler/assembler_common_test.go
@@ -74,6 +74,10 @@ func (fake *FakeRegion) Type() configapi.QoSRegionType {
 	return fake.regionType
 }
 
+func (fake *FakeRegion) GetMetaInfo() string {
+	return "fake"
+}
+
 func (fake *FakeRegion) OwnerPoolName() string {
 	return fake.ownerPoolName
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy.go
@@ -41,6 +41,8 @@ type ProvisionPolicy interface {
 	Update() error
 	// GetControlKnobAdjusted returns the latest legal control knob value
 	GetControlKnobAdjusted() (types.ControlKnob, error)
+
+	GetMetaInfo() string
 }
 
 type InitFunc func(regionName string, regionType configapi.QoSRegionType, ownerPoolName string,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_base.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_base.go
@@ -76,7 +76,7 @@ func (p *PolicyBase) GetControlKnobAdjusted() (types.ControlKnob, error) {
 		return p.controlKnobAdjusted.Clone(), nil
 
 	case configapi.QoSRegionTypeIsolation:
-		return map[configapi.ControlKnobName]types.ControlKnobValue{
+		return map[configapi.ControlKnobName]types.ControlKnobItem{
 			configapi.ControlKnobNonReclaimedCPURequirementUpper: {
 				Value:  p.ResourceUpperBound,
 				Action: types.ControlKnobActionNone,
@@ -90,4 +90,8 @@ func (p *PolicyBase) GetControlKnobAdjusted() (types.ControlKnob, error) {
 	default:
 		return nil, fmt.Errorf("unsupported region type %v", p.regionType)
 	}
+}
+
+func (p *PolicyBase) GetMetaInfo() string {
+	return fmt.Sprintf("[regionName: %s, regionType: %s, ownerPoolName: %s, NUMAs: %v]", p.regionName, p.regionType, p.ownerPoolName, p.bindingNumas.String())
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_canonical.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_canonical.go
@@ -60,7 +60,7 @@ func (p *PolicyCanonical) Update() error {
 	}
 
 	p.controlKnobAdjusted = types.ControlKnob{
-		configapi.ControlKnobNonReclaimedCPURequirement: types.ControlKnobValue{
+		configapi.ControlKnobNonReclaimedCPURequirement: types.ControlKnobItem{
 			Value:  cpuEstimation,
 			Action: types.ControlKnobActionNone,
 		},

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_none.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_none.go
@@ -42,3 +42,4 @@ func (p *PolicyNone) Update() error                                             
 func (p *PolicyNone) GetControlKnobAdjusted() (types.ControlKnob, error) {
 	return types.InvalidControlKnob, nil
 }
+func (p *PolicyNone) GetMetaInfo() string { return "" }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/provisionpolicy/policy_rama.go
@@ -77,14 +77,14 @@ func (p *PolicyRama) Update() error {
 
 		controller, ok := p.controllers[metricName]
 		if !ok {
-			controller = helper.NewPIDController(metricName, params)
+			controller = helper.NewPIDController(metricName, params, p.GetMetaInfo())
 			p.controllers[metricName] = controller
 		}
 
 		controller.SetEssentials(p.ResourceEssentials)
 		cpuAdjusted := controller.Adjust(cpuSize, indicator.Target, indicator.Current)
 
-		general.InfoS("[qosaware-cpu-rama] pid adjust result", "regionName", p.regionName, "metricName", metricName, "cpuAdjusted", cpuAdjusted, "last cpu size", cpuSize)
+		general.InfoS("[qosaware-cpu-rama] pid adjust result", "meta", p.GetMetaInfo(), "metricName", metricName, "cpuAdjusted", cpuAdjusted, "last cpu size", cpuSize)
 
 		if cpuAdjusted > cpuAdjustedRaw {
 			cpuAdjustedRaw = cpuAdjusted
@@ -104,12 +104,10 @@ func (p *PolicyRama) Update() error {
 		}
 	}
 
-	general.Infof("[qosaware-cpu-rama] ReclaimOverlap=%v, region=%v", p.ControlEssentials.ReclaimOverlap, p.regionName)
-
 	cpuAdjustedRestricted := cpuAdjustedRaw
 
 	p.controlKnobAdjusted = types.ControlKnob{
-		configapi.ControlKnobNonReclaimedCPURequirement: types.ControlKnobValue{
+		configapi.ControlKnobNonReclaimedCPURequirement: types.ControlKnobItem{
 			Value:  cpuAdjustedRestricted,
 			Action: types.ControlKnobActionNone,
 		},

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region.go
@@ -85,6 +85,8 @@ type QoSRegion interface {
 	GetStatus() types.RegionStatus
 	// GetControlEssentials returns the latest control essentials
 	GetControlEssentials() types.ControlEssentials
+
+	GetMetaInfo() string
 }
 
 // GetRegionBasicMetricTags returns metric tag slice of region info and status

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_dedicated_numa_exclusive.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_dedicated_numa_exclusive.go
@@ -110,12 +110,12 @@ func (r *QoSRegionDedicatedNumaExclusive) TryUpdateProvision() {
 	rawControlKnobs := r.getProvisionControlKnob()
 
 	// regulate control knobs
-	r.regulateProvisionControlKnob(rawControlKnobs, &r.ControlKnobs)
+	r.regulateProvisionControlKnob(rawControlKnobs, r.getEffectiveControlKnobs())
 }
 
 func (r *QoSRegionDedicatedNumaExclusive) updateProvisionPolicy() {
 	r.ControlEssentials = types.ControlEssentials{
-		ControlKnobs:   r.getControlKnobs(),
+		ControlKnobs:   r.getEffectiveControlKnobs(),
 		ReclaimOverlap: true,
 	}
 
@@ -174,7 +174,7 @@ out:
 	r.idle.Store(idle)
 }
 
-func (r *QoSRegionDedicatedNumaExclusive) getControlKnobs() types.ControlKnob {
+func (r *QoSRegionDedicatedNumaExclusive) getEffectiveControlKnobs() types.ControlKnob {
 	reclaimedCPUSize := 0
 	if reclaimedInfo, ok := r.metaReader.GetPoolInfo(commonstate.PoolNameReclaim); ok {
 		for _, numaID := range r.bindingNumas.ToSliceInt() {

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_share.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_share.go
@@ -94,12 +94,12 @@ func (r *QoSRegionShare) TryUpdateProvision() {
 	restrictedControlKnobs := r.restrictProvisionControlKnob(rawControlKnobs)
 
 	// regulate control knobs
-	r.regulateProvisionControlKnob(restrictedControlKnobs, &r.ControlKnobs)
+	r.regulateProvisionControlKnob(restrictedControlKnobs, r.getEffectiveControlKnobs())
 }
 
 func (r *QoSRegionShare) updateProvisionPolicy() {
 	r.ControlEssentials = types.ControlEssentials{
-		ControlKnobs:   r.getControlKnobs(),
+		ControlKnobs:   r.getEffectiveControlKnobs(),
 		ReclaimOverlap: r.AllowSharedCoresOverlapReclaimedCores,
 	}
 
@@ -197,7 +197,7 @@ func (r *QoSRegionShare) restrictProvisionControlKnob(originControlKnob map[type
 	return restrictedControlKnob
 }
 
-func (r *QoSRegionShare) getControlKnobs() types.ControlKnob {
+func (r *QoSRegionShare) getEffectiveControlKnobs() types.ControlKnob {
 	regionInfo, ok := r.metaReader.GetRegionInfo(r.name)
 	if ok {
 		if _, existed := regionInfo.ControlKnobMap[configapi.ControlKnobNonReclaimedCPURequirement]; existed {

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/region_test.go
@@ -220,8 +220,8 @@ func TestRestrictProvisionControlKnob(t *testing.T) {
 					MaxLowerGap: pointer.Float64(1),
 				},
 			},
-			originControlKnob: map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobValue{Value: 8}}, "p2": {"c1": types.ControlKnobValue{Value: 10}}},
-			wantControlKnob:   map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobValue{Value: 9}}, "p2": {"c1": types.ControlKnobValue{Value: 10}}},
+			originControlKnob: map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobItem{Value: 8}}, "p2": {"c1": types.ControlKnobItem{Value: 10}}},
+			wantControlKnob:   map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobItem{Value: 9}}, "p2": {"c1": types.ControlKnobItem{Value: 10}}},
 		},
 		{
 			name: "upper ref",
@@ -231,8 +231,8 @@ func TestRestrictProvisionControlKnob(t *testing.T) {
 					MaxLowerGap: pointer.Float64(1),
 				},
 			},
-			originControlKnob: map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobValue{Value: 16}}, "p2": {"c1": types.ControlKnobValue{Value: 10}}},
-			wantControlKnob:   map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobValue{Value: 14}}, "p2": {"c1": types.ControlKnobValue{Value: 10}}},
+			originControlKnob: map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobItem{Value: 16}}, "p2": {"c1": types.ControlKnobItem{Value: 10}}},
+			wantControlKnob:   map[types.CPUProvisionPolicyName]types.ControlKnob{"p1": {"c1": types.ControlKnobItem{Value: 14}}, "p2": {"c1": types.ControlKnobItem{Value: 10}}},
 		},
 	}
 

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/regulator/regulator.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region/regulator/regulator.go
@@ -32,12 +32,9 @@ type Regulator interface {
 	// SetEssentials updates some essential parameters to restrict requirement
 	SetEssentials(essentials types.ResourceEssentials)
 
-	// SetLatestControlKnobValue overwrites the latest regulated requirement
-	SetLatestControlKnobValue(controlKnobValue types.ControlKnobValue)
-
 	// Regulate runs an episode of regulation to restrict raw requirement and store the result
 	// as the latest requirement value
-	Regulate(controlKnobValue types.ControlKnobValue)
+	Regulate(controlKnob types.ControlKnobItem, effectiveControlKnob *types.ControlKnobItem)
 
 	// GetRequirement returns the latest regulated requirement
 	GetRequirement() int
@@ -45,7 +42,7 @@ type Regulator interface {
 
 // DummyRegulator always get requirement without regulate
 type DummyRegulator struct {
-	latestControlKnobValue types.ControlKnobValue
+	latestControlKnobValue types.ControlKnobItem
 }
 
 func NewDummyRegulator() Regulator {
@@ -57,12 +54,8 @@ var _ Regulator = &DummyRegulator{}
 func (d *DummyRegulator) SetEssentials(_ types.ResourceEssentials) {
 }
 
-func (d *DummyRegulator) SetLatestControlKnobValue(controlKnobValue types.ControlKnobValue) {
-	d.latestControlKnobValue = controlKnobValue
-}
-
-func (d *DummyRegulator) Regulate(controlKnobValue types.ControlKnobValue) {
-	d.SetLatestControlKnobValue(controlKnobValue)
+func (d *DummyRegulator) Regulate(controlKnob types.ControlKnobItem, effectiveControlKnob *types.ControlKnobItem) {
+	d.latestControlKnobValue = controlKnob
 }
 
 func (d *DummyRegulator) GetRequirement() int {
@@ -76,8 +69,8 @@ type CPURegulator struct {
 
 	RegulatorOptions
 
-	// latestControlKnobValue is the latest updated cpu requirement value
-	latestControlKnobValue types.ControlKnobValue
+	// latestControlKnobItem is the latest updated cpu requirement value
+	latestControlKnobItem types.ControlKnobItem
 
 	// latestRampDownTime is the latest ramp down timestamp
 	latestRampDownTime time.Time
@@ -89,6 +82,10 @@ type RegulatorOptions struct {
 
 	// MaxRampDownStep is the max cpu cores can be decreased during each cpu requirement update
 	MaxRampDownStep int
+
+	// Never share cores between latency-critical pods and best-effort pods when cpuset not overlapped
+	// so make latency-critical pods require at least a core's-worth of CPUs.
+	NeedHTAligned func() bool
 
 	// MinRampDownPeriod is the min time gap between two consecutive cpu requirement ramp down
 	MinRampDownPeriod time.Duration
@@ -109,55 +106,62 @@ func (c *CPURegulator) SetEssentials(essentials types.ResourceEssentials) {
 	c.ResourceEssentials = essentials
 }
 
-// SetLatestControlKnobValue overwrites the latest regulated cpu requirement
-func (c *CPURegulator) SetLatestControlKnobValue(controlKnobValue types.ControlKnobValue) {
-	c.latestControlKnobValue = controlKnobValue
-}
-
 // Regulate runs an episode of cpu regulation to restrict raw cpu requirement and store the result
 // as the latest cpu requirement value
-func (c *CPURegulator) Regulate(controlKnobValue types.ControlKnobValue) {
-	cpuRequirement := controlKnobValue.Value
+func (c *CPURegulator) Regulate(controlKnob types.ControlKnobItem, effectiveControlKnob *types.ControlKnobItem) {
+	cpuRequirement := controlKnob.Value
 	cpuRequirementReserved := cpuRequirement + c.ReservedForAllocate
 	cpuRequirementRound := c.round(cpuRequirementReserved)
-	cpuRequirementSlowdown := c.slowdown(cpuRequirementRound)
+	cpuRequirementSlowdown := c.slowdown(cpuRequirementRound, effectiveControlKnob)
 	cpuRequirementClamp := c.clamp(cpuRequirementSlowdown)
 
 	klog.Infof("[qosaware-cpu] cpu requirement by policy: %.2f, with reserve: %.2f, after round: %d, after slowdown: %d, after clamp: %d",
 		cpuRequirement, cpuRequirementReserved, cpuRequirementRound, cpuRequirementSlowdown, cpuRequirementClamp)
 
-	if cpuRequirementClamp != int(c.latestControlKnobValue.Value) {
-		c.latestControlKnobValue.Value = float64(cpuRequirementClamp)
-		c.latestRampDownTime = time.Now()
+	c.updateControlKnob(float64(cpuRequirementClamp))
+}
+
+func (c *CPURegulator) updateControlKnob(value float64) {
+	if int(value) != int(c.latestControlKnobItem.Value) {
+		if value < c.latestControlKnobItem.Value {
+			c.latestRampDownTime = time.Now()
+		}
+		c.latestControlKnobItem.Value = value
 	}
 }
 
 // GetRequirement returns the latest regulated cpu requirement
 func (c *CPURegulator) GetRequirement() int {
-	return int(c.latestControlKnobValue.Value)
+	return int(c.latestControlKnobItem.Value)
 }
 
-func (c *CPURegulator) slowdown(cpuRequirement int) int {
+func (c *CPURegulator) slowdown(cpuRequirement int, effectiveControlKnobItem *types.ControlKnobItem) int {
+	if effectiveControlKnobItem == nil {
+		return cpuRequirement
+	}
 	now := time.Now()
 
-	general.InfoS("slowdown info", "cpuRequirement", cpuRequirement, "latestCPURequirement", c.latestControlKnobValue.Value, "latestRampDownTime", c.latestRampDownTime, "minRampDownPeriod", c.MinRampDownPeriod)
+	general.InfoS("slowdown info", "cpuRequirement", cpuRequirement, "latestCPURequirement", c.latestControlKnobItem.Value, "latestRampDownTime", c.latestRampDownTime, "minRampDownPeriod", c.MinRampDownPeriod)
 
 	// Restrict ramp down frequency
-	if cpuRequirement < int(c.latestControlKnobValue.Value) && now.Before(c.latestRampDownTime.Add(c.MinRampDownPeriod)) {
-		return int(c.latestControlKnobValue.Value)
+	if cpuRequirement < int(effectiveControlKnobItem.Value) && now.Before(c.latestRampDownTime.Add(c.MinRampDownPeriod)) {
+		return int(effectiveControlKnobItem.Value)
 	}
 
 	// Restrict ramp up and down step
-	if cpuRequirement-int(c.latestControlKnobValue.Value) > c.MaxRampUpStep {
-		cpuRequirement = int(c.latestControlKnobValue.Value) + c.MaxRampUpStep
-	} else if int(c.latestControlKnobValue.Value)-cpuRequirement > c.MaxRampDownStep {
-		cpuRequirement = int(c.latestControlKnobValue.Value) - c.MaxRampDownStep
+	if cpuRequirement-int(effectiveControlKnobItem.Value) > c.MaxRampUpStep {
+		cpuRequirement = int(effectiveControlKnobItem.Value) + c.MaxRampUpStep
+	} else if int(effectiveControlKnobItem.Value)-cpuRequirement > c.MaxRampDownStep {
+		cpuRequirement = int(effectiveControlKnobItem.Value) - c.MaxRampDownStep
 	}
 
 	return cpuRequirement
 }
 
 func (c *CPURegulator) round(cpuRequirement float64) int {
+	if !c.NeedHTAligned() {
+		return int(math.Ceil(cpuRequirement))
+	}
 	// Never share cores between latency-critical pods and best-effort pods
 	// so make latency-critical pods require at least a core's-worth of CPUs.
 	// This rule can be broken by clamp.

--- a/pkg/agent/sysadvisor/types/cpu.go
+++ b/pkg/agent/sysadvisor/types/cpu.go
@@ -67,15 +67,15 @@ const (
 )
 
 // ControlKnob holds tunable system entries affecting indicator metrics
-type ControlKnob map[v1alpha1.ControlKnobName]ControlKnobValue
+type ControlKnob map[v1alpha1.ControlKnobName]ControlKnobItem
 
-// ControlKnobValue holds control knob value and action
-type ControlKnobValue struct {
+// ControlKnobItem holds control knob value and action
+type ControlKnobItem struct {
 	Value  float64
 	Action ControlKnobAction
 }
 
-var InvalidControlKnob = map[v1alpha1.ControlKnobName]ControlKnobValue{"": {}}
+var InvalidControlKnob = map[v1alpha1.ControlKnobName]ControlKnobItem{"": {}}
 
 const (
 	InvalidHeadroom = -1


### PR DESCRIPTION
1. no need to round requirement if cpuset overlapped
2. get effective control knobs by regionInfo for dedicated_cores

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
