### PR TITLE
fix(qrm-plugins): populate sidecar container annotations

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -1279,6 +1279,14 @@ func (p *DynamicPolicy) applySidecarAllocationInfoFromMainContainer(sidecarAlloc
 		changed = true
 	}
 
+	// Copy missing annotations from main container
+	for key, value := range mainAllocationInfo.Annotations {
+		if _, ok := sidecarAllocationInfo.Annotations[key]; !ok {
+			sidecarAllocationInfo.Annotations[key] = value
+			changed = true
+		}
+	}
+
 	request := p.getContainerRequestedCores(sidecarAllocationInfo)
 	if sidecarAllocationInfo.RequestQuantity != request {
 		sidecarAllocationInfo.RequestQuantity = request


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fix

#### What this PR does / why we need it:
Currently some annotations (including `numa_hint`) is missing in sidecar container allocation info in qrm cpu plugin state. This will result in sysadvisor update failure when SNB sidecar containers are present.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
