### PR TITLE
chore(*):  log clean up - log level downgraded to 6 for detailed and lengthy lines

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -137,8 +137,10 @@ func (s *cpuPluginState) SetPodEntries(podEntries PodEntries) {
 	defer s.Unlock()
 
 	s.podEntries = podEntries.Clone()
-	klog.InfoS("[cpu_plugin] Updated cpu plugin pod entries",
-		"podEntries", podEntries.String())
+	if klog.V(6).Enabled() {
+		klog.InfoS("[cpu_plugin] Updated cpu plugin pod entries",
+			"podEntries", podEntries.String())
+	}
 }
 
 func (s *cpuPluginState) SetAllowSharedCoresOverlapReclaimedCores(allowSharedCoresOverlapReclaimedCores bool) {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -104,7 +104,9 @@ func (s *cpuPluginState) SetMachineState(numaNodeMap NUMANodeMap) {
 	defer s.Unlock()
 
 	s.machineState = numaNodeMap.Clone()
-	klog.InfoS("[cpu_plugin] Updated cpu plugin machine state", "numaNodeMap", numaNodeMap.String())
+	if klog.V(6).Enabled() {
+		klog.InfoS("[cpu_plugin] Updated cpu plugin machine state", "numaNodeMap", numaNodeMap.String())
+	}
 }
 
 func (s *cpuPluginState) SetNUMAHeadroom(numaHeadroom map[int]float64) {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_mem.go
@@ -166,8 +166,10 @@ func (s *memoryPluginState) SetPodResourceEntries(podResourceEntries PodResource
 	defer s.Unlock()
 
 	s.podResourceEntries = podResourceEntries.Clone()
-	klog.InfoS("[memory_plugin] Updated memory plugin pod resource entries",
-		"podResourceEntries", podResourceEntries.String())
+	if klog.V(6).Enabled() {
+		klog.InfoS("[memory_plugin] Updated memory plugin pod resource entries",
+			"podResourceEntries", podResourceEntries.String())
+	}
 }
 
 func (s *memoryPluginState) Delete(resourceName v1.ResourceName, podUID, containerName string) {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_mem.go
@@ -127,8 +127,10 @@ func (s *memoryPluginState) SetMachineState(numaNodeResourcesMap NUMANodeResourc
 	defer s.Unlock()
 
 	s.machineState = numaNodeResourcesMap.Clone()
-	klog.InfoS("[memory_plugin] Updated memory plugin machine state",
-		"numaNodeResourcesMap", numaNodeResourcesMap.String())
+	if klog.V(6).Enabled() {
+		klog.InfoS("[memory_plugin] Updated memory plugin machine state",
+			"numaNodeResourcesMap", numaNodeResourcesMap.String())
+	}
 }
 
 func (s *memoryPluginState) SetNUMAHeadroom(numaHeadroom map[int]int64) {

--- a/pkg/agent/resourcemanager/reporter/cnr/cnrreporter.go
+++ b/pkg/agent/resourcemanager/reporter/cnr/cnrreporter.go
@@ -353,7 +353,10 @@ func (c *cnrReporterImpl) tryUpdateCNRStatus(ctx context.Context,
 				"status": "success",
 			})...)
 
-		klog.Infof("patch cnr status success old status: %#v,\n new status: %#v", originCNR.Status, cnr.Status)
+		if klog.V(6).Enabled() {
+			klog.Infof("patch cnr status success old status: %#v,\n new status: %#v", originCNR.Status, cnr.Status)
+		}
+
 		c.latestUpdatedCNR = cnr.DeepCopy()
 
 		// notify cnr status update

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor.go
@@ -267,7 +267,9 @@ func (cra *cpuResourceAdvisor) updateWithIsolationGuardian(tryIsolation bool) (
 
 	cra.advisorUpdated = true
 
-	klog.Infof("[qosaware-cpu] region map: %v", general.ToString(cra.regionMap))
+	if klog.V(6).Enabled() {
+		klog.Infof("[qosaware-cpu] region map: %v", general.ToString(cra.regionMap))
+	}
 
 	// assemble provision result from each region
 	calculationResult, err := cra.assembleProvision()

--- a/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server.go
@@ -180,7 +180,11 @@ func (cs *cpuServer) getAndSyncCheckpoint(ctx context.Context, client cpuadvisor
 		_ = cs.emitter.StoreInt64(cs.genMetricsName(metricServerLWGetCheckpointFailed), int64(cs.period.Seconds()), metrics.MetricTypeNameCount)
 		return fmt.Errorf("got nil checkpoint")
 	}
-	klog.Infof("[qosaware-server-cpu] got checkpoint: %v", general.ToString(getCheckpointResp.Entries))
+
+	if klog.V(6).Enabled() {
+		klog.Infof("[qosaware-server-cpu] got checkpoint: %v", general.ToString(getCheckpointResp.Entries))
+	}
+
 	_ = cs.emitter.StoreInt64(cs.genMetricsName(metricServerLWGetCheckpointSucceeded), int64(cs.period.Seconds()), metrics.MetricTypeNameCount)
 
 	cs.syncCheckpoint(ctx, getCheckpointResp, safeTime)
@@ -230,7 +234,11 @@ func (cs *cpuServer) getAndPushAdvice(client cpuadvisor.CPUPluginClient, server 
 		_ = cs.emitter.StoreInt64(cs.genMetricsName(metricServerLWSendResponseFailed), int64(cs.period.Seconds()), metrics.MetricTypeNameCount)
 		return fmt.Errorf("send listWatch response failed: %w", err)
 	}
-	klog.Infof("[qosaware-server-cpu] sent listWatch resp: %v", general.ToString(lwResp))
+
+	if klog.V(6).Enabled() {
+		klog.Infof("[qosaware-server-cpu] sent listWatch resp: %v", general.ToString(lwResp))
+	}
+
 	_ = cs.emitter.StoreInt64(cs.genMetricsName(metricServerLWSendResponseSucceeded), int64(cs.period.Seconds()), metrics.MetricTypeNameCount)
 	return nil
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/server/memory_server.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/server/memory_server.go
@@ -258,7 +258,11 @@ func (ms *memoryServer) getAndPushAdvice(server advisorsvc.AdvisorService_ListAn
 		_ = ms.emitter.StoreInt64(ms.genMetricsName(metricServerLWSendResponseFailed), int64(ms.period.Seconds()), metrics.MetricTypeNameCount)
 		return fmt.Errorf("send listWatch response failed: %w", err)
 	}
-	klog.Infof("[qosaware-server-memory] sent listWatch resp: %v", general.ToString(lwResp))
+
+	if klog.V(6).Enabled() {
+		klog.Infof("[qosaware-server-memory] sent listWatch resp: %v", general.ToString(lwResp))
+	}
+
 	_ = ms.emitter.StoreInt64(ms.genMetricsName(metricServerLWSendResponseSucceeded), int64(ms.period.Seconds()), metrics.MetricTypeNameCount)
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
enhancement - log cleanup

#### What this PR does / why we need it:
downgrade log level to 6 for those extreme long log details. 6 is chosen as the current convention in code indicates 6 is the lest one printing out json encode response in get devices function 

