### PR TITLE
enhance(advisor): power cap service supports GetAdvice

### DIFF
--- a/pkg/agent/sysadvisor/plugin/poweraware/capper/instruction.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/capper/instruction.go
@@ -150,10 +150,13 @@ func GetCappingInstructions(response *advisorsvc.ListAndWatchResponse) ([]*CapIn
 	if len(response.ExtraEntries) == 0 {
 		return nil, errors.New("no valid data of no capping instruction")
 	}
+	return GetCappingInstructionsFromCalculationInfo(response.ExtraEntries)
+}
 
-	count := len(response.ExtraEntries)
+func GetCappingInstructionsFromCalculationInfo(calcInfos []*advisorsvc.CalculationInfo) ([]*CapInstruction, error) {
+	count := len(calcInfos)
 	cis := make([]*CapInstruction, count)
-	for i, calcInfo := range response.ExtraEntries {
+	for i, calcInfo := range calcInfos {
 		ci, err := getCappingInstructionFromCalcInfo(calcInfo)
 		if err != nil {
 			return nil, err

--- a/pkg/agent/sysadvisor/plugin/poweraware/capper/instruction.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/capper/instruction.go
@@ -54,17 +54,8 @@ type CapInstruction struct {
 
 func (c CapInstruction) ToListAndWatchResponse() *advisorsvc.ListAndWatchResponse {
 	return &advisorsvc.ListAndWatchResponse{
-		PodEntries: nil,
-		ExtraEntries: []*advisorsvc.CalculationInfo{{
-			CgroupPath: "",
-			CalculationResult: &advisorsvc.CalculationResult{
-				Values: map[string]string{
-					keyOpCode:         string(c.OpCode),
-					keyOpCurrentValue: c.OpCurrentValue,
-					keyOpTargetValue:  c.OpTargetValue,
-				},
-			},
-		}},
+		PodEntries:   nil,
+		ExtraEntries: []*advisorsvc.CalculationInfo{wrapCapInst(c)},
 	}
 }
 
@@ -84,6 +75,26 @@ func (c CapInstruction) ToCapRequest() (opCode PowerCapOpCode, targetValue, curr
 	}
 
 	return opCode, targetValue, currentValue
+}
+
+func wrapCapInst(c CapInstruction) *advisorsvc.CalculationInfo {
+	return &advisorsvc.CalculationInfo{
+		CgroupPath: "",
+		CalculationResult: &advisorsvc.CalculationResult{
+			Values: map[string]string{
+				keyOpCode:         string(c.OpCode),
+				keyOpCurrentValue: c.OpCurrentValue,
+				keyOpTargetValue:  c.OpTargetValue,
+			},
+		},
+	}
+}
+
+func (c CapInstruction) ToAdviceResponse() *advisorsvc.GetAdviceResponse {
+	return &advisorsvc.GetAdviceResponse{
+		PodEntries:   nil,
+		ExtraEntries: []*advisorsvc.CalculationInfo{wrapCapInst(c)},
+	}
 }
 
 func getCappingInstructionFromCalcInfo(info *advisorsvc.CalculationInfo) (*CapInstruction, error) {

--- a/pkg/agent/sysadvisor/plugin/poweraware/capper/server/service.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/capper/server/service.go
@@ -42,14 +42,14 @@ const (
 	// ServiceNamePowerCap also is the unix socket name of the server is listening on
 	ServiceNamePowerCap = "node_power_cap"
 
-	metricServerGetAdviceCalled = "pap_get_advice_called"
-
 	pollingTimeout = time.Second * 60
 
 	// MetadataApplyPreviousReset is the custom information from power cap client to power cap advisor that
 	// allows client to catch up with the reset it just missed by specifying x-apply-previous-reset:yes.
 	// Typically, the client should not carry this metadata info anymore with the successive GetAdvice calls.
 	MetadataApplyPreviousReset = "x-apply-previous-reset"
+
+	MetadataValueYes = "yes"
 )
 
 type longPoller struct {
@@ -144,12 +144,12 @@ func (p *powerCapService) GetAdvice(ctx context.Context, request *advisorsvc.Get
 // getAdviceWithClientReadySignal has test hook point clientReadyCh, which serves as client signal that it has got hold of
 // data-ready channel and server can 'broadcast' the test update
 func (p *powerCapService) getAdviceWithClientReadySignal(ctx context.Context, request *advisorsvc.GetAdviceRequest, clientReadyCh chan<- struct{}) (*advisorsvc.GetAdviceResponse, error) {
-	_ = p.emitter.StoreInt64(metricServerGetAdviceCalled, 1, metrics.MetricTypeNameCount)
+	powermetric.EmitGetAdviceCalled(p.emitter)
 	general.InfofV(6, "pap: get advice request: %v", general.ToString(request))
 
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		toApplyPreviousReset := md.Get(MetadataApplyPreviousReset)
-		if len(toApplyPreviousReset) > 0 && toApplyPreviousReset[0] == "yes" {
+		if len(toApplyPreviousReset) > 0 && toApplyPreviousReset[0] == MetadataValueYes {
 			if p.hadReset() {
 				return p.getAdvice(ctx, request)
 			}

--- a/pkg/agent/sysadvisor/plugin/poweraware/metric/emit_metric.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/metric/emit_metric.go
@@ -81,3 +81,7 @@ func EmitErrorCode(emitter metrics.MetricEmitter, cause ErrorCause) {
 		})...,
 	)
 }
+
+func EmitGetAdviceCalled(emitter metrics.MetricEmitter) {
+	_ = emitter.StoreInt64(metricGetAdviceCalled, 1, metrics.MetricTypeNameCount)
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/metric/metric_tag.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/metric/metric_tag.go
@@ -25,6 +25,7 @@ const (
 	metricPowerCappingTarget           = "node_power_cap_target"
 	metricPowerCappingCurrent          = "node_power_cap_current"
 	metricPowerError                   = "node_power_error"
+	metricGetAdviceCalled              = "node_power_get_advice"
 
 	tagPowerAlert         = "alert"
 	tagPowerInternalOp    = "internal_op"


### PR DESCRIPTION
#### What type of PR is this?
Enhancements - power cap advisor supports GetAdvice unary GRPC protocol, with long polling ability

#### What this PR does / why we need it:
This PR implements GetAdvice method of new advisor-qrm communication protocol. To avoid communication overhead, it  leverages long-polling so as to reduce the client requests resulting empty responses.
