### PR TITLE
feat(qrm): support numa cpu pressure eviction

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/cpu_eviciton.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/cpu_eviciton.go
@@ -35,6 +35,7 @@ import (
 func init() {
 	RegisterCPUEvictionInitializer(strategy.EvictionNameLoad, strategy.NewCPUPressureLoadEviction)
 	RegisterCPUEvictionInitializer(strategy.EvictionNameSuppression, strategy.NewCPUPressureSuppressionEviction)
+	RegisterCPUEvictionInitializer(strategy.EvictionNameNumaCpuPressure, strategy.NewCPUPressureUsageEviction)
 }
 
 var cpuEvictionInitializers sync.Map

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/numa_history.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/numa_history.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"time"
+)
+
+const (
+	FakePodUID = ""
+)
+
+type NumaMetricHistory struct {
+	// numa -> pod -> metric -> ring
+	Inner    map[int]map[string]map[string]*MetricRing
+	RingSize int
+}
+
+func NewMetricHistory(ringSize int) *NumaMetricHistory {
+	return &NumaMetricHistory{
+		Inner:    make(map[int]map[string]map[string]*MetricRing),
+		RingSize: ringSize,
+	}
+}
+
+func (m *NumaMetricHistory) Push(numaID int, podUID string, metricName string, podMetric float64) {
+	collectTime := time.Now().UnixNano()
+
+	if m.Inner[numaID] == nil {
+		m.Inner[numaID] = make(map[string]map[string]*MetricRing)
+	}
+	if m.Inner[numaID][podUID] == nil {
+		m.Inner[numaID][podUID] = make(map[string]*MetricRing)
+	}
+	if m.Inner[numaID][podUID][metricName] == nil {
+		m.Inner[numaID][podUID][metricName] = CreateMetricRing(m.RingSize)
+	}
+	snapshot := &MetricSnapshot{
+		Info: MetricInfo{
+			Name:  metricName,
+			Value: podMetric,
+		},
+		Time: collectTime,
+	}
+	m.Inner[numaID][podUID][metricName].Push(snapshot)
+}
+
+func (m *NumaMetricHistory) PushNuma(numaID int, metricName string, podMetric float64) {
+	m.Push(numaID, FakePodUID, metricName, podMetric)
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_metric.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_metric.go
@@ -90,6 +90,14 @@ func (ring *MetricRing) Sum() float64 {
 	return sum
 }
 
+func (ring *MetricRing) Avg() float64 {
+	length := len(ring.Queue)
+	if length == 0 {
+		return 0
+	}
+	return ring.Sum() / float64(length)
+}
+
 func (ring *MetricRing) Push(snapShot *MetricSnapshot) {
 	ring.Lock()
 	defer ring.Unlock()
@@ -136,6 +144,23 @@ func (ring *MetricRing) Count() (softOverCount, hardOverCount int) {
 			if snapshot.Info.Value > snapshot.Info.UpperBound {
 				hardOverCount++
 			}
+		}
+	}
+	return
+}
+
+// OverCount pass threshold from outside
+func (ring *MetricRing) OverCount(threshold float64) (overCount int) {
+	ring.RLock()
+	defer ring.RUnlock()
+
+	for _, snapshot := range ring.Queue {
+		if snapshot == nil {
+			continue
+		}
+
+		if snapshot.Info.Value > threshold {
+			overCount++
 		}
 	}
 	return

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_numa.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_numa.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/helper"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/metric"
+	"github.com/kubewharf/katalyst-core/pkg/util/qos"
+)
+
+const EvictionNameNumaCpuPressure = "numa-cpu-pressure-plugin"
+
+const evictionConditionCPUUsagePressure = "NumaCPUPressure"
+
+const (
+	metricsNameNumaCollectMetricsCalled = "numa_cpu_pressure_usage_collect_metrics_called"
+	// metricsNamePodRaw  = "numa_cpu_pressure_pod_raw"
+	metricsNameNumaRaw = "numa_cpu_pressure_numa_raw"
+
+	metricsNameNumaThresholdMet = "numa_cpu_pressure_threshold_met"
+	metricsNameGetEvictPods     = "numa_cpu_pressure_get_evict_pods"
+
+	metricNameNumaOverloadNumaCount = "numa_cpu_pressure_overload_numa_count"
+	metricNameNumaOverloadRatio     = "numa_cpu_pressure_overload_ratio"
+	metricNameNumaOverloadTopPod    = "numa_cpu_pressure_overload_top_pod"
+
+	metricNameMetricNoThreshold = "numa_cpu_pressure_metric_no_threshold"
+
+	metricTagMetricName = "metric_name"
+	metricTagNuma       = "numa"
+	// metricTagPod        = "pod"
+	metricTagIsOverload = "is_overload"
+)
+
+var (
+	targetMetric = consts.MetricsCPUUsageNUMAContainer
+	// targetMetrics      = []string{consts.MetricCPUUsageContainer, consts.MetricLoad1MinContainer}
+	targetMetrics = []string{consts.MetricsCPUUsageNUMAContainer}
+)
+
+type NumaCPUPressureEviction struct {
+	sync.RWMutex
+	emitter    metrics.MetricEmitter
+	metaServer *metaserver.MetaServer
+
+	conf               *config.Configuration
+	numaPressureConfig *NumaPressureConfig
+
+	syncPeriod time.Duration
+
+	thresholds map[string]float64
+
+	metricsHistory    *NumaMetricHistory
+	overloadNumaCount int
+
+	enabled bool
+}
+
+func NewCPUPressureUsageEviction(emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer,
+	conf *config.Configuration, _ state.ReadonlyState,
+) (CPUPressureEviction, error) {
+	numaPressureConfig := &NumaPressureConfig{
+		MetricRingSize:         conf.DynamicAgentConfiguration.GetDynamicConfiguration().NumaCpuPressureMetricRingSize,
+		ThresholdMetPercentage: conf.DynamicAgentConfiguration.GetDynamicConfiguration().NumaCpuPressureThresholdMetPercentage,
+		GracePeriod:            conf.DynamicAgentConfiguration.GetDynamicConfiguration().NumaCpuPressureGracePeriod,
+		ExpandFactor:           conf.DynamicAgentConfiguration.GetDynamicConfiguration().NumaCpuThresholdExpandFactor,
+	}
+
+	return &NumaCPUPressureEviction{
+		emitter:            emitter,
+		metaServer:         metaServer,
+		conf:               conf,
+		numaPressureConfig: numaPressureConfig,
+		metricsHistory:     NewMetricHistory(numaPressureConfig.MetricRingSize),
+		syncPeriod:         15 * time.Second,
+	}, nil
+}
+
+func (p *NumaCPUPressureEviction) Start(ctx context.Context) (err error) {
+	general.Infof("%s", p.Name())
+
+	go wait.UntilWithContext(ctx, p.update, p.syncPeriod)
+	go wait.UntilWithContext(ctx, p.pullThresholds, p.syncPeriod)
+	return
+}
+
+func (p *NumaCPUPressureEviction) Name() string { return EvictionNameNumaCpuPressure }
+
+// todo may change to GetTopEvictionPods?
+func (p *NumaCPUPressureEviction) GetEvictPods(_ context.Context, request *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error) {
+	if request == nil {
+		return nil, fmt.Errorf("GetTopEvictionPods got nil request")
+	} else if len(request.ActivePods) == 0 {
+		general.Warningf("got empty active pods list")
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	p.RLock()
+	defer p.RUnlock()
+
+	if !p.enabled {
+		general.Infof("numa cpu pressure eviction is disabled")
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	if p.overloadNumaCount == 0 {
+		_ = p.emitter.StoreInt64(metricsNameGetEvictPods, 0, metrics.MetricTypeNameRaw)
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	// todo may pick multiple numas if overload
+	numaID, numaOverloadRatio, err := p.pickTopOverRatioNuma(targetMetric, p.thresholds)
+	if err != nil {
+		general.ErrorS(err, "pick top over ratio numa failed")
+		_ = p.emitter.StoreFloat64(metricsNameGetEvictPods, 0, metrics.MetricTypeNameRaw,
+			metrics.ConvertMapToTags(map[string]string{
+				metricTagMetricName: targetMetric,
+				metricTagNuma:       strconv.Itoa(numaID),
+			})...)
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	topPod, podUsageRatio, err := p.pickTopOverRatioPod(numaID, targetMetric, request.ActivePods)
+	if err != nil {
+		general.ErrorS(err, "pick top over ratio nums pods failed")
+		_ = p.emitter.StoreFloat64(metricsNameGetEvictPods, 0, metrics.MetricTypeNameRaw,
+			metrics.ConvertMapToTags(map[string]string{
+				metricTagMetricName: targetMetric,
+				metricTagNuma:       strconv.Itoa(numaID),
+			})...)
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	general.InfoS("evict pod", "pod", topPod.Name, "podUsageRatio",
+		podUsageRatio, "numa", numaID, "numaOverloadRatio", numaOverloadRatio)
+
+	resp := &pluginapi.GetEvictPodsResponse{
+		EvictPods: []*pluginapi.EvictPod{
+			{
+				Pod: topPod,
+				Reason: fmt.Sprintf("numa cpu usage %f overload, kill top pod with %f",
+					numaOverloadRatio, podUsageRatio),
+				ForceEvict:         true,
+				EvictionPluginName: EvictionNameNumaCpuPressure,
+			},
+		},
+	}
+
+	if gracePeriod := p.numaPressureConfig.GracePeriod; gracePeriod >= 0 {
+		deletionOptions := &pluginapi.DeletionOptions{
+			GracePeriodSeconds: gracePeriod,
+		}
+		for _, e := range resp.EvictPods {
+			e.DeletionOptions = deletionOptions
+		}
+	}
+
+	_ = p.emitter.StoreFloat64(metricsNameGetEvictPods, 1, metrics.MetricTypeNameRaw,
+		metrics.ConvertMapToTags(map[string]string{
+			metricTagMetricName: targetMetric,
+			metricTagNuma:       strconv.Itoa(numaID),
+		})...)
+
+	return resp, nil
+}
+
+func (p *NumaCPUPressureEviction) ThresholdMet(_ context.Context, _ *pluginapi.Empty,
+) (*pluginapi.ThresholdMetResponse, error) {
+	p.RLock()
+	defer p.RUnlock()
+
+	if !p.enabled {
+		general.Infof("numa cpu pressure eviction is disabled")
+		return &pluginapi.ThresholdMetResponse{
+			MetType: pluginapi.ThresholdMetType_NOT_MET,
+		}, nil
+	}
+
+	nodeOverload := p.isNodeOverload()
+
+	if !nodeOverload {
+		_ = p.emitter.StoreFloat64(metricsNameNumaThresholdMet, 0, metrics.MetricTypeNameRaw,
+			metrics.ConvertMapToTags(map[string]string{
+				metricTagMetricName: targetMetric,
+			})...)
+		return &pluginapi.ThresholdMetResponse{
+			MetType: pluginapi.ThresholdMetType_NOT_MET,
+		}, nil
+	}
+
+	_ = p.emitter.StoreFloat64(metricsNameNumaThresholdMet, 1, metrics.MetricTypeNameRaw,
+		metrics.ConvertMapToTags(map[string]string{
+			metricTagMetricName: targetMetric,
+		})...)
+
+	return &pluginapi.ThresholdMetResponse{
+		ThresholdValue:    1,
+		ObservedValue:     1,
+		ThresholdOperator: pluginapi.ThresholdOperator_GREATER_THAN,
+		MetType:           pluginapi.ThresholdMetType_HARD_MET,
+		EvictionScope:     targetMetric,
+		Condition: &pluginapi.Condition{
+			ConditionType: pluginapi.ConditionType_NODE_CONDITION,
+			Effects:       []string{string(v1.TaintEffectNoSchedule)},
+			ConditionName: evictionConditionCPUUsagePressure,
+			MetCondition:  true,
+		},
+	}, nil
+}
+
+func (p *NumaCPUPressureEviction) GetTopEvictionPods(_ context.Context, _ *pluginapi.GetTopEvictionPodsRequest,
+) (*pluginapi.GetTopEvictionPodsResponse, error) {
+	return &pluginapi.GetTopEvictionPodsResponse{}, nil
+}
+
+// 1 collect numa / pod level metrics
+// 2 update node / numa overload status
+func (p *NumaCPUPressureEviction) update(_ context.Context) {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.enabled {
+		general.Infof("numa cpu pressure eviction is disabled")
+		return
+	}
+
+	_ = p.emitter.StoreInt64(metricsNameNumaCollectMetricsCalled, 1, metrics.MetricTypeNameRaw)
+
+	snbPods, err := p.metaServer.GetPodList(context.Background(), func(pod *v1.Pod) bool {
+		isValid, err := p.conf.QoSConfiguration.CheckSharedQoSForPod(pod)
+		if err != nil || !isValid {
+			return false
+		}
+
+		return qos.IsPodNumaBinding(p.conf.QoSConfiguration, pod)
+	})
+	if err != nil {
+		general.Warningf("failed to check shared qos on pods: %v", err)
+		return
+	}
+
+	if len(snbPods) == 0 {
+		general.Warningf("find no shared_cores pods")
+		return
+	}
+
+	general.Infof("start to collect numa pod metrics, shared pods count %v", len(snbPods))
+	numaSize := p.metaServer.CPUsPerNuma()
+	// numa -> pod -> metric -> ring
+	for numaID := 0; numaID < p.metaServer.NumNUMANodes; numaID++ {
+		for _, pod := range snbPods {
+			podUID := string(pod.UID)
+			for _, metricName := range targetMetrics {
+				val, err := helper.GetPodMetric(p.metaServer.MetricsFetcher, p.emitter, pod, metricName, numaID)
+				if val == 0 {
+					continue
+				}
+				// calculate per core metric
+				// todo refactor
+				valRatio := val / float64(numaSize)
+
+				if err != nil {
+					general.Warningf("failed to get pod metric, numa %v, pod %v, metric %v err: %v",
+						numaID, pod.Name, metricName, err)
+					continue
+				}
+				p.metricsHistory.Push(numaID, podUID, metricName, valRatio)
+				general.InfoS("Push pod metric", "metric", metricName, "numa", numaID, "pod", pod.Name, "value", valRatio)
+			}
+		}
+		// numa level sum
+		for _, metricName := range targetMetrics {
+			val := p.metaServer.AggregatePodNumaMetric(snbPods, numaID, metricName, metric.AggregatorSum, metric.DefaultContainerMetricFilter).Value
+			// calculate per core metric
+			// todo refactor
+			valRatio := val / float64(numaSize)
+
+			p.metricsHistory.PushNuma(numaID, metricName, valRatio)
+			general.InfoS("Push numa metric", "metric", metricName, "numa", numaID, "value", valRatio)
+			_ = p.emitter.StoreFloat64(metricsNameNumaRaw, valRatio, metrics.MetricTypeNameRaw,
+				metrics.ConvertMapToTags(map[string]string{
+					metricTagMetricName: metricName,
+					metricTagNuma:       strconv.Itoa(numaID),
+				})...)
+		}
+	}
+
+	// update overload numa count and node overload
+	p.overloadNumaCount = p.calOverloadNumaCount()
+}
+
+func (p *NumaCPUPressureEviction) isNodeOverload() (nodeOverload bool) {
+	numaCount := p.metaServer.NumNUMANodes
+	overloadNumaCount := p.overloadNumaCount
+
+	nodeOverload = overloadNumaCount == numaCount
+	general.Infof("Update node overload %v", nodeOverload)
+
+	return
+}
+
+func (p *NumaCPUPressureEviction) calOverloadNumaCount() (overloadNumaCount int) {
+	thresholds := p.thresholds
+	thresholdMetPercentage := p.numaPressureConfig.ThresholdMetPercentage
+	metricsHistory := p.metricsHistory
+	emitter := p.emitter
+
+	for numaID, numaHis := range metricsHistory.Inner {
+		numaHisInner := numaHis[FakePodUID]
+		var numaOver bool
+		for metricName, metricRing := range numaHisInner {
+			threshold, exist := thresholds[metricName]
+			if !exist {
+				general.Warningf("no threshold for metric %v", metricName)
+				_ = emitter.StoreFloat64(metricNameMetricNoThreshold, 1, metrics.MetricTypeNameRaw,
+					metrics.ConvertMapToTags(map[string]string{
+						metricTagMetricName: metricName,
+					})...)
+				continue
+			}
+			// per numa metric
+			overCount := metricRing.OverCount(threshold)
+			// whether current numa is overload
+			overRatio := float64(overCount) / float64(metricRing.MaxLen)
+
+			numaOver = overRatio >= thresholdMetPercentage
+
+			_ = emitter.StoreFloat64(metricNameNumaOverloadRatio, overRatio, metrics.MetricTypeNameRaw,
+				metrics.ConvertMapToTags(map[string]string{
+					metricTagMetricName: metricName,
+					metricTagNuma:       strconv.Itoa(numaID),
+					metricTagIsOverload: strconv.FormatBool(numaOver),
+				})...)
+
+			if numaOver {
+				general.InfoS("numa is overload", "numaID", numaID, "metric", metricName, "usageRatio", overRatio)
+				break
+			}
+		}
+
+		if numaOver {
+			overloadNumaCount++
+		}
+	}
+	_ = emitter.StoreInt64(metricNameNumaOverloadNumaCount, int64(overloadNumaCount), metrics.MetricTypeNameRaw)
+	general.Infof("Update overload numa count %v", overloadNumaCount)
+	return
+}
+
+func (p *NumaCPUPressureEviction) pickTopOverRatioNuma(metricName string, thresholds map[string]float64) (int, float64, error) {
+	type NumaOverRatio struct {
+		numaID        int
+		overloadRatio float64
+	}
+	var numaOverRatios []NumaOverRatio
+
+	for numaID, numaHis := range p.metricsHistory.Inner {
+		numaHisInner := numaHis[FakePodUID]
+		metricRing, ok := numaHisInner[metricName]
+		if !ok {
+			continue
+		}
+		threshold := thresholds[metricName]
+		overCount := metricRing.OverCount(threshold)
+		overRatio := float64(overCount) / float64(metricRing.MaxLen)
+		numaOverRatios = append(numaOverRatios, NumaOverRatio{
+			numaID:        numaID,
+			overloadRatio: overRatio,
+		})
+
+	}
+
+	sort.Slice(numaOverRatios, func(i, j int) bool {
+		return numaOverRatios[i].overloadRatio > numaOverRatios[j].overloadRatio
+	})
+
+	for _, numa := range numaOverRatios {
+		general.InfoS("Numa with overload ratio", "numa", numa.numaID, "overloadRatio", numa.overloadRatio)
+	}
+
+	if len(numaOverRatios) > 0 {
+		return numaOverRatios[0].numaID, numaOverRatios[0].overloadRatio, nil
+	}
+	return -1, 0, fmt.Errorf("no valid numa found")
+}
+
+func (p *NumaCPUPressureEviction) pickTopOverRatioPod(numaID int, metricName string,
+	activePods []*v1.Pod,
+) (*v1.Pod, float64, error) {
+	type PodWithUsage struct {
+		pod        *v1.Pod
+		usageRatio float64
+	}
+	var podWithUsages []PodWithUsage
+	numaHis, ok := p.metricsHistory.Inner[numaID]
+	if !ok {
+		return nil, 0, fmt.Errorf("cannot find numa %v usage", numaID)
+	}
+	for _, pod := range activePods {
+		podUID := string(pod.UID)
+		podHis, existMetric := numaHis[podUID]
+		if !existMetric {
+			continue
+		}
+		metricRing, ok := podHis[metricName]
+		if !ok {
+			continue
+		}
+		avgUsageRatio := metricRing.Avg()
+		podWithUsages = append(podWithUsages, PodWithUsage{
+			pod:        pod,
+			usageRatio: avgUsageRatio,
+		})
+	}
+
+	if len(podWithUsages) <= 1 {
+		return nil, 0, fmt.Errorf("cannot find enough pod for numa %v, pod count: %v", numaID, len(podWithUsages))
+	}
+
+	sort.Slice(podWithUsages, func(i, j int) bool {
+		return podWithUsages[i].usageRatio > podWithUsages[j].usageRatio
+	})
+
+	for _, pod := range podWithUsages {
+		general.InfoS("Pod with usage ratio", "podName", pod.pod.Name, "usageRatio", pod.usageRatio)
+	}
+
+	if len(podWithUsages) > 0 {
+		_ = p.emitter.StoreFloat64(metricNameNumaOverloadTopPod, podWithUsages[0].usageRatio, metrics.MetricTypeNameRaw,
+			metrics.ConvertMapToTags(map[string]string{
+				metricTagMetricName: metricName,
+				metricTagNuma:       strconv.Itoa(numaID),
+			})...)
+		return podWithUsages[0].pod, podWithUsages[0].usageRatio, nil
+	}
+	return nil, 0, fmt.Errorf("cannot find any pod to be evicted")
+}
+
+type NumaPressureConfig struct {
+	MetricRingSize          int
+	ThresholdMetPercentage  float64
+	NumaThresholdPercentage float64
+	GracePeriod             int64
+	ExpandFactor            float64
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/metricthreshold"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/helper"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/strategygroup"
+)
+
+var ThresholdMin = 0.4
+
+func (p *NumaCPUPressureEviction) pullThresholds(_ context.Context) {
+	enabled, err := strategygroup.IsStrategyEnabledForNode(consts.StrategyNameNumaCpuPressureEviction, false, p.conf)
+	if err != nil {
+		general.Errorf("failed to get eviction strategy: %v", err)
+		return
+	}
+	if !enabled {
+		general.Warningf("eviction strategy is disabled, skip pullThresholds")
+		return
+	}
+
+	cpuCodeName := helper.GetCpuCodeName(p.metaServer.MetricsFetcher)
+	isVM, _ := helper.GetIsVm(p.metaServer.MetricsFetcher)
+
+	globalThresholds := p.conf.DynamicAgentConfiguration.GetDynamicConfiguration().MetricThreshold
+	thresholds := getOverLoadThreshold(globalThresholds, cpuCodeName, isVM)
+	thresholds = convertThreshold(thresholds)
+	expandedThresholds := expandThresholds(thresholds, p.numaPressureConfig.ExpandFactor)
+	err = validateThresholds(thresholds)
+	if err != nil {
+		general.Warningf("%v", err.Error())
+		return
+	}
+
+	// update
+	p.Lock()
+	defer p.Unlock()
+	general.Infof("%v update enabled", EvictionNameNumaCpuPressure)
+	p.enabled = enabled
+	general.Infof("update thresholds to %v", expandedThresholds)
+	p.thresholds = expandedThresholds
+}
+
+func expandThresholds(thresholds map[string]float64, expandFactor float64) map[string]float64 {
+	for key, val := range thresholds {
+		thresholds[key] = val * expandFactor
+	}
+	return thresholds
+}
+
+func validateThresholds(thresholds map[string]float64) error {
+	for key, val := range thresholds {
+		if val < ThresholdMin {
+			return fmt.Errorf("%v threshold %v is lower than threshold %v", key, val, ThresholdMin)
+		}
+	}
+	return nil
+}
+
+func getOverLoadThreshold(globalThresholds *metricthreshold.MetricThreshold, cpuCode string, isVM bool) map[string]float64 {
+	modelThresholds, exists := globalThresholds.Threshold[cpuCode]
+	if !exists {
+		general.Warningf("no suitable threshold for cpuCode %v using default", isVM)
+		modelThresholds = globalThresholds.Threshold[metricthreshold.DefaultCPUCodeName]
+	}
+	threshold, exists := modelThresholds[isVM]
+	if !exists {
+		general.Warningf("no suitable threshold for cpuCode %v isVm %v, using default", cpuCode, isVM)
+		return modelThresholds[false]
+	}
+	return threshold
+}
+
+func convertThreshold(origin map[string]float64) map[string]float64 {
+	res := map[string]float64{}
+	for k, v := range origin {
+		if k == "cpu_usage_threshold" {
+			res[consts.MetricCPUUsageContainer] = v
+		} else if k == "cpu_load_threshold" {
+			res[consts.MetricLoad1MinContainer] = v
+		}
+	}
+	return res
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/metricthreshold"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+)
+
+func Test_expandThresholds(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		thresholds   map[string]float64
+		expandFactor float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]float64
+	}{
+		{
+			name: "test",
+			args: args{
+				thresholds: map[string]float64{
+					"1": 1,
+					"2": 2,
+					"3": 3,
+				},
+				expandFactor: 2,
+			},
+			want: map[string]float64{
+				"1": 2,
+				"2": 4,
+				"3": 6,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, expandThresholds(tt.args.thresholds, tt.args.expandFactor), "expandThresholds(%v, %v)", tt.args.thresholds, tt.args.expandFactor)
+		})
+	}
+}
+
+func Test_convertThreshold(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		origin map[string]float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]float64
+	}{
+		{
+			name: "test",
+			args: args{
+				origin: map[string]float64{
+					"cpu_usage_threshold": 1,
+					"cpu_load_threshold":  2,
+					"xxx":                 3,
+				},
+			},
+			want: map[string]float64{
+				consts.MetricCPUUsageContainer: 1,
+				consts.MetricLoad1MinContainer: 2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, convertThreshold(tt.args.origin), "convertThreshold(%v)", tt.args.origin)
+		})
+	}
+}
+
+func Test_getOverLoadThreshold(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		globalThresholds *metricthreshold.MetricThreshold
+		cpuCode          string
+		isVM             bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]float64
+	}{
+		{
+			name: "test",
+			args: args{
+				globalThresholds: &metricthreshold.MetricThreshold{
+					Threshold: map[string]map[bool]map[string]float64{
+						"abc": {
+							true: {
+								"cpu_usage_threshold": 1,
+								"cpu_load_threshold":  2,
+							},
+							false: {
+								"cpu_usage_threshold": 3,
+								"cpu_load_threshold":  4,
+							},
+						},
+						"def": {
+							true: {
+								"cpu_usage_threshold": 5,
+								"cpu_load_threshold":  6,
+							},
+							false: {
+								"cpu_usage_threshold": 7,
+								"cpu_load_threshold":  8,
+							},
+						},
+					},
+				},
+				cpuCode: "abc",
+				isVM:    true,
+			},
+			want: map[string]float64{
+				"cpu_usage_threshold": 1,
+				"cpu_load_threshold":  2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equalf(t, tt.want, getOverLoadThreshold(tt.args.globalThresholds, tt.args.cpuCode, tt.args.isVM), "getOverLoadThreshold(%v, %v, %v)", tt.args.globalThresholds, tt.args.cpuCode, tt.args.isVM)
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/node/node.go
+++ b/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/node/node.go
@@ -19,7 +19,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -36,6 +35,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/custom-metric/store/data"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/helper"
 	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	metricspool "github.com/kubewharf/katalyst-core/pkg/metrics/metrics-pool"
@@ -179,31 +179,17 @@ func (n *MetricSyncerNode) generateMetricTag(ctx context.Context) (tags []metric
 	}
 
 	// append cpu codename info
-	cpuCodeNameInterface := n.metaServer.MetricsFetcher.GetByStringIndex(consts.MetricCPUCodeName)
-	cpuCodeName, ok := cpuCodeNameInterface.(string)
-	if !ok {
-		klog.Warningf("parse cpu code name %v failed", cpuCodeNameInterface)
-		cpuCodeName = ""
-	}
-
 	tags = append(tags, metrics.MetricTag{
 		Key: fmt.Sprintf("%s%s", data.CustomMetricLabelSelectorPrefixKey, "cpu_codename"),
-		Val: cpuCodeName,
+		Val: helper.GetCpuCodeName(n.metaServer.MetricsFetcher),
 	})
 
 	// append vendor info
-	isVM := ""
-	isVMInterface := n.metaServer.MetricsFetcher.GetByStringIndex(consts.MetricInfoIsVM)
-	isVMBool, ok := isVMInterface.(bool)
-	if !ok {
-		klog.Warningf("parse is vm %v failed", isVMInterface)
-	} else {
-		isVM = strconv.FormatBool(isVMBool)
-	}
+	_, isVmStr := helper.GetIsVm(n.metaServer.MetricsFetcher)
 
 	tags = append(tags, metrics.MetricTag{
 		Key: fmt.Sprintf("%s%s", data.CustomMetricLabelSelectorPrefixKey, "is_vm"),
-		Val: isVM,
+		Val: isVmStr,
 	})
 
 	// append node numa bit mask

--- a/pkg/agent/sysadvisor/types/cpu.go
+++ b/pkg/agent/sysadvisor/types/cpu.go
@@ -25,6 +25,13 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
+type (
+	CPUAdvisorPluginName string
+	CPUPressureState     int
+)
+
+type CPUPressureStatus struct{}
+
 type TopologyAwareAssignment map[int]machine.CPUSet
 
 // CPUProvisionPolicyName defines policy names for cpu advisor resource provision

--- a/pkg/config/agent/dynamic/adminqos/eviction/eviction_base.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/eviction_base.go
@@ -31,6 +31,7 @@ type EvictionConfiguration struct {
 	*ReclaimedResourcesEvictionConfiguration
 	*SystemLoadEvictionPluginConfiguration
 	*NetworkEvictionConfiguration
+	*NumaCPUPressureEvictionConfiguration
 }
 
 func NewEvictionConfiguration() *EvictionConfiguration {
@@ -41,6 +42,7 @@ func NewEvictionConfiguration() *EvictionConfiguration {
 		ReclaimedResourcesEvictionConfiguration: NewReclaimedResourcesEvictionConfiguration(),
 		SystemLoadEvictionPluginConfiguration:   NewSystemLoadEvictionPluginConfiguration(),
 		NetworkEvictionConfiguration:            NewNetworkEvictionConfiguration(),
+		NumaCPUPressureEvictionConfiguration:    NewNumaCPUPressureEvictionConfiguration(),
 	}
 }
 
@@ -56,4 +58,5 @@ func (c *EvictionConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
 	c.ReclaimedResourcesEvictionConfiguration.ApplyConfiguration(conf)
 	c.SystemLoadEvictionPluginConfiguration.ApplyConfiguration(conf)
 	c.NetworkEvictionConfiguration.ApplyConfiguration(conf)
+	c.NumaCPUPressureEvictionConfiguration.ApplyConfiguration(conf)
 }

--- a/pkg/config/agent/dynamic/adminqos/eviction/numa_cpu_pressure_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/numa_cpu_pressure_eviction.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+)
+
+type NumaCPUPressureEvictionConfiguration struct {
+	NumaCpuPressureEnableEviction         bool
+	NumaCpuPressureThresholdMetPercentage float64
+	NumaCpuPressureMetricRingSize         int
+	NumaCpuPressureGracePeriod            int64
+	NumaCpuThresholdExpandFactor          float64
+}
+
+func NewNumaCPUPressureEvictionConfiguration() *NumaCPUPressureEvictionConfiguration {
+	return &NumaCPUPressureEvictionConfiguration{
+		NumaCpuPressureEnableEviction:         false,
+		NumaCpuPressureThresholdMetPercentage: 0.7,
+		NumaCpuPressureMetricRingSize:         4,
+		NumaCpuPressureGracePeriod:            60,
+		NumaCpuThresholdExpandFactor:          1.1,
+	}
+}
+
+// todo Due to the tight schedule, the EvictionConfig in AQC of katalyst-api has not been updated.
+// It is expected that the configuration connection will be supported in the future.
+func (n *NumaCPUPressureEvictionConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
+}

--- a/pkg/consts/strategy_names.go
+++ b/pkg/consts/strategy_names.go
@@ -43,6 +43,9 @@ const (
 	// StrategyNameBorweinTaint is the placeholder strategy for the strategy group,
 	// it indicates that there is no strategy enabled in the strategy group.
 	StrategyNameNone = "none"
+	// StrategyNameNumaCpuPressureEviction is the name of numa_cpu_pressure_eviction strategy,
+	// it evicts pods with high cpu pressure on numa nodes.
+	StrategyNameNumaCpuPressureEviction = "numa_cpu_pressure_eviction"
 )
 
 const (

--- a/pkg/metaserver/agent/metric/helper/system.go
+++ b/pkg/metaserver/agent/metric/helper/system.go
@@ -99,3 +99,32 @@ func GetNumaMetric(metricsFetcher types.MetricsFetcher, emitter metrics.MetricEm
 	}
 	return metricWithTime.Value, err
 }
+
+func GetCpuCodeName(metricsFetcher types.MetricsFetcher) string {
+	cpuCodeNameInterface := metricsFetcher.GetByStringIndex(consts.MetricCPUCodeName)
+	cpuCodeName, ok := cpuCodeNameInterface.(string)
+	if !ok {
+		general.Warningf("parse cpu code name %v failed", cpuCodeNameInterface)
+		cpuCodeName = ""
+	}
+	return cpuCodeName
+}
+
+func GetIsVm(metricsFetcher types.MetricsFetcher) (bool, string) {
+	isVMInterface := metricsFetcher.GetByStringIndex(consts.MetricInfoIsVM)
+	if isVMInterface == nil {
+		general.Warningf("isVM metric not found")
+		return false, ""
+	}
+	isVMStr, ok := isVMInterface.(string)
+	if !ok {
+		general.Warningf("parse is vm %v failed", isVMInterface)
+		return false, ""
+	}
+	parseBool, err := strconv.ParseBool(isVMStr)
+	if err != nil {
+		general.Warningf("parse is vm %v failed %v", isVMInterface, err)
+		return false, ""
+	}
+	return parseBool, isVMStr
+}

--- a/pkg/metaserver/agent/metric/helper/system_test.go
+++ b/pkg/metaserver/agent/metric/helper/system_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+func TestGetCpuCodeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setFakeMetric func(store *metric.FakeMetricsFetcher)
+		want          string
+	}{
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricCPUCodeName, "abc")
+			},
+			want: "abc",
+		},
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricCPUCodeName, "eee")
+			},
+			want: "eee",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			metricsFetcher := metric.NewFakeMetricsFetcher(metrics.DummyMetrics{})
+			store := metricsFetcher.(*metric.FakeMetricsFetcher)
+			tt.setFakeMetric(store)
+			assert.Equalf(t, tt.want, GetCpuCodeName(metricsFetcher), "GetCpuCodeName")
+		})
+	}
+}
+
+func TestGetIsVm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setFakeMetric func(store *metric.FakeMetricsFetcher)
+		wantBool      bool
+		wantStr       string
+	}{
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricInfoIsVM, "true")
+			},
+			wantBool: true,
+			wantStr:  "true",
+		},
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricInfoIsVM, "false")
+			},
+			wantBool: false,
+			wantStr:  "false",
+		},
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricInfoIsVM, "true1")
+			},
+			wantBool: false,
+			wantStr:  "",
+		},
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricInfoIsVM, "123")
+			},
+			wantBool: false,
+			wantStr:  "",
+		},
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricInfoIsVM, nil)
+			},
+			wantBool: false,
+			wantStr:  "",
+		},
+		{
+			name: "test",
+			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
+				store.SetByStringIndex(consts.MetricInfoIsVM, "")
+			},
+			wantBool: false,
+			wantStr:  "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			metricsFetcher := metric.NewFakeMetricsFetcher(metrics.DummyMetrics{})
+			store := metricsFetcher.(*metric.FakeMetricsFetcher)
+			tt.setFakeMetric(store)
+
+			wantBool, wantStr := GetIsVm(metricsFetcher)
+			assert.Equalf(t, tt.wantBool, wantBool, "GetCpuCodeName")
+			assert.Equalf(t, tt.wantStr, wantStr, "GetCpuCodeName")
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
A new Eviction Plugin has been implemented. It retrieves the CPU usage of shared_cores at the NUMA level. Based on this, it compares the CPU usage with the thresholds set for different machine types and isVM, and then realizes the eviction of Pods. If all NUMA nodes are overloaded, a taint will be added to the entire machine.
