### PR TITLE
fix(sysadvisor): pap - level p1 action plan not to evict

### DIFF
--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
@@ -69,22 +69,54 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 		wantInDVFS bool
 	}{
 		{
-			name: "internal op is always respected if exists",
+			name: "plan of s0 always targets full range",
 			fields: fields{
 				coefficient:     exponentialDecay{},
 				evictableProber: nil,
 				dvfsUsed:        0,
 			},
 			args: args{
+				alert:       spec.PowerAlertS0,
 				actualWatt:  100,
 				desiredWatt: 80,
-				internalOp:  spec.InternalOpFreqCap,
 			},
 			want: action.PowerAction{
 				Op:  spec.InternalOpFreqCap,
 				Arg: 80,
 			},
 			wantInDVFS: true,
+		},
+		{
+			name: "plan of p0 is constraint when allowing dvfs only",
+			fields: fields{
+				coefficient:     exponentialDecay{},
+				evictableProber: nil,
+				dvfsUsed:        0,
+			},
+			args: args{
+				alert:       spec.PowerAlertP0,
+				actualWatt:  100,
+				desiredWatt: 80,
+				internalOp:  spec.InternalOpFreqCap,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpFreqCap,
+				Arg: 90,
+			},
+			wantInDVFS: true,
+		},
+		{
+			name:   "p1 is noop",
+			fields: fields{},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 80,
+				alert:       spec.PowerAlertP1,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpNoop,
+				Arg: 0,
+			},
 		},
 		{
 			name:   "p2 is noop",

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader.go
@@ -55,7 +55,12 @@ func (m *metricStorePowerReader) Get(ctx context.Context) (int, error) {
 func (m *metricStorePowerReader) get(ctx context.Context, now time.Time) (int, error) {
 	data, err := m.GetNodeMetric(consts.MetricTotalPowerUsedWatts)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get metric from metric store")
+		return 0, errors.Wrap(err, "failed to get power usage from metric store")
+	}
+
+	// 0 actually is error, typically caused by null response from malachite realtime power service
+	if data.Value == 0 {
+		return 0, errors.New("got invalid 0 power usage from metric store")
 	}
 
 	if !isDataFresh(data, now) {

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
 )
 
@@ -100,4 +102,20 @@ func Test_metricStorePowerReader_get(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_metricStorePowerReader_get_0_is_error(t *testing.T) {
+	t.Parallel()
+
+	setTime := time.Date(2024, 11, 11, 8, 30, 10, 0, time.UTC)
+	dummyMetricStore := utilmetric.NewMetricStore()
+	dummyMetricStore.SetNodeMetric("total.power.used.watts", utilmetric.MetricData{
+		Value: 0,
+		Time:  &setTime,
+	})
+
+	m := NewMetricStorePowerReader(dummyMetricStore).(*metricStorePowerReader)
+	now := time.Date(2024, 11, 11, 8, 30, 11, 0, time.UTC)
+	_, err := m.get(context.TODO(), now)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes/Enhancements

#### What this PR does / why we need it:
this PR has 2 parts:
* minor bug fix that treating power usage of 0 as error - it is actually caused by malachite realtime power service feeding null response - so that the reader error metric would catch such case;
* slight change of implications of alert level p1 and internal-op supplementation - in short, p1 not to evict anymore, and power-cap internal-op only applicable at level s0&p0 (dvfs-related levels) - this semantic change is part of iteration of power aware development in 2025 Q1

| level | Default allowed action |  
| --- | --- | --- |
| S0 | Power cap | unconstrained dvfs cap |
| P0 | Evict first;Up to 10% DVFS power reduction if low-qos pod exhausted | w/ internal-op it may result in variant:1 - evict only;2- constrained DVFS reduction only |
| P1 | No action | Let low-qos drain (via scheduler no-sched effect) |
| P2 | No action | Allow low-qos to run (if scheduler decideds so) |
| CLEARED | Clear DVFS setting | To reset DVFS-based power capping and have compute restored |

