### PR TITLE
fix(network): check if sysfs is mounted before mounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: ## Run go test against code.
-	go test -v -coverprofile=coverage.txt -parallel=16 -p=16 -covermode=atomic -race -coverpkg=./... \
+	go test -v -coverprofile=coverage.txt -parallel=16 -p=16 -covermode=atomic -race -coverpkg=./... -gcflags=all="-l"\
 		`go list ./pkg/... | grep -E -v "pkg/scheduler|pkg/controller/resource-recommend|pkg/util/resource-recommend"`
 
 .PHONY: license

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/h2non/gock v1.2.0
 	github.com/klauspost/cpuid/v2 v2.2.6
 	github.com/kubewharf/katalyst-api v0.5.3-0.20250409032616-8011e0283b31
+	github.com/moby/sys/mountinfo v0.6.2
 	github.com/montanaflynn/stats v0.7.1
 	github.com/opencontainers/runc v1.1.6
 	github.com/opencontainers/selinux v1.10.0
@@ -108,7 +109,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
-	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/pkg/util/machine/network_linux_test.go
+++ b/pkg/util/machine/network_linux_test.go
@@ -20,225 +20,448 @@ limitations under the License.
 package machine
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"testing"
+	"time"
 
-	"github.com/bytedance/mockey"
+	. "github.com/bytedance/mockey"
 	"github.com/moby/sys/mountinfo"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/vishvananda/netns"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
-	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
 
-func testDoNetNS() {
-	Convey("Test DoNetNS", func() {
-		Convey("non-default namespace", func() {
-			mockey.PatchConvey("should handle mount/unmount correctly", func() {
-				mockMkdirAll := mockey.Mock(os.MkdirAll).Return(nil).Build()
-				mockMount := mockey.Mock(syscall.Mount).Return(nil).Build()
-				mockUnmount := mockey.Mock(syscall.Unmount).Return(nil).Build()
-				mockGetFromPath := mockey.Mock(netns.GetFromPath).Return(netns.NsHandle(1), nil).Build()
-				mockSet := mockey.Mock(netns.Set).Return(nil).Build()
-				mockMounted := mockey.Mock(mountinfo.Mounted).Return(true, nil).Build()
-
-				defer func() {
-					mockMkdirAll.UnPatch()
-					mockMount.UnPatch()
-					mockUnmount.UnPatch()
-					mockGetFromPath.UnPatch()
-					mockSet.UnPatch()
-					mockMounted.UnPatch()
-				}()
-
-				err := DoNetNS("test-ns", "/test/path", func(sysFsDir, nsAbsPath string) error {
-					return nil
-				})
-				So(err, ShouldBeNil)
-			})
-		})
-
-		Convey("error cases", func() {
-			mockey.PatchConvey("should handle mount error", func() {
-				mockMkdirAll := mockey.Mock(os.MkdirAll).Return(nil).Build()
-				mockMount := mockey.Mock(syscall.Mount).Return(fmt.Errorf("mount error")).Build()
-				mockGetFromPath := mockey.Mock(netns.GetFromPath).Return(netns.NsHandle(1), nil).Build()
-				mockSet := mockey.Mock(netns.Set).Return(nil).Build()
-
-				defer func() {
-					mockMkdirAll.UnPatch()
-					mockMount.UnPatch()
-					mockGetFromPath.UnPatch()
-					mockSet.UnPatch()
-				}()
-
-				err := DoNetNS("test-ns", "/test/path", func(sysFsDir, nsAbsPath string) error {
-					return nil
-				})
-				So(err, ShouldNotBeNil)
-			})
-		})
-	})
+// MockFileInfo is a mock implementation of os.FileInfo for testing purposes.
+type MockFileInfo struct {
+	name    string
+	isDir   bool
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	sys     interface{}
 }
 
-func testGetNSNetworkHardwareTopology() {
-	Convey("Test getNSNetworkHardwareTopology", func() {
-		Convey("single namespace case", func() {
-			mockey.PatchConvey("should return network interfaces for single namespace", func() {
-				mockDoNetNS := mockey.Mock(DoNetNS).Return(nil).Build()
-				mockReadDir := mockey.Mock(os.ReadDir).Return([]os.DirEntry{}, nil).Build()
-				mockEvalSymlinks := mockey.Mock(filepath.EvalSymlinks).Return("", nil).Build()
-				mockGetInterfaceAddr := mockey.Mock(getInterfaceAddr).Return(map[string]*IfaceAddr{}, nil).Build()
+func (m MockFileInfo) Name() string       { return m.name }
+func (m MockFileInfo) IsDir() bool        { return m.isDir }
+func (m MockFileInfo) Size() int64        { return m.size }
+func (m MockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m MockFileInfo) ModTime() time.Time { return m.modTime }
+func (m MockFileInfo) Sys() interface{}   { return m.sys }
 
-				defer func() {
-					mockDoNetNS.UnPatch()
-					mockReadDir.UnPatch()
-					mockEvalSymlinks.UnPatch()
-					mockGetInterfaceAddr.UnPatch()
-				}()
-
-				result, err := getNSNetworkHardwareTopology("test-ns", "/test/path")
-				So(err, ShouldBeNil)
-				So(result, ShouldNotBeNil)
-			})
-		})
-
-		Convey("error cases", func() {
-			mockey.PatchConvey("should handle DoNetNS error", func() {
-				mockDoNetNS := mockey.Mock(DoNetNS).Return(fmt.Errorf("test error")).Build()
-				defer mockDoNetNS.UnPatch()
-
-				_, err := getNSNetworkHardwareTopology("test-ns", "/test/path")
-				So(err, ShouldNotBeNil)
-			})
-
-			mockey.PatchConvey("should handle ReadDir error", func() {
-				mockDoNetNS := mockey.Mock(DoNetNS).Return(nil).Build()
-				mockReadDir := mockey.Mock(os.ReadDir).Return(nil, fmt.Errorf("test error")).Build()
-				defer func() {
-					mockDoNetNS.UnPatch()
-					mockReadDir.UnPatch()
-				}()
-
-				_, err := getNSNetworkHardwareTopology("test-ns", "/test/path")
-				So(err, ShouldNotBeNil)
-			})
-		})
-	})
-}
-
-func testGetInterfaceAttr() {
-	Convey("Test getInterfaceAttr", func() {
-		mockey.PatchConvey("should get interface attributes successfully", func() {
-			mockReadFileIntoInt := mockey.Mock(general.ReadFileIntoInt).Return(1, nil).Build()
-			mockIsPathExists := mockey.Mock(general.IsPathExists).Return(true).Build()
-			mockReadFileIntoLines := mockey.Mock(general.ReadFileIntoLines).Return([]string{"up"}, nil).Build()
-			defer func() {
-				mockReadFileIntoInt.UnPatch()
-				mockIsPathExists.UnPatch()
-				mockReadFileIntoLines.UnPatch()
-			}()
-
-			info := &InterfaceInfo{Iface: "eth0"}
-			getInterfaceAttr(info, "/sys/class/net/eth0")
-			So(info.NumaNode, ShouldEqual, 1)
-			So(info.Enable, ShouldBeTrue)
-			So(info.Speed, ShouldEqual, 1)
-		})
-
-		mockey.PatchConvey("should handle read file errors", func() {
-			mockReadFileIntoInt := mockey.Mock(general.ReadFileIntoInt).Return(-1, fmt.Errorf("test error")).Build()
-			mockIsPathExists := mockey.Mock(general.IsPathExists).Return(false).Build()
-			mockReadFileIntoLines := mockey.Mock(general.ReadFileIntoLines).Return(nil, fmt.Errorf("test error")).Build()
-			defer func() {
-				mockReadFileIntoInt.UnPatch()
-				mockIsPathExists.UnPatch()
-				mockReadFileIntoLines.UnPatch()
-			}()
-
-			info := &InterfaceInfo{Iface: "eth0"}
-			getInterfaceAttr(info, "/sys/class/net/eth0")
-			So(info.NumaNode, ShouldEqual, -1)
-			So(info.Enable, ShouldBeFalse)
-			So(info.Speed, ShouldEqual, -1)
-		})
-	})
-}
-
-func TestGetExtraNetworkInfo(t *testing.T) {
+func Test_Network(t *testing.T) {
 	t.Parallel()
-	Convey("Test GetExtraNetworkInfo", t, func() {
-		testGetNSNetworkHardwareTopology()
-		testDoNetNS()
-		testGetInterfaceAttr()
+	testDoNetNS(t)
+	testGetNSNetworkHardwareTopology(t)
+	testGetExtraNetworkInfo(t)
+}
 
-		Convey("default case", func() {
-			mockey.PatchConvey("should return empty network info when config is nil", func() {
-				result, err := GetExtraNetworkInfo(nil)
+func testGetExtraNetworkInfo(t *testing.T) {
+	PatchConvey("Test GetExtraNetworkInfo", t, func() {
+		// Mock dependencies and setup
+		conf := &global.MachineInfoConfiguration{}
+
+		PatchConvey("Test NetMultipleNS is false", func() {
+			conf.NetMultipleNS = false
+			PatchConvey("Test getNSNetworkHardwareTopology success", func() {
+				expectedNics := []InterfaceInfo{{Iface: "eth0", IfIndex: 1, Speed: 1000, NumaNode: 0, Enable: true}}
+				Mock(getNSNetworkHardwareTopology).Return(expectedNics, nil).Build()
+				actual, err := GetExtraNetworkInfo(conf)
+				So(actual, ShouldNotBeNil)
 				So(err, ShouldBeNil)
-				So(result, ShouldNotBeNil)
-				So(len(result.Interface), ShouldEqual, 0)
+				So(actual.Interface, ShouldResemble, expectedNics)
 			})
-		})
-
-		Convey("single namespace case", func() {
-			mockey.PatchConvey("should return network info from default namespace", func() {
-				mockGetNSNetworkHardwareTopology := mockey.Mock(getNSNetworkHardwareTopology).Return([]InterfaceInfo{{
-					Iface:    "eth0",
-					NumaNode: 0,
-					Enable:   true,
-				}}, nil).Build()
-				defer mockGetNSNetworkHardwareTopology.UnPatch()
-
-				conf := &global.MachineInfoConfiguration{
-					NetMultipleNS: false,
-				}
-
-				result, err := GetExtraNetworkInfo(conf)
-				So(err, ShouldBeNil)
-				So(result, ShouldNotBeNil)
-				So(len(result.Interface), ShouldEqual, 1)
-			})
-		})
-
-		Convey("multiple namespace case", func() {
-			mockey.PatchConvey("should return network info from multiple namespaces", func() {
-				mockGetNSNetworkHardwareTopology := mockey.Mock(getNSNetworkHardwareTopology).Return([]InterfaceInfo{{
-					Iface:    "eth0",
-					NumaNode: 0,
-					Enable:   true,
-				}}, nil).Build()
-				defer mockGetNSNetworkHardwareTopology.UnPatch()
-
-				conf := &global.MachineInfoConfiguration{
-					NetMultipleNS:   true,
-					NetNSDirAbsPath: "/test/path",
-				}
-
-				result, err := GetExtraNetworkInfo(conf)
-				So(err, ShouldBeNil)
-				So(result, ShouldNotBeNil)
-				So(len(result.Interface), ShouldEqual, 1)
-			})
-		})
-
-		Convey("error cases", func() {
-			mockey.PatchConvey("should return error when getNSNetworkHardwareTopology fails", func() {
-				mockGetNSNetworkHardwareTopology := mockey.Mock(getNSNetworkHardwareTopology).Return(nil, fmt.Errorf("test error")).Build()
-				defer mockGetNSNetworkHardwareTopology.UnPatch()
-
-				conf := &global.MachineInfoConfiguration{
-					NetMultipleNS: false,
-				}
-
-				result, err := GetExtraNetworkInfo(conf)
+			PatchConvey("Test getNSNetworkHardwareTopology failed", func() {
+				Mock(getNSNetworkHardwareTopology).Return(nil, errors.New("failed to get network topology")).Build()
+				actual, err := GetExtraNetworkInfo(conf)
+				So(actual, ShouldBeNil)
 				So(err, ShouldNotBeNil)
-				So(result, ShouldBeNil)
+			})
+		})
+
+		PatchConvey("Test NetMultipleNS is true", func() {
+			conf.NetMultipleNS = true
+			PatchConvey("Test NetNSDirAbsPath is empty", func() {
+				conf.NetNSDirAbsPath = ""
+				actual, err := GetExtraNetworkInfo(conf)
+				So(actual, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+			})
+
+			PatchConvey("Test ReadDir failed", func() {
+				conf.NetNSDirAbsPath = "/valid/path"
+				Mock(ioutil.ReadDir).Return(nil, errors.New("failed to read directory")).Build()
+				actual, err := GetExtraNetworkInfo(conf)
+				So(actual, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+			})
+
+			PatchConvey("Test ReadDir success", func() {
+				conf.NetNSDirAbsPath = "/valid/path"
+				Mock(ioutil.ReadDir).Return([]os.FileInfo{
+					MockFileInfo{name: "ns1", isDir: true},
+					MockFileInfo{name: "ns2", isDir: true},
+				}, nil).Build()
+				PatchConvey("Test getNSNetworkHardwareTopology for all namespaces success", func() {
+					expectedNics := []InterfaceInfo{
+						{Iface: "eth0", IfIndex: 1, Speed: 1000, NumaNode: 0, Enable: true},
+						{Iface: "eth1", IfIndex: 2, Speed: 1000, NumaNode: 1, Enable: true},
+					}
+					Mock(getNSNetworkHardwareTopology).Return(expectedNics, nil).Build()
+					actual, err := GetExtraNetworkInfo(conf)
+					So(actual, ShouldNotBeNil)
+					So(err, ShouldBeNil)
+					So(len(actual.Interface), ShouldEqual, len(expectedNics)) // Since we have two namespaces
+				})
+				PatchConvey("Test getNSNetworkHardwareTopology for some namespaces failed", func() {
+					Mock(getNSNetworkHardwareTopology).Return(nil, errors.New("failed to get network topology")).Build()
+					actual, err := GetExtraNetworkInfo(conf)
+					So(actual, ShouldNotBeNil)
+					So(err, ShouldBeNil)
+					So(len(actual.Interface), ShouldEqual, 0) // Since all getNSNetworkHardwareTopology calls failed
+				})
 			})
 		})
 	})
+}
+
+func testGetNSNetworkHardwareTopology(t *testing.T) {
+	nsName := "test-ns"
+	netNSDirAbsPath := "/path/to/netns"
+
+	PatchConvey("Test DoNetNS failed", t, func() {
+		Mock(DoNetNS).Return(errors.New("DoNetNS failed")).Build()
+		actual, err := getNSNetworkHardwareTopology(nsName, netNSDirAbsPath)
+		So(actual, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	PatchConvey("Test DoNetNS success", t, func() {
+		Mock(DoNetNS).To(func(nsName, netNSDirAbsPath string, cb func(sysFsDir, nsAbsPath string) error) error {
+			return cb("", "")
+		}).Build()
+		PatchConvey("Test os.ReadDir failed", func() {
+			Mock(os.ReadDir).Return(nil, errors.New("ReadDir failed")).Build()
+			actual, err := getNSNetworkHardwareTopology(nsName, netNSDirAbsPath)
+			So(actual, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+
+		PatchConvey("Test os.ReadDir success", func() {
+			Mock(os.ReadDir).Return([]os.DirEntry{
+				fs.FileInfoToDirEntry(MockFileInfo{name: "eth0"}),
+			}, nil).Build()
+			PatchConvey("Test getInterfaceAddr failed", func() {
+				Mock(getInterfaceAddr).Return(nil, errors.New("getInterfaceAddr failed")).Build()
+				actual, err := getNSNetworkHardwareTopology(nsName, netNSDirAbsPath)
+				So(actual, ShouldBeNil)
+				So(err, ShouldNotBeNil)
+			})
+
+			PatchConvey("Test getInterfaceAddr success", func() {
+				Mock(getInterfaceAddr).Return(map[string]*IfaceAddr{
+					"eth0": {},
+				}, nil).Build()
+				PatchConvey("Test filepath.EvalSymlinks failed", func() {
+					Mock(filepath.EvalSymlinks).Return("", errors.New("EvalSymlinks failed")).Build()
+					actual, err := getNSNetworkHardwareTopology(nsName, netNSDirAbsPath)
+					So(actual, ShouldBeNil)
+					So(err, ShouldBeNil)
+				})
+
+				PatchConvey("Test filepath.EvalSymlinks success", func() {
+					Mock(filepath.EvalSymlinks).Return("/path/to/device", nil).Build()
+					PatchConvey("Test NIC is not PCI and not in bondingNICs", func() {
+						Mock(getBondingNetworkInterfaces).Return(sets.String{}).Build()
+						actual, err := getNSNetworkHardwareTopology(nsName, netNSDirAbsPath)
+						So(actual, ShouldBeEmpty)
+						So(err, ShouldBeNil)
+					})
+
+					PatchConvey("Test NIC is PCI or in bondingNICs", func() {
+						Mock(getBondingNetworkInterfaces).Return(sets.NewString("eth0")).Build()
+						PatchConvey("Test getInterfaceIndex and getInterfaceAttr", func() {
+							// Mock getInterfaceIndex and getInterfaceAttr to modify the InterfaceInfo object
+							Mock(getInterfaceIndex).Build()
+							Mock(getInterfaceAttr).Build()
+							actual, err := getNSNetworkHardwareTopology(nsName, netNSDirAbsPath)
+							So(actual, ShouldNotBeEmpty)
+							So(err, ShouldBeNil)
+						})
+					})
+				})
+			})
+		})
+	})
+}
+
+// testDoNetNS tests the DoNetNS function with various scenarios using table-driven tests.
+func testDoNetNS(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name                   string
+		nsName                 string
+		netNSDirAbsPath        string
+		mockSetup              func()
+		expectError            bool
+		expectedErrorSubstring string
+		cb                     func(sysFsDir, nsAbsPath string) error
+	}{
+		{
+			name:            "Default namespace",
+			nsName:          DefaultNICNamespace,
+			netNSDirAbsPath: "/test/path",
+			mockSetup:       func() {},
+			expectError:     false,
+			cb: func(sysFsDir, nsAbsPath string) error {
+				So(sysFsDir, ShouldEqual, sysFSDirNormal)
+				So(nsAbsPath, ShouldBeEmpty)
+				return nil
+			},
+		},
+		{
+			name:            "Custom namespace - Success case",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, nil).Build()
+				Mock(mountinfo.Mounted).Return(false, nil).Build()
+				Mock(syscall.Mount).Return(nil).Build()
+				Mock(syscall.Unmount).Return(nil).Build()
+			},
+			expectError: false,
+			cb: func(sysFsDir, nsAbsPath string) error {
+				So(sysFsDir, ShouldEqual, sysFSDirNetNSTmp)
+				So(nsAbsPath, ShouldEqual, "/test/path/custom-ns")
+				return nil
+			},
+		},
+		{
+			name:            "Custom namespace - Get error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(0), fmt.Errorf("get error")).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "get error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - GetFromPath error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(0), fmt.Errorf("get from path error")).Build()
+				Mock(netns.Set).Return(nil).Build() // Mock Set to handle the defer call
+			},
+			expectError:            true,
+			expectedErrorSubstring: "get from path error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - Set error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).To(func(ns netns.NsHandle) (err error) {
+					if ns == netns.NsHandle(1) { // Mock the Set back to original NS
+						return nil
+					} else {
+						return fmt.Errorf("set error")
+					}
+				}).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "set error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - Stat error (not ErrNotExist)",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, fmt.Errorf("stat error")).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "check dir: /tmp/net_ns_sysfs failed with error: stat error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - MkdirAll error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, os.ErrNotExist).Build()
+				Mock(os.MkdirAll).Return(fmt.Errorf("mkdir error")).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "make dir: /tmp/net_ns_sysfs failed with error: mkdir error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - Mounted check error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, nil).Build()
+				Mock(mountinfo.Mounted).Return(false, fmt.Errorf("mounted check error")).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "check mounted dir: /tmp/net_ns_sysfs failed with error: mounted check error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - Mount error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, nil).Build()
+				Mock(mountinfo.Mounted).Return(false, nil).Build()
+				Mock(syscall.Mount).Return(fmt.Errorf("mount error")).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "mount sysfs to /tmp/net_ns_sysfs failed with error: mount error",
+			cb:                     func(sysFsDir, nsAbsPath string) error { return nil },
+		},
+		{
+			name:            "Custom namespace - Callback error",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, nil).Build()
+				Mock(mountinfo.Mounted).Return(false, nil).Build()
+				Mock(syscall.Mount).Return(nil).Build()
+				Mock(syscall.Unmount).Return(nil).Build()
+			},
+			expectError:            true,
+			expectedErrorSubstring: "callback error",
+			cb: func(sysFsDir, nsAbsPath string) error {
+				return fmt.Errorf("callback error")
+			},
+		},
+		{
+			name:            "Custom namespace - SysFs already mounted",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, nil).Build()
+				Mock(mountinfo.Mounted).Return(true, nil).Build()
+				// syscall.Mount should not be called
+				Mock(syscall.Unmount).Return(nil).Build()
+			},
+			expectError: false,
+			cb: func(sysFsDir, nsAbsPath string) error {
+				So(sysFsDir, ShouldEqual, sysFSDirNetNSTmp)
+				So(nsAbsPath, ShouldEqual, "/test/path/custom-ns")
+				return nil
+			},
+		},
+		{
+			name:            "Custom namespace - SysFs does not exist, MkdirAll succeeds",
+			nsName:          "custom-ns",
+			netNSDirAbsPath: "/test/path",
+			mockSetup: func() {
+				Mock(runtime.LockOSThread).Build()
+				Mock(runtime.UnlockOSThread).Build()
+				Mock(netns.Get).Return(netns.NsHandle(1), nil).Build()
+				Mock((*netns.NsHandle).Close).Return(nil).Build()
+				Mock(netns.GetFromPath).Return(netns.NsHandle(2), nil).Build()
+				Mock(netns.Set).Return(nil).Build()
+				Mock(os.Stat).Return(nil, os.ErrNotExist).Build()
+				Mock(os.MkdirAll).Return(nil).Build()
+				Mock(mountinfo.Mounted).Return(false, nil).Build()
+				Mock(syscall.Mount).Return(nil).Build()
+				Mock(syscall.Unmount).Return(nil).Build()
+			},
+			expectError: false,
+			cb: func(sysFsDir, nsAbsPath string) error {
+				So(sysFsDir, ShouldEqual, sysFSDirNetNSTmp)
+				So(nsAbsPath, ShouldEqual, "/test/path/custom-ns")
+				return nil
+			},
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		PatchConvey(tc.name, t, func() {
+			// Arrange
+			tc.mockSetup()
+
+			// Act
+			err := DoNetNS(tc.nsName, tc.netNSDirAbsPath, tc.cb)
+
+			// Assert
+			if tc.expectError {
+				So(err, ShouldNotBeNil)
+				if tc.expectedErrorSubstring != "" {
+					So(err.Error(), ShouldContainSubstring, tc.expectedErrorSubstring)
+				}
+			} else {
+				So(err, ShouldBeNil)
+			}
+		})
+	}
 }

--- a/pkg/util/machine/network_linux_test.go
+++ b/pkg/util/machine/network_linux_test.go
@@ -20,78 +20,225 @@ limitations under the License.
 package machine
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/bytedance/mockey"
+	"github.com/moby/sys/mountinfo"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/vishvananda/netns"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
+
+func testDoNetNS() {
+	Convey("Test DoNetNS", func() {
+		Convey("non-default namespace", func() {
+			mockey.PatchConvey("should handle mount/unmount correctly", func() {
+				mockMkdirAll := mockey.Mock(os.MkdirAll).Return(nil).Build()
+				mockMount := mockey.Mock(syscall.Mount).Return(nil).Build()
+				mockUnmount := mockey.Mock(syscall.Unmount).Return(nil).Build()
+				mockGetFromPath := mockey.Mock(netns.GetFromPath).Return(netns.NsHandle(1), nil).Build()
+				mockSet := mockey.Mock(netns.Set).Return(nil).Build()
+				mockMounted := mockey.Mock(mountinfo.Mounted).Return(true, nil).Build()
+
+				defer func() {
+					mockMkdirAll.UnPatch()
+					mockMount.UnPatch()
+					mockUnmount.UnPatch()
+					mockGetFromPath.UnPatch()
+					mockSet.UnPatch()
+					mockMounted.UnPatch()
+				}()
+
+				err := DoNetNS("test-ns", "/test/path", func(sysFsDir, nsAbsPath string) error {
+					return nil
+				})
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("error cases", func() {
+			mockey.PatchConvey("should handle mount error", func() {
+				mockMkdirAll := mockey.Mock(os.MkdirAll).Return(nil).Build()
+				mockMount := mockey.Mock(syscall.Mount).Return(fmt.Errorf("mount error")).Build()
+				mockGetFromPath := mockey.Mock(netns.GetFromPath).Return(netns.NsHandle(1), nil).Build()
+				mockSet := mockey.Mock(netns.Set).Return(nil).Build()
+
+				defer func() {
+					mockMkdirAll.UnPatch()
+					mockMount.UnPatch()
+					mockGetFromPath.UnPatch()
+					mockSet.UnPatch()
+				}()
+
+				err := DoNetNS("test-ns", "/test/path", func(sysFsDir, nsAbsPath string) error {
+					return nil
+				})
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func testGetNSNetworkHardwareTopology() {
+	Convey("Test getNSNetworkHardwareTopology", func() {
+		Convey("single namespace case", func() {
+			mockey.PatchConvey("should return network interfaces for single namespace", func() {
+				mockDoNetNS := mockey.Mock(DoNetNS).Return(nil).Build()
+				mockReadDir := mockey.Mock(os.ReadDir).Return([]os.DirEntry{}, nil).Build()
+				mockEvalSymlinks := mockey.Mock(filepath.EvalSymlinks).Return("", nil).Build()
+				mockGetInterfaceAddr := mockey.Mock(getInterfaceAddr).Return(map[string]*IfaceAddr{}, nil).Build()
+
+				defer func() {
+					mockDoNetNS.UnPatch()
+					mockReadDir.UnPatch()
+					mockEvalSymlinks.UnPatch()
+					mockGetInterfaceAddr.UnPatch()
+				}()
+
+				result, err := getNSNetworkHardwareTopology("test-ns", "/test/path")
+				So(err, ShouldBeNil)
+				So(result, ShouldNotBeNil)
+			})
+		})
+
+		Convey("error cases", func() {
+			mockey.PatchConvey("should handle DoNetNS error", func() {
+				mockDoNetNS := mockey.Mock(DoNetNS).Return(fmt.Errorf("test error")).Build()
+				defer mockDoNetNS.UnPatch()
+
+				_, err := getNSNetworkHardwareTopology("test-ns", "/test/path")
+				So(err, ShouldNotBeNil)
+			})
+
+			mockey.PatchConvey("should handle ReadDir error", func() {
+				mockDoNetNS := mockey.Mock(DoNetNS).Return(nil).Build()
+				mockReadDir := mockey.Mock(os.ReadDir).Return(nil, fmt.Errorf("test error")).Build()
+				defer func() {
+					mockDoNetNS.UnPatch()
+					mockReadDir.UnPatch()
+				}()
+
+				_, err := getNSNetworkHardwareTopology("test-ns", "/test/path")
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func testGetInterfaceAttr() {
+	Convey("Test getInterfaceAttr", func() {
+		mockey.PatchConvey("should get interface attributes successfully", func() {
+			mockReadFileIntoInt := mockey.Mock(general.ReadFileIntoInt).Return(1, nil).Build()
+			mockIsPathExists := mockey.Mock(general.IsPathExists).Return(true).Build()
+			mockReadFileIntoLines := mockey.Mock(general.ReadFileIntoLines).Return([]string{"up"}, nil).Build()
+			defer func() {
+				mockReadFileIntoInt.UnPatch()
+				mockIsPathExists.UnPatch()
+				mockReadFileIntoLines.UnPatch()
+			}()
+
+			info := &InterfaceInfo{Iface: "eth0"}
+			getInterfaceAttr(info, "/sys/class/net/eth0")
+			So(info.NumaNode, ShouldEqual, 1)
+			So(info.Enable, ShouldBeTrue)
+			So(info.Speed, ShouldEqual, 1)
+		})
+
+		mockey.PatchConvey("should handle read file errors", func() {
+			mockReadFileIntoInt := mockey.Mock(general.ReadFileIntoInt).Return(-1, fmt.Errorf("test error")).Build()
+			mockIsPathExists := mockey.Mock(general.IsPathExists).Return(false).Build()
+			mockReadFileIntoLines := mockey.Mock(general.ReadFileIntoLines).Return(nil, fmt.Errorf("test error")).Build()
+			defer func() {
+				mockReadFileIntoInt.UnPatch()
+				mockIsPathExists.UnPatch()
+				mockReadFileIntoLines.UnPatch()
+			}()
+
+			info := &InterfaceInfo{Iface: "eth0"}
+			getInterfaceAttr(info, "/sys/class/net/eth0")
+			So(info.NumaNode, ShouldEqual, -1)
+			So(info.Enable, ShouldBeFalse)
+			So(info.Speed, ShouldEqual, -1)
+		})
+	})
+}
 
 func TestGetExtraNetworkInfo(t *testing.T) {
 	t.Parallel()
+	Convey("Test GetExtraNetworkInfo", t, func() {
+		testGetNSNetworkHardwareTopology()
+		testDoNetNS()
+		testGetInterfaceAttr()
 
-	testCases := []struct {
-		description  string
-		noError      bool
-		conf         *global.MachineInfoConfiguration
-		expectedResp *ExtraNetworkInfo
-	}{
-		{
-			description: "single NS",
-			noError:     true,
-			conf: &global.MachineInfoConfiguration{
-				NetMultipleNS:   false,
-				NetNSDirAbsPath: "",
-			},
-			expectedResp: nil,
-		},
-		{
-			description: "multi NS",
-			noError:     false,
-			conf: &global.MachineInfoConfiguration{
-				NetMultipleNS:   true,
-				NetNSDirAbsPath: "",
-			},
-			expectedResp: nil,
-		},
-	}
+		Convey("default case", func() {
+			mockey.PatchConvey("should return empty network info when config is nil", func() {
+				result, err := GetExtraNetworkInfo(nil)
+				So(err, ShouldBeNil)
+				So(result, ShouldNotBeNil)
+				So(len(result.Interface), ShouldEqual, 0)
+			})
+		})
 
-	for _, tc := range testCases {
-		netInfo, err := GetExtraNetworkInfo(tc.conf)
-		if tc.noError {
-			assert.Nil(t, err)
-			assert.NotNil(t, netInfo)
-		} else {
-			assert.NotNil(t, err)
-			assert.Nil(t, netInfo)
-		}
-	}
-}
+		Convey("single namespace case", func() {
+			mockey.PatchConvey("should return network info from default namespace", func() {
+				mockGetNSNetworkHardwareTopology := mockey.Mock(getNSNetworkHardwareTopology).Return([]InterfaceInfo{{
+					Iface:    "eth0",
+					NumaNode: 0,
+					Enable:   true,
+				}}, nil).Build()
+				defer mockGetNSNetworkHardwareTopology.UnPatch()
 
-func TestGetInterfaceAttr(t *testing.T) {
-	t.Parallel()
+				conf := &global.MachineInfoConfiguration{
+					NetMultipleNS: false,
+				}
 
-	nic := &InterfaceInfo{
-		Iface: "eth0",
-	}
+				result, err := GetExtraNetworkInfo(conf)
+				So(err, ShouldBeNil)
+				So(result, ShouldNotBeNil)
+				So(len(result.Interface), ShouldEqual, 1)
+			})
+		})
 
-	getInterfaceAttr(nic, "/sys/class/net")
-	assert.NotNil(t, nic)
-	assert.Equal(t, -1, nic.NumaNode)
-	assert.Equal(t, false, nic.Enable)
-}
+		Convey("multiple namespace case", func() {
+			mockey.PatchConvey("should return network info from multiple namespaces", func() {
+				mockGetNSNetworkHardwareTopology := mockey.Mock(getNSNetworkHardwareTopology).Return([]InterfaceInfo{{
+					Iface:    "eth0",
+					NumaNode: 0,
+					Enable:   true,
+				}}, nil).Build()
+				defer mockGetNSNetworkHardwareTopology.UnPatch()
 
-func TestGetInterfaceAddr(t *testing.T) {
-	t.Parallel()
+				conf := &global.MachineInfoConfiguration{
+					NetMultipleNS:   true,
+					NetNSDirAbsPath: "/test/path",
+				}
 
-	addr, err := getInterfaceAddr()
-	assert.NotNil(t, addr)
-	assert.Nil(t, err)
-}
+				result, err := GetExtraNetworkInfo(conf)
+				So(err, ShouldBeNil)
+				So(result, ShouldNotBeNil)
+				So(len(result.Interface), ShouldEqual, 1)
+			})
+		})
 
-func TestGetNSNetworkHardwareTopology(t *testing.T) {
-	t.Parallel()
+		Convey("error cases", func() {
+			mockey.PatchConvey("should return error when getNSNetworkHardwareTopology fails", func() {
+				mockGetNSNetworkHardwareTopology := mockey.Mock(getNSNetworkHardwareTopology).Return(nil, fmt.Errorf("test error")).Build()
+				defer mockGetNSNetworkHardwareTopology.UnPatch()
 
-	_, err := getNSNetworkHardwareTopology("", "")
-	assert.Nil(t, err)
+				conf := &global.MachineInfoConfiguration{
+					NetMultipleNS: false,
+				}
+
+				result, err := GetExtraNetworkInfo(conf)
+				So(err, ShouldNotBeNil)
+				So(result, ShouldBeNil)
+			})
+		})
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Add a check using the mountinfo package to verify if sysfs is already mounted before attempting to mount it. This prevents redundant mount operations and potential errors when switching network namespaces.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
