### PR TITLE
fix(tmo): remove target size zero check to fix swap not off

### DIFF
--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
@@ -2237,6 +2237,7 @@ func TestHandleAdvisorResp(t *testing.T) {
 	pod2UID := string(uuid.NewUUID())
 	pod3UID := string(uuid.NewUUID())
 	pod4UID := string(uuid.NewUUID())
+	pod5UID := string(uuid.NewUUID())
 	testName := "test"
 
 	testCases := []struct {
@@ -2357,10 +2358,24 @@ func TestHandleAdvisorResp(t *testing.T) {
 					pod4UID: {
 						ContainerEntries: map[string]*advisorsvc.CalculationInfo{
 							testName: {
+								CgroupPath: pod4UID,
 								CalculationResult: &advisorsvc.CalculationResult{
 									Values: map[string]string{
 										string(memoryadvisor.ControlKnobKeySwapMax):          coreconsts.ControlKnobON,
 										string(memoryadvisor.ControlKnowKeyMemoryOffloading): "40960",
+									},
+								},
+							},
+						},
+					},
+					pod5UID: {
+						ContainerEntries: map[string]*advisorsvc.CalculationInfo{
+							testName: {
+								CgroupPath: pod5UID,
+								CalculationResult: &advisorsvc.CalculationResult{
+									Values: map[string]string{
+										string(memoryadvisor.ControlKnobKeySwapMax):          coreconsts.ControlKnobOFF,
+										string(memoryadvisor.ControlKnowKeyMemoryOffloading): "0",
 									},
 								},
 							},

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor_test.go
@@ -1667,14 +1667,22 @@ func TestUpdate(t *testing.T) {
 							string(memoryadvisor.ControlKnowKeyMemoryOffloading): "96636764",
 						},
 					},
-					//{
-					//	PodUID:        "uid4",
-					//	ContainerName: "c4",
-					//	Values: map[string]string{
-					//		string(memoryadvisor.ControlKnobKeySwapMax):          coreconsts.ControlKnobOFF,
-					//		string(memoryadvisor.ControlKnowKeyMemoryOffloading): "96636764",
-					//	},
-					//},
+					{
+						PodUID:        "uid2",
+						ContainerName: "c2",
+						Values: map[string]string{
+							string(memoryadvisor.ControlKnobKeySwapMax):          coreconsts.ControlKnobOFF,
+							string(memoryadvisor.ControlKnowKeyMemoryOffloading): "0",
+						},
+					},
+					{
+						PodUID:        "uid4",
+						ContainerName: "c4",
+						Values: map[string]string{
+							string(memoryadvisor.ControlKnobKeySwapMax):          coreconsts.ControlKnobOFF,
+							string(memoryadvisor.ControlKnowKeyMemoryOffloading): "0",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/memory_offloading.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/memory_offloading.go
@@ -601,9 +601,6 @@ func (tmo *transparentMemoryOffloading) GetAdvices() types.InternalMemoryCalcula
 	tmo.mutex.RLock()
 	defer tmo.mutex.RUnlock()
 	for _, tmoEngine := range tmo.containerTmoEngines {
-		if tmoEngine.GetOffloadingTargetSize() <= 0 {
-			continue
-		}
 		enableSwap := consts.ControlKnobOFF
 		if tmoEngine.GetConf().EnableSwap {
 			enableSwap = consts.ControlKnobON
@@ -621,9 +618,6 @@ func (tmo *transparentMemoryOffloading) GetAdvices() types.InternalMemoryCalcula
 	}
 
 	for cgpath, tmoEngine := range tmo.cgpathTmoEngines {
-		if tmoEngine.GetOffloadingTargetSize() <= 0 {
-			continue
-		}
 		enableSwap := consts.ControlKnobOFF
 		if tmoEngine.GetConf().EnableSwap {
 			enableSwap = consts.ControlKnobON


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
remove memory advisor the check for offloading target size less than or equal to zero to fix swap not off when target pod tmo is disabled.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
