### PR TITLE
feat(sysadvisor): support indicator offset update by borwein

### DIFF
--- a/cmd/katalyst-agent/app/options/sysadvisor/qosaware/model/borwein/borwein.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/qosaware/model/borwein/borwein.go
@@ -30,6 +30,8 @@ type BorweinOptions struct {
 	FeatureDescriptionFilePath         string
 	NodeFeatureNames                   []string
 	ContainerFeatureNames              []string
+	TargetIndicators                   []string
+	DryRun                             bool
 }
 
 func NewBorweinOptions() *BorweinOptions {
@@ -50,6 +52,9 @@ func (o *BorweinOptions) AddFlags(fs *pflag.FlagSet) {
 		"borwein node feature name list")
 	fs.StringSliceVar(&o.ContainerFeatureNames, "borwein-container-feature-names", o.ContainerFeatureNames,
 		"borwein node feature name list")
+	fs.StringSliceVar(&o.TargetIndicators, "borwein-target-indicators", o.TargetIndicators,
+		"borwein target indicator name list")
+	fs.BoolVar(&o.DryRun, "borwein-dry-run", o.DryRun, "A bool to enable and disable borwein dry-run")
 }
 
 // ApplyTo fills up config with options
@@ -61,6 +66,8 @@ func (o *BorweinOptions) ApplyTo(c *borwein.BorweinConfiguration) error {
 	}{}
 
 	c.ModelNameToInferenceSvcSockAbsPath = o.ModelNameToInferenceSvcSockAbsPath
+	c.TargetIndicators = o.TargetIndicators
+	c.DryRun = o.DryRun
 
 	if len(o.NodeFeatureNames)+len(o.ContainerFeatureNames) > 0 {
 		c.NodeFeatureNames = o.NodeFeatureNames

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
@@ -1355,7 +1355,6 @@ func (p *StaticPolicy) generateAndApplyGroups() error {
 		return fmt.Errorf("generateLowPriorityGroup failed with error: %v", err)
 	} else {
 		err = p.applyNetworkGroupsFunc(p.lowPriorityGroups)
-
 		if err != nil {
 			return fmt.Errorf("applyGroups failed with error: %v", err)
 		}

--- a/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression.go
+++ b/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression.go
@@ -19,6 +19,8 @@ package latencyregression
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"time"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
 	borweinconsts "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/inference/models/borwein/consts"
@@ -29,13 +31,47 @@ import (
 )
 
 type LatencyRegression struct {
-	PredictValue     float64 `json:"predict_value"`
-	EquilibriumValue float64 `json:"equilibrium_value"`
+	PredictValue float64 `json:"predict_value"`
 	// Ignore is used to ignore the result of this container
 	Ignore bool `json:"ignore"`
 }
 
-func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader) (map[string]map[string]*LatencyRegression, int64, error) {
+type BorweinStrategy struct {
+	// StrategySlots indicates strategy slots based on given net quantile
+	StrategySlots ClusterStrategy `json:"strategy_slots"`
+	// StrategySpecialTime indicates strategy slots based on given special times
+	StrategySpecialTime ClusterSpecialTimeStrategy `json:"strategy_special_time"`
+}
+
+// ClusterStrategy describe indicator level strategy
+type ClusterStrategy map[string]StrategySlots
+
+type StrategySlots []StrategySlot
+
+type StrategySlot struct {
+	// Slot indicates the quantile corresponding to the strategy slot
+	Slot int `json:"slot"`
+	// NET indicates the NET quantile value corresponding to the strategy slot
+	// The full name of NET is normalized equivalent throughput, it defines the normalized equivalent throughput of a certain node at time t
+	NET float64 `json:"net"`
+	// Offset indicates how much offset the Indicator should adjust when current node NET value falls within the strategy slot
+	Offset float64 `json:"offset"`
+}
+
+type GlobalSpecialTimeStrategy map[string]map[string]StrategySpecialTimeSlots
+
+type ClusterSpecialTimeStrategy map[string]StrategySpecialTimeSlots
+
+type StrategySpecialTimeSlots []StrategySpecialTimeSlot
+
+type StrategySpecialTimeSlot struct {
+	// TimeRange indicates the time range of the current strategy slot.
+	TimeRange []string `json:"time_range"`
+	// Offset indicates how much offset the Indicator should adjust when current node NET value falls within the strategy slot
+	Offset float64 `json:"offset"`
+}
+
+func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader, dryRun bool) (map[string]map[string]*LatencyRegression, int64, error) {
 	if metaReader == nil {
 		return nil, 0, fmt.Errorf("nil metaReader")
 	}
@@ -48,9 +84,11 @@ func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader) (map[str
 
 	ret := make(map[string]map[string]*LatencyRegression)
 	var resultTimestamp int64
+
 	switch typedResults := results.(type) {
 	case *borweintypes.BorweinInferenceResults:
 		resultTimestamp = typedResults.Timestamp
+
 		typedResults.RangeInferenceResults(func(podUID, containerName string, result *borweininfsvc.InferenceResult) {
 			if result == nil {
 				return
@@ -62,7 +100,7 @@ func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader) (map[str
 				general.Errorf("invalid generic output: %s for %s", result.GenericOutput, inferenceResultKey)
 				return
 			}
-			if specificResult.Ignore {
+			if !dryRun && specificResult.Ignore {
 				return
 			}
 
@@ -77,4 +115,81 @@ func GetLatencyRegressionPredictResult(metaReader metacache.MetaReader) (map[str
 	}
 
 	return ret, resultTimestamp, nil
+}
+
+func MatchSlotOffset(nodeAvgNet float64, clusterStrategy ClusterStrategy, indicator string, borweinParameter *borweintypes.BorweinParameter) float64 {
+	slots, ok := clusterStrategy[indicator]
+	if !ok {
+		general.Warningf("find no slot for indicator %v", indicator)
+		return 0
+	}
+
+	sort.Slice(slots, func(i, j int) bool {
+		return slots[i].NET < slots[j].NET
+	})
+
+	for _, slot := range slots {
+		if nodeAvgNet < slot.NET {
+			general.InfoS("predicted match offset", "nodeAvgNet", nodeAvgNet,
+				"slot", slot.Slot, "net", slot.NET, "offset", slot.Offset)
+			return slot.Offset
+		}
+	}
+	general.Infof("match no slot, use max offset")
+	return borweinParameter.OffsetMax
+}
+
+func MatchSpecialTimes(clusterSpecialTimeStrategy ClusterSpecialTimeStrategy, indicator string) (float64, bool) {
+	specialTimeSlots, ok := clusterSpecialTimeStrategy[indicator]
+	if !ok {
+		return 0, false
+	}
+
+	for _, specialTime := range specialTimeSlots {
+		offset, match := InSpecialTime(specialTime)
+		if !match {
+			continue
+		}
+		general.InfoS("match special time", "timeRange", specialTime.TimeRange, "offset", specialTime.Offset)
+		return offset, true
+	}
+	return 0, false
+}
+
+func InSpecialTime(specialTime StrategySpecialTimeSlot) (float64, bool) {
+	if len(specialTime.TimeRange) != 2 {
+		return 0, false
+	}
+
+	layout := "15:04"
+	now := time.Now()
+	loc := now.Location()
+
+	start, err := time.ParseInLocation(layout, specialTime.TimeRange[0], loc)
+	if err != nil {
+		return 0, false
+	}
+	end, err := time.ParseInLocation(layout, specialTime.TimeRange[1], loc)
+	if err != nil {
+		return 0, false
+	}
+
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc)
+	startTime := today.Add(time.Duration(start.Hour())*time.Hour + time.Duration(start.Minute())*time.Minute)
+	endTime := today.Add(time.Duration(end.Hour())*time.Hour + time.Duration(end.Minute())*time.Minute)
+
+	if now.After(startTime) && now.Before(endTime) {
+		return specialTime.Offset, true
+	}
+
+	return 0, false
+}
+
+func ParseStrategy(strategyParam string) (BorweinStrategy, error) {
+	var ret BorweinStrategy
+	err := json.Unmarshal([]byte(strategyParam), &ret)
+	if err != nil {
+		return BorweinStrategy{}, err
+	}
+	return ret, nil
 }

--- a/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression_test.go
+++ b/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression_test.go
@@ -18,6 +18,7 @@ package latencyregression
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -33,15 +34,13 @@ func TestGetLatencyRegressionPredictValue(t *testing.T) {
 	t.Parallel()
 	timeNow := time.Now().Unix()
 	res1 := &LatencyRegression{
-		PredictValue:     0.6,
-		EquilibriumValue: 0.1,
-		Ignore:           false,
+		PredictValue: 0.6,
+		Ignore:       false,
 	}
 	bs1, _ := json.Marshal(res1)
 	res2 := &LatencyRegression{
-		PredictValue:     0.7,
-		EquilibriumValue: 0.1,
-		Ignore:           true,
+		PredictValue: 0.7,
+		Ignore:       true,
 	}
 	bs2, _ := json.Marshal(res2)
 	reader := metacache.NewDummyMetaCacheImp()
@@ -88,9 +87,8 @@ func TestGetLatencyRegressionPredictValue(t *testing.T) {
 			want: map[string]map[string]*LatencyRegression{
 				"test1": {
 					"test": &LatencyRegression{
-						PredictValue:     0.6,
-						EquilibriumValue: 0.1,
-						Ignore:           false,
+						PredictValue: 0.6,
+						Ignore:       false,
 					},
 				},
 			},
@@ -102,13 +100,418 @@ func TestGetLatencyRegressionPredictValue(t *testing.T) {
 		curTT := tt
 		t.Run(curTT.name, func(t *testing.T) {
 			t.Parallel()
-			got, _, err := GetLatencyRegressionPredictResult(curTT.args.metaReader)
+			got, _, err := GetLatencyRegressionPredictResult(curTT.args.metaReader, false)
 			if (err != nil) != curTT.wantErr {
 				t.Errorf("GetLatencyRegressionPredictResult() error = %v, wantErr %v", err, curTT.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, curTT.want) {
 				t.Errorf("GetLatencyRegressionPredictResult() got = %v, want %v", got, curTT.want)
+			}
+		})
+	}
+}
+
+func TestInSpecialTime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	currentHour := now.Hour()
+	currentMinute := now.Minute()
+
+	inRangeStartHour := currentHour
+	inRangeStartMinute := currentMinute - 10
+	if inRangeStartMinute < 0 {
+		inRangeStartMinute += 60
+		inRangeStartHour--
+	}
+	inRangeEndHour := currentHour
+	inRangeEndMinute := currentMinute + 10
+	if inRangeEndMinute >= 60 {
+		inRangeEndMinute -= 60
+		inRangeEndHour++
+	}
+	inRangeStartStr := fmt.Sprintf("%02d:%02d", inRangeStartHour, inRangeStartMinute)
+	inRangeEndStr := fmt.Sprintf("%02d:%02d", inRangeEndHour, inRangeEndMinute)
+
+	outOfRangeStartHour := currentHour + 1
+	outOfRangeStartMinute := currentMinute
+	if outOfRangeStartMinute >= 60 {
+		outOfRangeStartMinute -= 60
+		outOfRangeStartHour++
+	}
+	outOfRangeEndHour := outOfRangeStartHour + 1
+	outOfRangeEndMinute := currentMinute
+	if outOfRangeEndMinute >= 60 {
+		outOfRangeEndMinute -= 60
+		outOfRangeEndHour++
+	}
+	outOfRangeStartStr := fmt.Sprintf("%02d:%02d", outOfRangeStartHour, outOfRangeStartMinute)
+	outOfRangeEndStr := fmt.Sprintf("%02d:%02d", outOfRangeEndHour, outOfRangeEndMinute)
+
+	tests := []struct {
+		name        string
+		specialTime StrategySpecialTimeSlot
+		wantOffset  float64
+		wantResult  bool
+	}{
+		{
+			name: "In range",
+			specialTime: StrategySpecialTimeSlot{
+				TimeRange: []string{inRangeStartStr, inRangeEndStr},
+				Offset:    1.5,
+			},
+			wantOffset: 1.5,
+			wantResult: true,
+		},
+		{
+			name: "Out of range",
+			specialTime: StrategySpecialTimeSlot{
+				TimeRange: []string{outOfRangeStartStr, outOfRangeEndStr},
+				Offset:    2.0,
+			},
+			wantOffset: 0,
+			wantResult: false,
+		},
+		{
+			name: "Invalid time range length",
+			specialTime: StrategySpecialTimeSlot{
+				TimeRange: []string{"14:00"},
+				Offset:    2.5,
+			},
+			wantOffset: 0,
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		curTT := tt
+		t.Run(curTT.name, func(t *testing.T) {
+			t.Parallel()
+			gotOffset, gotResult := InSpecialTime(curTT.specialTime)
+			if !reflect.DeepEqual(gotOffset, curTT.wantOffset) {
+				t.Errorf("InSpecialTime() gotOffset = %v, want %v", gotOffset, curTT.wantOffset)
+			}
+			if gotResult != curTT.wantResult {
+				t.Errorf("InSpecialTime() gotResult = %v, want %v", gotResult, curTT.wantResult)
+			}
+		})
+	}
+}
+
+func TestParseStrategy(t *testing.T) {
+	t.Parallel()
+
+	jsonStr := `{
+       "strategy_slots": {
+           "cpu_usage_ratio": [
+           {
+				"slot": 5,
+                "net": -1.1,
+				"offset": -0.15
+           },
+           {
+                "slot": 20,
+                "net": -0.5,
+				"offset": -0.08
+           },
+           {
+                "slot": 50,
+                "net": 0.2,
+				"offset": 0.07
+           },
+           {
+                "slot": 90,
+                "net": 1.1,
+				"offset": 0.18
+           }
+       ]
+       },
+       "strategy_special_time": {
+         "cpu_usage_ratio": [
+			{
+				"time_range": [
+					"20:30",
+					"21:00"
+				],
+				"offset": -0.15
+			},
+			{
+				"time_range": [
+					"21:00",
+					"22:00"
+				],
+				"offset": -0.2
+			}
+		]
+       }
+   }`
+	type args struct {
+		strategyParam string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    BorweinStrategy
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				strategyParam: jsonStr,
+			},
+			want: BorweinStrategy{
+				StrategySlots: ClusterStrategy{
+					"cpu_usage_ratio": StrategySlots{
+						{
+							Slot:   5,
+							NET:    -1.1,
+							Offset: -0.15,
+						},
+						{
+							Slot:   20,
+							NET:    -0.5,
+							Offset: -0.08,
+						},
+						{
+							Slot:   50,
+							NET:    0.2,
+							Offset: 0.07,
+						},
+						{
+							Slot:   90,
+							NET:    1.1,
+							Offset: 0.18,
+						},
+					},
+				},
+				StrategySpecialTime: ClusterSpecialTimeStrategy{
+					"cpu_usage_ratio": []StrategySpecialTimeSlot{
+						{
+							TimeRange: []string{"20:30", "21:00"},
+							Offset:    -0.15,
+						},
+						{
+							TimeRange: []string{"21:00", "22:00"},
+							Offset:    -0.2,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		curTT := tt
+		t.Run(curTT.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseStrategy(curTT.args.strategyParam)
+			if (err != nil) != curTT.wantErr {
+				t.Errorf("ParseStrategy() error = %v, wantErr %v", err, curTT.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, curTT.want) {
+				t.Errorf("ParseStrategy() got = %v, want %v", got, curTT.want)
+			}
+		})
+	}
+}
+
+func TestMatchSlotOffset(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		nodeAvgNet       float64
+		clusterStrategy  ClusterStrategy
+		indicator        string
+		borweinParameter *borweintypes.BorweinParameter
+	}
+	tests := []struct {
+		name string
+		args args
+		want float64
+	}{
+		{
+			name: "test1",
+			args: args{
+				nodeAvgNet: 1.0,
+				clusterStrategy: ClusterStrategy{
+					"cpu_usage_ratio": StrategySlots{
+						{
+							Slot:   5,
+							NET:    -1.1,
+							Offset: -0.15,
+						},
+						{
+							Slot:   20,
+							NET:    -0.5,
+							Offset: -0.08,
+						},
+						{
+							Slot:   50,
+							NET:    0.2,
+							Offset: 0.07,
+						},
+						{
+							Slot:   90,
+							NET:    1.1,
+							Offset: 0.18,
+						},
+					},
+				},
+				indicator: "cpu_usage_ratio",
+				borweinParameter: &borweintypes.BorweinParameter{
+					OffsetMin: -0.2,
+					OffsetMax: 0.2,
+				},
+			},
+			want: 0.18,
+		},
+		{
+			name: "test2",
+			args: args{
+				nodeAvgNet: -1.3,
+				clusterStrategy: ClusterStrategy{
+					"cpu_usage_ratio": StrategySlots{
+						{
+							Slot:   5,
+							NET:    -1.1,
+							Offset: -0.15,
+						},
+						{
+							Slot:   20,
+							NET:    -0.5,
+							Offset: -0.08,
+						},
+						{
+							Slot:   50,
+							NET:    0.2,
+							Offset: 0.07,
+						},
+						{
+							Slot:   90,
+							NET:    1.1,
+							Offset: 0.18,
+						},
+					},
+				},
+				indicator: "cpu_usage_ratio",
+				borweinParameter: &borweintypes.BorweinParameter{
+					OffsetMin: -0.2,
+					OffsetMax: 0.2,
+				},
+			},
+			want: -0.15,
+		},
+		{
+			name: "test3",
+			args: args{
+				nodeAvgNet: -1.3,
+				clusterStrategy: ClusterStrategy{
+					"cpu_usage_ratio": StrategySlots{
+						{
+							Slot:   5,
+							NET:    -1.1,
+							Offset: -0.15,
+						},
+						{
+							Slot:   20,
+							NET:    -0.5,
+							Offset: -0.08,
+						},
+						{
+							Slot:   50,
+							NET:    0.2,
+							Offset: 0.07,
+						},
+						{
+							Slot:   90,
+							NET:    1.1,
+							Offset: 0.18,
+						},
+					},
+				},
+				indicator: "cpu_sched_wait",
+				borweinParameter: &borweintypes.BorweinParameter{
+					OffsetMin: -0.2,
+					OffsetMax: 0.2,
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "test3",
+			args: args{
+				nodeAvgNet: 2.1,
+				clusterStrategy: ClusterStrategy{
+					"cpu_usage_ratio": StrategySlots{
+						{
+							Slot:   5,
+							NET:    -1.1,
+							Offset: -0.15,
+						},
+						{
+							Slot:   20,
+							NET:    -0.5,
+							Offset: -0.08,
+						},
+						{
+							Slot:   50,
+							NET:    0.2,
+							Offset: 0.07,
+						},
+						{
+							Slot:   90,
+							NET:    1.1,
+							Offset: 0.18,
+						},
+					},
+				},
+				indicator: "cpu_usage_ratio",
+				borweinParameter: &borweintypes.BorweinParameter{
+					OffsetMin: -0.2,
+					OffsetMax: 0.2,
+				},
+			},
+			want: 0.2,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := MatchSlotOffset(tt.args.nodeAvgNet, tt.args.clusterStrategy, tt.args.indicator, tt.args.borweinParameter); got != tt.want {
+				t.Errorf("MatchSlotOffset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchSpecialTimes(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		clusterSpecialTimeStrategy ClusterSpecialTimeStrategy
+		indicator                  string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      float64
+		wantMatch bool
+	}{
+		{},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, got1 := MatchSpecialTimes(tt.args.clusterSpecialTimeStrategy, tt.args.indicator)
+			if got != tt.want {
+				t.Errorf("MatchSpecialTimes() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.wantMatch {
+				t.Errorf("MatchSpecialTimes() got1 = %v, want %v", got1, tt.wantMatch)
 			}
 		})
 	}

--- a/pkg/agent/sysadvisor/plugin/inference/models/borwein/types/types.go
+++ b/pkg/agent/sysadvisor/plugin/inference/models/borwein/types/types.go
@@ -21,12 +21,13 @@ import (
 )
 
 type BorweinParameter struct {
-	AbnormalRatioThreshold float64 `json:"abnormal_ratio_threshold"`
-	OffsetMax              float64 `json:"offset_max"`
-	OffsetMin              float64 `json:"offset_min"`
-	RampUpStep             float64 `json:"ramp_up_step"`
-	RampDownStep           float64 `json:"ramp_down_step"`
-	Version                string  `json:"version"`
+	OffsetMax    float64 `json:"offset_max"`
+	OffsetMin    float64 `json:"offset_min"`
+	RampUpStep   float64 `json:"ramp_up_step"`
+	RampDownStep float64 `json:"ramp_down_step"`
+	Version      string  `json:"version"`
+	IndicatorMax float64 `json:"indicator_max"`
+	IndicatorMin float64 `json:"indicator_min"`
 }
 
 // BorweinInferenceResults is a descriptor for borwein inference results.

--- a/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/model.go
+++ b/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/model.go
@@ -74,7 +74,8 @@ func (p *MetricSyncerPod) emitBorweinTrainingThroughput() {
 }
 
 func (p *MetricSyncerPod) emitBorweinLatencyRegression() {
-	latencyRegressionData, resultTimestamp, err := latencyregression.GetLatencyRegressionPredictResult(p.metaReader)
+	latencyRegressionData, resultTimestamp, err := latencyregression.GetLatencyRegressionPredictResult(
+		p.metaReader, p.borweinConf.DryRun)
 	if err != nil {
 		klog.Errorf("failed to get inference results of model(%s) error: %v\n", borweinconsts.ModelNameBorweinLatencyRegression, err)
 		return

--- a/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/pod.go
+++ b/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/pod.go
@@ -34,6 +34,7 @@ import (
 	sysadvisortypes "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	metricemitter "github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/metric-emitter"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/qosaware/model/borwein"
 	"github.com/kubewharf/katalyst-core/pkg/config/generic"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/custom-metric/store/data"
@@ -80,6 +81,7 @@ type MetricSyncerPod struct {
 
 	emitterConf *metricemitter.MetricEmitterPluginConfiguration
 	qosConf     *generic.QoSConfiguration
+	borweinConf *borwein.BorweinConfiguration
 
 	// no need to lock this map, since we only refer to it in syncChanel
 	rawNotifier map[string]podRawChanel
@@ -117,6 +119,7 @@ func NewMetricSyncerPod(conf *config.Configuration, _ interface{},
 
 		emitterConf: conf.AgentConfiguration.MetricEmitterPluginConfiguration,
 		qosConf:     conf.GenericConfiguration.QoSConfiguration,
+		borweinConf: conf.BorweinConfiguration,
 		rawNotifier: make(map[string]podRawChanel),
 
 		metricEmitter: metricEmitter,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"testing"
 
+	borweinutils "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/inference/models/borwein/utils"
+
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,14 +34,20 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	configapi "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
 	workloadv1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/workload/v1alpha1"
 	internalfake "github.com/kubewharf/katalyst-api/pkg/client/clientset/versioned/fake"
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
-	advisortypes "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
+	borweinconsts "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/inference/models/borwein/consts"
+	borweininfsvc "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/inference/models/borwein/inferencesvc"
+	borweintypes "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/inference/models/borwein/types"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
 	"github.com/kubewharf/katalyst-core/pkg/client"
 	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
 	metaconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
@@ -52,6 +60,71 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	metricspool "github.com/kubewharf/katalyst-core/pkg/metrics/metrics-pool"
 	metricutil "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+var (
+	testStrategyParam = `{
+       "strategy_slots": {
+           "cpu_usage_ratio": [
+           {
+				"slot": 5,
+                "net": -1.1,
+				"offset": -0.15
+           },
+           {
+                "slot": 20,
+                "net": -0.5,
+				"offset": -0.08
+           },
+           {
+                "slot": 50,
+                "net": 0.2,
+				"offset": 0.07
+           },
+           {
+                "slot": 90,
+                "net": 1.1,
+				"offset": 0.18
+           }
+       ]
+       },
+       "strategy_special_time": {
+         "cpu_usage_ratio": [
+			{
+				"time_range": [
+					"20:30",
+					"21:00"
+				],
+				"offset": -0.15
+			},
+			{
+				"time_range": [
+					"21:00",
+					"22:00"
+				],
+				"offset": -0.2
+			}
+		]
+       }
+   }`
+	initConf = func(t *testing.T, checkpointDir string, stateFileDir string) *config.Configuration {
+		conf := generateTestConfiguration(t, checkpointDir, stateFileDir)
+		conf.BorweinConfiguration.TargetIndicators = []string{
+			string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio),
+		}
+		dynamicConf := dynamic.NewConfiguration()
+		strategyName := consts.StrategyNameBorweinV2
+		dynamicConf.StrategyGroup.EnabledStrategies = []configapi.Strategy{
+			{
+				Name: &strategyName,
+				Parameters: map[string]string{
+					consts.StrategyNameBorweinV2: testStrategyParam,
+				},
+			},
+		}
+		conf.DynamicAgentConfiguration.SetDynamicConfiguration(dynamicConf)
+		return conf
+	}
 )
 
 func generateTestConfiguration(t *testing.T, checkpointDir, stateFileDir string) *config.Configuration {
@@ -99,6 +172,9 @@ func TestNewBorweinController(t *testing.T) {
 	defer func() { _ = os.RemoveAll(stateFileDir) }()
 
 	conf := generateTestConfiguration(t, checkpointDir, stateFileDir)
+	conf.BorweinConfiguration.TargetIndicators = []string{
+		string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio),
+	}
 	regionName := "test"
 	regionType := configapi.QoSRegionTypeShare
 
@@ -132,7 +208,7 @@ func TestNewBorweinController(t *testing.T) {
 	}}
 	mc, err := metacache.NewMetaCacheImp(conf, metricspool.DummyMetricsEmitterPool{}, metaServer.MetricsFetcher)
 	require.NoError(t, err)
-	mc.AddContainer(podUID, containerName, &advisortypes.ContainerInfo{
+	mc.AddContainer(podUID, containerName, &types.ContainerInfo{
 		PodUID:        podUID,
 		PodName:       podName,
 		ContainerName: containerName,
@@ -160,13 +236,17 @@ func TestNewBorweinController(t *testing.T) {
 				metaReader: mc,
 			},
 			want: &BorweinController{
-				regionName:              regionName,
-				regionType:              regionType,
-				conf:                    conf,
-				borweinParameters:       conf.BorweinConfiguration.BorweinParameters,
-				indicatorOffsets:        map[string]float64{},
-				metaReader:              mc,
-				indicatorOffsetUpdaters: map[string]IndicatorOffsetUpdater{},
+				regionName:        regionName,
+				regionType:        regionType,
+				conf:              conf,
+				borweinParameters: conf.BorweinConfiguration.BorweinParameters,
+				indicatorOffsets: map[string]float64{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): 0,
+				},
+				metaReader: mc,
+				indicatorOffsetUpdaters: map[string]IndicatorOffsetUpdater{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): updateCPUUsageIndicatorOffset,
+				},
 			},
 		},
 	}
@@ -182,6 +262,738 @@ func TestNewBorweinController(t *testing.T) {
 			require.True(t, reflect.DeepEqual(got.borweinParameters, tt.want.borweinParameters))
 			require.True(t, reflect.DeepEqual(got.indicatorOffsets, tt.want.indicatorOffsets))
 			require.True(t, reflect.DeepEqual(got.metaReader, tt.want.metaReader))
+		})
+	}
+}
+
+func Test_updateCPUUsageIndicatorOffset(t *testing.T) {
+	t.Parallel()
+	podUID1 := "test-pod-uid1"
+	podName1 := "test-pod1"
+	containerName := "test-container"
+	podUID2 := "test-pod-uid2"
+	podName2 := "test-pod2"
+	nodeName := "node1"
+	fakeCPUUsage := 20.0
+
+	checkpointDir, err := ioutil.TempDir("", "checkpoint-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(checkpointDir) }()
+
+	stateFileDir, err := ioutil.TempDir("", "statefile-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(stateFileDir) }()
+
+	conf := initConf(t, checkpointDir, stateFileDir)
+
+	clientSet := generateTestGenericClientSet([]runtime.Object{&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}}, nil)
+	metaServer := generateTestMetaServer(clientSet)
+	metaServer.NodeFetcher = node.NewRemoteNodeFetcher(&global.BaseConfiguration{NodeName: nodeName}, &metaconfig.NodeConfiguration{}, clientSet.KubeClient.CoreV1().Nodes())
+	metaServer.MetricsFetcher.RegisterExternalMetric(func(store *metricutil.MetricStore) {
+		store.SetContainerMetric(podUID1, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+		store.SetContainerMetric(podUID2, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+	})
+	metaServer.MetricsFetcher.Run(context.Background())
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID1),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID2),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+	}}
+
+	type args struct {
+		podSet                 types.PodSet
+		currentIndicatorOffset float64
+		borweinParameter       *borweintypes.BorweinParameter
+		metaReader             metacache.MetaReader
+		conf                   *config.Configuration
+		inferenceResults       *borweintypes.BorweinInferenceResults
+		emitter                metrics.MetricEmitter
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    float64
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				podSet: types.PodSet{
+					podUID1: sets.NewString(containerName),
+					podUID2: sets.NewString(containerName),
+				},
+				currentIndicatorOffset: 0.03,
+				borweinParameter:       conf.BorweinParameters[string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio)],
+				conf:                   conf,
+				inferenceResults: &borweintypes.BorweinInferenceResults{
+					Timestamp: 0,
+					Results: map[string]map[string][]*borweininfsvc.InferenceResult{
+						podUID1: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": 1.0}",
+								},
+							},
+						},
+						podUID2: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -0.5}",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    0.18,
+			wantErr: false,
+		},
+		{
+			name: "test2",
+			args: args{
+				podSet: types.PodSet{
+					podUID1: sets.NewString(containerName),
+					podUID2: sets.NewString(containerName),
+				},
+				currentIndicatorOffset: 0.03,
+				borweinParameter:       conf.BorweinParameters[string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio)],
+				conf:                   conf,
+				inferenceResults: &borweintypes.BorweinInferenceResults{
+					Timestamp: 0,
+					Results: map[string]map[string][]*borweininfsvc.InferenceResult{
+						podUID1: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1}",
+								},
+							},
+						},
+						podUID2: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -0.5}",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    -0.08,
+			wantErr: false,
+		},
+		{
+			name: "test3",
+			args: args{
+				podSet: types.PodSet{
+					podUID1: sets.NewString(containerName),
+					podUID2: sets.NewString(containerName),
+				},
+				currentIndicatorOffset: 0.01,
+				borweinParameter:       conf.BorweinParameters[string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio)],
+				conf:                   conf,
+				inferenceResults: &borweintypes.BorweinInferenceResults{
+					Timestamp: 0,
+					Results: map[string]map[string][]*borweininfsvc.InferenceResult{
+						podUID1: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1}",
+								},
+							},
+						},
+						podUID2: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1.5}",
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    -0.15,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			inferenceResultKey := borweinutils.GetInferenceResultKey(borweinconsts.ModelNameBorweinLatencyRegression)
+			mc, err := metacache.NewMetaCacheImp(conf, metricspool.DummyMetricsEmitterPool{}, metaServer.MetricsFetcher)
+			require.NoError(t, err)
+			mc.AddContainer(podUID1, containerName, &types.ContainerInfo{
+				PodUID:        podUID1,
+				PodName:       podName1,
+				ContainerName: containerName,
+				ContainerType: v1alpha1.ContainerType_MAIN,
+			})
+			mc.AddContainer(podUID2, containerName, &types.ContainerInfo{
+				PodUID:        podUID2,
+				PodName:       podName2,
+				ContainerName: containerName,
+				ContainerType: v1alpha1.ContainerType_MAIN,
+			})
+			mc.SetInferenceResult(inferenceResultKey, tt.args.inferenceResults)
+			got, err := updateCPUUsageIndicatorOffset(tt.args.podSet, tt.args.currentIndicatorOffset,
+				tt.args.borweinParameter, mc, tt.args.conf)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updateCPUUsageIndicatorOffset() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("updateCPUUsageIndicatorOffset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBorweinController_updateIndicatorOffsets(t *testing.T) {
+	t.Parallel()
+	podUID1 := "test-pod-uid1"
+	podName1 := "test-pod1"
+	containerName := "test-container"
+	podUID2 := "test-pod-uid2"
+	podName2 := "test-pod2"
+	nodeName := "node1"
+	fakeCPUUsage := 20.0
+
+	regionName := "test"
+	regionType := configapi.QoSRegionTypeShare
+
+	checkpointDir, err := ioutil.TempDir("", "checkpoint-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(checkpointDir) }()
+
+	stateFileDir, err := ioutil.TempDir("", "statefile-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(stateFileDir) }()
+
+	conf := initConf(t, checkpointDir, stateFileDir)
+
+	clientSet := generateTestGenericClientSet([]runtime.Object{&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}}, nil)
+	metaServer := generateTestMetaServer(clientSet)
+	metaServer.NodeFetcher = node.NewRemoteNodeFetcher(&global.BaseConfiguration{NodeName: nodeName}, &metaconfig.NodeConfiguration{}, clientSet.KubeClient.CoreV1().Nodes())
+	metaServer.MetricsFetcher.RegisterExternalMetric(func(store *metricutil.MetricStore) {
+		store.SetContainerMetric(podUID1, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+		store.SetContainerMetric(podUID2, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+	})
+	metaServer.MetricsFetcher.Run(context.Background())
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID1),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID2),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+	}}
+	mc, err := metacache.NewMetaCacheImp(conf, metricspool.DummyMetricsEmitterPool{}, metaServer.MetricsFetcher)
+	require.NoError(t, err)
+	mc.AddContainer(podUID1, containerName, &types.ContainerInfo{
+		PodUID:        podUID1,
+		PodName:       podName1,
+		ContainerName: containerName,
+		ContainerType: v1alpha1.ContainerType_MAIN,
+	})
+	mc.AddContainer(podUID2, containerName, &types.ContainerInfo{
+		PodUID:        podUID2,
+		PodName:       podName2,
+		ContainerName: containerName,
+		ContainerType: v1alpha1.ContainerType_MAIN,
+	})
+
+	type fields struct {
+		regionName              string
+		regionType              configapi.QoSRegionType
+		conf                    *config.Configuration
+		borweinParameters       map[string]*borweintypes.BorweinParameter
+		indicatorOffsets        map[string]float64
+		metaReader              metacache.MetaReader
+		indicatorOffsetUpdaters map[string]IndicatorOffsetUpdater
+		inferenceResults        *borweintypes.BorweinInferenceResults
+	}
+	type args struct {
+		podSet types.PodSet
+	}
+	tests := []struct {
+		name                 string
+		fields               fields
+		args                 args
+		wantIndicatorOffsets map[string]float64
+	}{
+		{
+			name: "test update indicator offsets normally",
+			fields: fields{
+				regionName:        regionName,
+				regionType:        regionType,
+				conf:              conf,
+				borweinParameters: conf.BorweinConfiguration.BorweinParameters,
+				indicatorOffsets: map[string]float64{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): 0,
+				},
+				metaReader: mc,
+				indicatorOffsetUpdaters: map[string]IndicatorOffsetUpdater{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): updateCPUUsageIndicatorOffset,
+				},
+				inferenceResults: &borweintypes.BorweinInferenceResults{
+					Timestamp: 0,
+					Results: map[string]map[string][]*borweininfsvc.InferenceResult{
+						podUID1: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1}",
+								},
+							},
+						},
+						podUID2: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1.5}",
+								},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				podSet: types.PodSet{
+					podUID1: sets.NewString(containerName),
+					podUID2: sets.NewString(containerName),
+				},
+			},
+			wantIndicatorOffsets: map[string]float64{
+				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): -0.15,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bc := &BorweinController{
+				regionName:              tt.fields.regionName,
+				regionType:              tt.fields.regionType,
+				conf:                    tt.fields.conf,
+				borweinParameters:       tt.fields.borweinParameters,
+				indicatorOffsets:        tt.fields.indicatorOffsets,
+				metaReader:              tt.fields.metaReader,
+				indicatorOffsetUpdaters: tt.fields.indicatorOffsetUpdaters,
+				emitter:                 metrics.DummyMetrics{},
+			}
+			inferenceResultKey := borweinutils.GetInferenceResultKey(borweinconsts.ModelNameBorweinLatencyRegression)
+			mc.SetInferenceResult(inferenceResultKey, tt.fields.inferenceResults)
+			bc.updateIndicatorOffsets(tt.args.podSet)
+		})
+	}
+}
+
+func TestBorweinController_getUpdatedIndicators(t *testing.T) {
+	t.Parallel()
+	podUID1 := "test-pod-uid1"
+	podName1 := "test-pod1"
+	containerName := "test-container"
+	podUID2 := "test-pod-uid2"
+	podName2 := "test-pod2"
+	nodeName := "node1"
+	fakeCPUUsage := 20.0
+
+	regionName := "test"
+	regionType := configapi.QoSRegionTypeShare
+
+	checkpointDir, err := ioutil.TempDir("", "checkpoint-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(checkpointDir) }()
+
+	stateFileDir, err := ioutil.TempDir("", "statefile-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(stateFileDir) }()
+
+	conf := initConf(t, checkpointDir, stateFileDir)
+
+	clientSet := generateTestGenericClientSet([]runtime.Object{&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}}, nil)
+	metaServer := generateTestMetaServer(clientSet)
+	metaServer.NodeFetcher = node.NewRemoteNodeFetcher(&global.BaseConfiguration{NodeName: nodeName}, &metaconfig.NodeConfiguration{}, clientSet.KubeClient.CoreV1().Nodes())
+	metaServer.MetricsFetcher.RegisterExternalMetric(func(store *metricutil.MetricStore) {
+		store.SetContainerMetric(podUID1, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+		store.SetContainerMetric(podUID2, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+	})
+	metaServer.MetricsFetcher.Run(context.Background())
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID1),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID2),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+	}}
+	mc, err := metacache.NewMetaCacheImp(conf, metricspool.DummyMetricsEmitterPool{}, metaServer.MetricsFetcher)
+	require.NoError(t, err)
+	mc.AddContainer(podUID1, containerName, &types.ContainerInfo{
+		PodUID:        podUID1,
+		PodName:       podName1,
+		ContainerName: containerName,
+		ContainerType: v1alpha1.ContainerType_MAIN,
+	})
+	mc.AddContainer(podUID2, containerName, &types.ContainerInfo{
+		PodUID:        podUID2,
+		PodName:       podName2,
+		ContainerName: containerName,
+		ContainerType: v1alpha1.ContainerType_MAIN,
+	})
+
+	type fields struct {
+		regionName              string
+		regionType              configapi.QoSRegionType
+		conf                    *config.Configuration
+		borweinParameters       map[string]*borweintypes.BorweinParameter
+		indicatorOffsets        map[string]float64
+		metaReader              metacache.MetaReader
+		indicatorOffsetUpdaters map[string]IndicatorOffsetUpdater
+	}
+	type args struct {
+		indicators       types.Indicator
+		inferenceResults *borweintypes.BorweinInferenceResults
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   types.Indicator
+	}{
+		{
+			name: "test get updated indicators normally",
+			fields: fields{
+				regionName:        regionName,
+				regionType:        regionType,
+				conf:              conf,
+				borweinParameters: conf.BorweinConfiguration.BorweinParameters,
+				indicatorOffsets: map[string]float64{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): -0.08,
+				},
+				metaReader: mc,
+				indicatorOffsetUpdaters: map[string]IndicatorOffsetUpdater{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): updateCPUUsageIndicatorOffset,
+				},
+			},
+			args: args{
+				indicators: types.Indicator{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): types.IndicatorValue{Current: 0.45, Target: 0.7},
+				},
+				inferenceResults: &borweintypes.BorweinInferenceResults{
+					Timestamp: 0,
+					Results: map[string]map[string][]*borweininfsvc.InferenceResult{
+						podUID1: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1}",
+								},
+							},
+						},
+						podUID2: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1.5}",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: types.Indicator{
+				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): types.IndicatorValue{Current: 0.45, Target: 0.62},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mc.SetInferenceResult(borweinconsts.ModelNameBorweinLatencyRegression, tt.args.inferenceResults)
+			bc := &BorweinController{
+				regionName:              tt.fields.regionName,
+				regionType:              tt.fields.regionType,
+				conf:                    tt.fields.conf,
+				borweinParameters:       tt.fields.borweinParameters,
+				indicatorOffsets:        tt.fields.indicatorOffsets,
+				metaReader:              tt.fields.metaReader,
+				indicatorOffsetUpdaters: tt.fields.indicatorOffsetUpdaters,
+			}
+			if got := bc.getUpdatedIndicators(tt.args.indicators); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BorweinController.getUpdatedIndicators() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBorweinController_GetUpdatedIndicators(t *testing.T) {
+	t.Parallel()
+	podUID1 := "test-pod-uid1"
+	podName1 := "test-pod1"
+	containerName := "test-container"
+	podUID2 := "test-pod-uid2"
+	podName2 := "test-pod2"
+	nodeName := "node1"
+	fakeCPUUsage := 20.0
+
+	regionName := "test"
+	regionType := configapi.QoSRegionTypeShare
+
+	checkpointDir, err := ioutil.TempDir("", "checkpoint-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(checkpointDir) }()
+
+	stateFileDir, err := ioutil.TempDir("", "statefile-updateCPUUsageIndicatorOffset")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(stateFileDir) }()
+
+	conf := initConf(t, checkpointDir, stateFileDir)
+
+	clientSet := generateTestGenericClientSet([]runtime.Object{&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}}, nil)
+	metaServer := generateTestMetaServer(clientSet)
+	metaServer.NodeFetcher = node.NewRemoteNodeFetcher(&global.BaseConfiguration{NodeName: nodeName}, &metaconfig.NodeConfiguration{}, clientSet.KubeClient.CoreV1().Nodes())
+	metaServer.MetricsFetcher.RegisterExternalMetric(func(store *metricutil.MetricStore) {
+		store.SetContainerMetric(podUID1, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+		store.SetContainerMetric(podUID2, containerName, consts.MetricCPUUsageContainer, metricutil.MetricData{
+			Value: fakeCPUUsage,
+		})
+	})
+	metaServer.MetricsFetcher.Run(context.Background())
+	metaServer.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID1),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName1,
+				UID:  apitypes.UID(podUID2),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: containerName,
+					},
+				},
+			},
+		},
+	}}
+	mc, err := metacache.NewMetaCacheImp(conf, metricspool.DummyMetricsEmitterPool{}, metaServer.MetricsFetcher)
+	require.NoError(t, err)
+	mc.AddContainer(podUID1, containerName, &types.ContainerInfo{
+		PodUID:        podUID1,
+		PodName:       podName1,
+		ContainerName: containerName,
+		ContainerType: v1alpha1.ContainerType_MAIN,
+	})
+	mc.AddContainer(podUID2, containerName, &types.ContainerInfo{
+		PodUID:        podUID2,
+		PodName:       podName2,
+		ContainerName: containerName,
+		ContainerType: v1alpha1.ContainerType_MAIN,
+	})
+
+	type fields struct {
+		regionName              string
+		regionType              configapi.QoSRegionType
+		conf                    *config.Configuration
+		borweinParameters       map[string]*borweintypes.BorweinParameter
+		indicatorOffsets        map[string]float64
+		metaReader              metacache.MetaReader
+		indicatorOffsetUpdaters map[string]IndicatorOffsetUpdater
+		podSet                  types.PodSet
+	}
+	type args struct {
+		indicators       types.Indicator
+		inferenceResults *borweintypes.BorweinInferenceResults
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   types.Indicator
+	}{
+		{
+			name: "test get updated indicators normally",
+			fields: fields{
+				regionName:        regionName,
+				regionType:        regionType,
+				conf:              conf,
+				borweinParameters: conf.BorweinConfiguration.BorweinParameters,
+				indicatorOffsets: map[string]float64{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): -0.08,
+				},
+				metaReader: mc,
+				indicatorOffsetUpdaters: map[string]IndicatorOffsetUpdater{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): updateCPUUsageIndicatorOffset,
+				},
+				podSet: types.PodSet{
+					podUID1: sets.NewString(containerName),
+					podUID2: sets.NewString(containerName),
+				},
+			},
+			args: args{
+				indicators: types.Indicator{
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): types.IndicatorValue{Current: 0.45, Target: 0.7},
+				},
+				inferenceResults: &borweintypes.BorweinInferenceResults{
+					Timestamp: 0,
+					Results: map[string]map[string][]*borweininfsvc.InferenceResult{
+						podUID1: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1}",
+								},
+							},
+						},
+						podUID2: {
+							containerName: {
+								{
+									InferenceType: borweininfsvc.InferenceType_Other,
+									GenericOutput: "{\"predict_value\": -1.5}",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: types.Indicator{
+				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): types.IndicatorValue{Current: 0.45, Target: 0.62},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mc.SetInferenceResult(borweinconsts.ModelNameBorweinLatencyRegression, tt.args.inferenceResults)
+			bc := &BorweinController{
+				regionName:              tt.fields.regionName,
+				regionType:              tt.fields.regionType,
+				conf:                    tt.fields.conf,
+				borweinParameters:       tt.fields.borweinParameters,
+				indicatorOffsets:        tt.fields.indicatorOffsets,
+				metaReader:              tt.fields.metaReader,
+				indicatorOffsetUpdaters: tt.fields.indicatorOffsetUpdaters,
+			}
+			if got := bc.GetUpdatedIndicators(tt.args.indicators, tt.fields.podSet); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BorweinController.getUpdatedIndicators() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }
@@ -204,11 +1016,11 @@ func TestBorweinController_ResetIndicatorOffsets(t *testing.T) {
 			name: "test with non-nil indicatorOffsets",
 			fields: fields{
 				indicatorOffsets: map[string]float64{
-					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUSchedWait): 460,
+					string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): 460,
 				},
 			},
 			results: map[string]float64{
-				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUSchedWait): 0,
+				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): 0,
 			},
 		},
 	}

--- a/pkg/config/agent/sysadvisor/qosaware/model/borwein/borwein.go
+++ b/pkg/config/agent/sysadvisor/qosaware/model/borwein/borwein.go
@@ -26,21 +26,24 @@ type BorweinConfiguration struct {
 	NodeFeatureNames                   []string
 	ContainerFeatureNames              []string
 	ModelNameToInferenceSvcSockAbsPath map[string]string
+	TargetIndicators                   []string
+	DryRun                             bool
 }
 
 func NewBorweinConfiguration() *BorweinConfiguration {
 	return &BorweinConfiguration{
 		BorweinParameters: map[string]*borweintypes.BorweinParameter{
-			string(v1alpha1.ServiceSystemIndicatorNameCPUSchedWait): {
-				AbnormalRatioThreshold: 0.12,
-				OffsetMax:              250,
-				OffsetMin:              -50,
-				RampUpStep:             2,
-				RampDownStep:           10,
-				Version:                "default",
+			string(v1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): {
+				OffsetMax:    0.2,
+				OffsetMin:    -0.17,
+				Version:      "default",
+				IndicatorMax: 0.87,
+				IndicatorMin: 0.5,
 			},
 		},
 		NodeFeatureNames:      []string{},
 		ContainerFeatureNames: []string{},
+		TargetIndicators:      []string{},
+		DryRun:                false,
 	}
 }

--- a/pkg/util/strategygroup/strategy_group.go
+++ b/pkg/util/strategygroup/strategy_group.go
@@ -50,7 +50,6 @@ func IsStrategyEnabledForNode(strategyName string, defaultValue bool, conf *conf
 	if err != nil {
 		return defaultValue, fmt.Errorf("invalid conf: %v", err)
 	}
-
 	for _, strategy := range strategyGroup.EnabledStrategies {
 		if strategy.Name != nil && *strategy.Name == strategyName {
 			return true, nil
@@ -74,4 +73,19 @@ func GetEnabledStrategiesForNode(conf *config.Configuration) ([]string, error) {
 	}
 
 	return enabledStrategies, nil
+}
+
+func GetSpecificStrategyParam(strategyName string, conf *config.Configuration) (string, bool, error) {
+	strategyGroup, err := validateConf(conf)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid conf: %v", err)
+	}
+
+	for _, strategy := range strategyGroup.EnabledStrategies {
+		if strategy.Name != nil && *strategy.Name == strategyName {
+			return strategy.Parameters[strategyName], true, nil
+		}
+	}
+
+	return "", false, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
Previously, we have launched the Borwein V2 strategy: requesting inference results from the Borwein Inference Server and writing the inference results into KCMAS. This time, we support adjusting the Offset value of the Indicator in Rama based on the inference results of Borwein.
In order to better observe and compare the performance of the Borwein strategy through the AB Test method, we have integrated the StrategyGroup capability. Based on StrategyGroup, we can dynamically group and control whether the Borwein strategy is enabled on nodes.
In order to flexibly compare the business performance at the node level with the historical business performance of the cluster, we issue the historical NET performance of the cluster based on StrategyGroup, and adjust Borwein according to the issued Offset strategy.

