### PR TITLE
fix(sysadvisor): supplement the missing metrics in CGroupV2

### DIFF
--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -970,6 +970,19 @@ func (m *MalachiteMetricsProvisioner) processContainerCPUData(podUID, containerN
 			utilmetric.MetricData{Value: cpu.CPUSysUsageRatio, Time: &updateTime})
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUUsageRatioContainer,
 			utilmetric.MetricData{Value: cpu.CPUUsageRatio / (float64(cpu.Max) / float64(cpu.MaxPeriod)), Time: &updateTime})
+		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUShareContainer,
+			utilmetric.MetricData{Value: float64(cpu.Weight), Time: &updateTime})
+
+		var cpuQuota float64
+		if cpu.Max == math.MaxUint64 {
+			cpuQuota = -1
+		} else {
+			cpuQuota = float64(cpu.Max)
+		}
+		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUQuotaContainer,
+			utilmetric.MetricData{Value: cpuQuota, Time: &updateTime})
+		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUPeriodContainer,
+			utilmetric.MetricData{Value: float64(cpu.MaxPeriod), Time: &updateTime})
 
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUNrRunnableContainer,
 			utilmetric.MetricData{Value: float64(cpu.TaskNrRunning), Time: &updateTime})


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
When performing inference in the Borwein model, we found that some metrics are missing when the node is in CGroupV2 mode. This, in turn, causes the inference feature to be 0. Therefore, we need to supplement these metrics and ensure that the calculation criteria are consistent with those of the Malachite Reporter.

#### Which issue(s) this PR fixes:
some metrics are missing when the node is in CGroupV2 mode
(cpu.share.container, cpu.period.container, cpu.quota.container)

#### Special notes for your reviewer:
