### PR TITLE
feat(*): add a reallocate tag to the MetricNameAllocateFailed metric

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -761,6 +761,8 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 	// we should do it before GetKatalystQoSLevelFromResourceReq.
 	isDebugPod := util.IsDebugPod(req.Annotations, p.podDebugAnnoKeys)
 
+	existReallocAnno, isReallocation := util.IsReallocation(req.Annotations)
+
 	qosLevel, err := util.GetKatalystQoSLevelFromResourceReq(p.qosConfig, req, p.podAnnotationKeptKeys, p.podLabelKeptKeys)
 	if err != nil {
 		err = fmt.Errorf("GetKatalystQoSLevelFromResourceReq for pod: %s/%s, container: %s failed with error: %v",
@@ -854,9 +856,15 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 			if !inplaceUpdateResizing {
 				_ = p.removeContainer(req.PodUid, req.ContainerName, false)
 			}
-			_ = p.emitter.StoreInt64(util.MetricNameAllocateFailed, 1, metrics.MetricTypeNameRaw,
-				metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)},
-				metrics.MetricTag{Key: util.MetricTagNameInplaceUpdateResizing, Val: strconv.FormatBool(inplaceUpdateResizing)})
+
+			metricTags := []metrics.MetricTag{
+				{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)},
+				{Key: util.MetricTagNameInplaceUpdateResizing, Val: strconv.FormatBool(inplaceUpdateResizing)},
+			}
+			if existReallocAnno {
+				metricTags = append(metricTags, metrics.MetricTag{Key: "reallocation", Val: isReallocation})
+			}
+			_ = p.emitter.StoreInt64(util.MetricNameAllocateFailed, 1, metrics.MetricTypeNameRaw, metricTags...)
 		}
 		if err := p.state.StoreState(); err != nil {
 			general.ErrorS(err, "store state failed", "podName", req.PodName, "containerName", req.ContainerName)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -886,6 +886,8 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 	// we should do it before GetKatalystQoSLevelFromResourceReq.
 	isDebugPod := util.IsDebugPod(req.Annotations, p.podDebugAnnoKeys)
 
+	existReallocAnno, isReallocation := util.IsReallocation(req.Annotations)
+
 	qosLevel, err := util.GetKatalystQoSLevelFromResourceReq(p.qosConfig, req, p.podAnnotationKeptKeys, p.podLabelKeptKeys)
 	if err != nil {
 		err = fmt.Errorf("GetKatalystQoSLevelFromResourceReq for pod: %s/%s, container: %s failed with error: %v",
@@ -983,9 +985,15 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 			if !inplaceUpdateResizing {
 				_ = p.removeContainer(req.PodUid, req.ContainerName, false)
 			}
-			_ = p.emitter.StoreInt64(util.MetricNameAllocateFailed, 1, metrics.MetricTypeNameRaw,
-				metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)},
-				metrics.MetricTag{Key: util.MetricTagNameInplaceUpdateResizing, Val: strconv.FormatBool(inplaceUpdateResizing)})
+
+			metricTags := []metrics.MetricTag{
+				{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)},
+				{Key: util.MetricTagNameInplaceUpdateResizing, Val: strconv.FormatBool(inplaceUpdateResizing)},
+			}
+			if existReallocAnno {
+				metricTags = append(metricTags, metrics.MetricTag{Key: "reallocation", Val: isReallocation})
+			}
+			_ = p.emitter.StoreInt64(util.MetricNameAllocateFailed, 1, metrics.MetricTypeNameRaw, metricTags...)
 		}
 		if err := p.state.StoreState(); err != nil {
 			general.ErrorS(err, "store state failed", "podName", req.PodName, "containerName", req.ContainerName)

--- a/pkg/agent/qrm-plugins/util/consts.go
+++ b/pkg/agent/qrm-plugins/util/consts.go
@@ -73,6 +73,7 @@ const (
 	//[TODO]: move them to apiserver
 	PodAnnotationQuantityFromQRMDeclarationKey  = "qrm.katalyst.kubewharf.io/quantity-from-qrm-declaration"
 	PodAnnotationQuantityFromQRMDeclarationTrue = "true"
+	PodAnnotationResourceReallocationKey        = "qrm.katalyst.kubewharf.io/resource-reallocation"
 )
 
 const QRMTimeFormat = "2006-01-02 15:04:05.999999999 -0700 MST"

--- a/pkg/agent/qrm-plugins/util/util.go
+++ b/pkg/agent/qrm-plugins/util/util.go
@@ -77,6 +77,12 @@ func IsDebugPod(podAnnotations map[string]string, podDebugAnnoKeys []string) boo
 	return false
 }
 
+func IsReallocation(podAnnotations map[string]string) (bool, string) {
+	value, exists := podAnnotations[PodAnnotationResourceReallocationKey]
+
+	return exists, value
+}
+
 // GetKatalystQoSLevelFromResourceReq retrieves QoS Level for a given request
 func GetKatalystQoSLevelFromResourceReq(qosConf *generic.QoSConfiguration, req *pluginapi.ResourceRequest,
 	podAnnotationKeptKeys, podLabelKeptKeys []string,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Observation metric enhancement 

#### What this PR does / why we need it:
When resource allocation fails, it indicates whether it is the first allocation or reallocation.
#### Which issue(s) this PR fixes:
Add `reallocated` tag to `katalyst.alloc_failed` metric

#### Special notes for your reviewer:
