### PR TITLE
refactor(cpu/dynamicpolicy): track pool size per NUMA node for better granularity

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1067,9 +1068,12 @@ func (p *DynamicPolicy) applyPoolsAndIsolatedInfo(poolsCPUSet map[string]machine
 			OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(topologyAwareAssignments),
 		}
 
-		_ = p.emitter.StoreInt64(util.MetricNamePoolSize, int64(cset.Size()), metrics.MetricTypeNameRaw,
-			metrics.MetricTag{Key: "poolName", Val: poolName},
-			metrics.MetricTag{Key: "pool_type", Val: commonstate.GetPoolType(poolName)})
+		for numaID, cpus := range topologyAwareAssignments {
+			_ = p.emitter.StoreInt64(util.MetricNamePoolSize, int64(cpus.Size()),
+				metrics.MetricTypeNameRaw, metrics.MetricTag{Key: "poolName", Val: poolName},
+				metrics.MetricTag{Key: "pool_type", Val: commonstate.GetPoolType(poolName)},
+				metrics.MetricTag{Key: "numa_id", Val: strconv.Itoa(numaID)})
+		}
 	}
 
 	// revise reclaim pool size to avoid reclaimed_cores and numa_binding containers


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Modify the pool size metric tracking to report sizes per NUMA node instead of the entire pool. This provides more detailed insights into resource allocation and utilization across different NUMA nodes.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
