### PR TITLE
feat(cpu): add sidecar requirement inclusion in CPU isolation

### DIFF
--- a/cmd/katalyst-agent/app/options/sysadvisor/qosaware/resource/cpu/cpu_isolation.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/qosaware/resource/cpu/cpu_isolation.go
@@ -57,6 +57,8 @@ type CPUIsolationOptions struct {
 	IsolationDisabledPools     []string
 	IsolationForceEnablePools  []string
 	IsolationNonExclusivePools []string
+
+	IsolationIncludeSidecarRequirement bool
 }
 
 // NewCPUIsolationOptions creates a new Options with a default config
@@ -115,6 +117,8 @@ func (o *CPUIsolationOptions) AddFlags(fs *pflag.FlagSet) {
 		"isolation force enable for get given pool")
 	fs.StringArrayVar(&o.IsolationNonExclusivePools, "isolation-non-exclusive-pools", o.IsolationNonExclusivePools,
 		"isolation is non-exclusive for get given pool")
+	fs.BoolVar(&o.IsolationIncludeSidecarRequirement, "isolation-include-sidecar-requirement", o.IsolationIncludeSidecarRequirement,
+		"isolation include sidecar requirement")
 }
 
 // ApplyTo fills up config with options
@@ -157,6 +161,8 @@ func (o *CPUIsolationOptions) ApplyTo(c *cpu.CPUIsolationConfiguration) error {
 	c.IsolationDisabledPools = sets.NewString(o.IsolationDisabledPools...)
 	c.IsolationForceEnablePools = sets.NewString(o.IsolationForceEnablePools...)
 	c.IsolationNonExclusivePools = sets.NewString(o.IsolationNonExclusivePools...)
+
+	c.IsolationIncludeSidecarRequirement = o.IsolationIncludeSidecarRequirement
 
 	return nil
 }

--- a/pkg/config/agent/sysadvisor/qosaware/resource/cpu/cpu_isolation.go
+++ b/pkg/config/agent/sysadvisor/qosaware/resource/cpu/cpu_isolation.go
@@ -47,6 +47,10 @@ type CPUIsolationConfiguration struct {
 	IsolationDisabledPools     sets.String
 	IsolationForceEnablePools  sets.String
 	IsolationNonExclusivePools sets.String
+
+	// IsolationIncludeSidecarRequirement indicates whether to include sidecar requirements
+	// when calculating CPU isolation
+	IsolationIncludeSidecarRequirement bool
 }
 
 // NewCPUIsolationConfiguration creates new resource advisor configurations


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Introduce a new configuration flag `IsolationIncludeSidecarRequirement` to optionally include sidecar container requirements when calculating CPU isolation. This allows for more flexible resource allocation in environments where sidecar containers have significant resource needs.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
