### PR TITLE
chore(*): fix kubelet endpoint do not support ipv6

### DIFF
--- a/pkg/util/native/kubelet.go
+++ b/pkg/util/native/kubelet.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"k8s.io/client-go/discovery"
@@ -145,8 +147,7 @@ func generateURI(port int, nodeAddress, endpoint string) (string, error) {
 	if nodeAddress == "" {
 		return "", fmt.Errorf("node address is empty")
 	}
-
-	u, err := url.ParseRequestURI(fmt.Sprintf("https://%s:%d%s", nodeAddress, port, endpoint))
+	u, err := url.ParseRequestURI(fmt.Sprintf("https://%s%s", net.JoinHostPort(nodeAddress, strconv.Itoa(port)), endpoint))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse -kubelet-config-uri: %w", err)
 	}

--- a/pkg/util/native/kubelet_test.go
+++ b/pkg/util/native/kubelet_test.go
@@ -30,9 +30,16 @@ func TestGenerateURI(t *testing.T) {
 	nodeAddress := "127.0.0.1"
 	endpoint := "/configz"
 
+	// ipv4
 	uri, err := generateURI(port, nodeAddress, endpoint)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://127.0.0.1:10250/configz", uri)
+
+	// ipv6
+	nodeAddress = "::1"
+	uri, err = generateURI(port, nodeAddress, endpoint)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://[::1]:10250/configz", uri)
 }
 
 func TestInsecureConfig(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes


#### What this PR does / why we need it:
for ipv6 only enviroment, katalyst does not work

#### Which issue(s) this PR fixes:
ipv6 compatible when requesting Kubelet

#### Special notes for your reviewer:
