### PR TITLE
fix(cpu): correct log message and adjust topology hint preference

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
@@ -386,7 +386,7 @@ func (p *DynamicPolicy) reclaimedCoresWithNUMABindingHintHandler(_ context.Conte
 		}
 	}
 
-	general.Infof("memory hints for pod:%s/%s, container: %s success, hints: %v",
+	general.Infof("cpu hints for pod:%s/%s, container: %s success, hints: %v",
 		req.PodNamespace, req.PodName, req.ContainerName, hints)
 
 	return util.PackResourceHintsResponse(req, string(v1.ResourceCPU), hints)
@@ -1126,10 +1126,17 @@ func (p *DynamicPolicy) populateBestEffortHintsByAvailableNUMANodes(
 	hintList := make([]*pluginapi.TopologyHint, 0, len(nodeHints))
 	// Add sorted hints to the hint list
 	for _, nh := range nodeHints {
-		hintList = append(hintList, &pluginapi.TopologyHint{
-			Nodes:     []uint64{uint64(nh.nodeID)},
-			Preferred: true,
-		})
+		if nh.curLeft < 0 {
+			hintList = append(hintList, &pluginapi.TopologyHint{
+				Nodes:     []uint64{uint64(nh.nodeID)},
+				Preferred: false,
+			})
+		} else {
+			hintList = append(hintList, &pluginapi.TopologyHint{
+				Nodes:     []uint64{uint64(nh.nodeID)},
+				Preferred: true,
+			})
+		}
 	}
 
 	// Update the hints map

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
@@ -3232,19 +3232,19 @@ func TestGetTopologyHints(t *testing.T) {
 						Hints: []*pluginapi.TopologyHint{
 							{
 								Nodes:     []uint64{3},
-								Preferred: true,
+								Preferred: false,
 							},
 							{
 								Nodes:     []uint64{2},
-								Preferred: true,
+								Preferred: false,
 							},
 							{
 								Nodes:     []uint64{0},
-								Preferred: true,
+								Preferred: false,
 							},
 							{
 								Nodes:     []uint64{1},
-								Preferred: true,
+								Preferred: false,
 							},
 						},
 					},
@@ -3495,7 +3495,7 @@ func TestGetTopologyHints(t *testing.T) {
 							},
 							{
 								Nodes:     []uint64{0},
-								Preferred: true,
+								Preferred: false,
 							},
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Update the log message to accurately reflect CPU hints instead of memory hints. Additionally, modify the topology hint logic to set the preferred flag based on the current available resources, ensuring correct resource allocation.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
