### PR TITLE
feat(sysadvisor): add ignore check in borwein model

### DIFF
--- a/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression.go
+++ b/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression.go
@@ -31,6 +31,8 @@ import (
 type LatencyRegression struct {
 	PredictValue     float64 `json:"predict_value"`
 	EquilibriumValue float64 `json:"equilibrium_value"`
+	// Ignore is used to ignore the result of this container
+	Ignore bool `json:"ignore"`
 }
 
 func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader) (map[string]map[string]*LatencyRegression, int64, error) {
@@ -58,6 +60,9 @@ func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader) (map[str
 			err := json.Unmarshal([]byte(result.GenericOutput), specificResult)
 			if err != nil {
 				general.Errorf("invalid generic output: %s for %s", result.GenericOutput, inferenceResultKey)
+				return
+			}
+			if specificResult.Ignore {
 				return
 			}
 


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
To make the prediction results more accurate, a new field `ignore` is added in the Borwein Latency Regression, and small-scale services are excluded
