### PR TITLE
refactor: remove MBWNUMAsPoint and simplify memory bandwidth handling

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
@@ -317,21 +317,19 @@ func (p *DynamicPolicy) calculateHints(request float64,
 		return nil, errNoAvailableCPUHints
 	}
 
-	if numaBound > machine.MBWNUMAsPoint {
-		numaAllocatedMemBW, err := getNUMAAllocatedMemBW(machineState, p.metaServer, p.getContainerRequestedCores)
+	numaAllocatedMemBW, err := getNUMAAllocatedMemBW(machineState, p.metaServer, p.getContainerRequestedCores)
 
-		general.InfoS("getNUMAAllocatedMemBW",
-			"podNamespace", req.PodNamespace,
-			"podName", req.PodName,
-			"numaAllocatedMemBW", numaAllocatedMemBW)
+	general.InfoS("getNUMAAllocatedMemBW",
+		"podNamespace", req.PodNamespace,
+		"podName", req.PodName,
+		"numaAllocatedMemBW", numaAllocatedMemBW)
 
-		if err != nil {
-			general.Errorf("getNUMAAllocatedMemBW failed with error: %v", err)
-			_ = p.emitter.StoreInt64(util.MetricNameGetNUMAAllocatedMemBWFailed, 1, metrics.MetricTypeNameRaw)
-		} else {
-			p.updatePreferredCPUHintsByMemBW(preferredHintIndexes, availableNumaHints,
-				request, numaAllocatedMemBW, req, numaExclusive)
-		}
+	if err != nil {
+		general.Errorf("getNUMAAllocatedMemBW failed with error: %v", err)
+		_ = p.emitter.StoreInt64(util.MetricNameGetNUMAAllocatedMemBWFailed, 1, metrics.MetricTypeNameRaw)
+	} else {
+		p.updatePreferredCPUHintsByMemBW(preferredHintIndexes, availableNumaHints,
+			request, numaAllocatedMemBW, req, numaExclusive)
 	}
 
 	hints := map[string]*pluginapi.ListOfTopologyHints{

--- a/pkg/util/machine/util.go
+++ b/pkg/util/machine/util.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	LargeNUMAsPoint = 16
-	MBWNUMAsPoint   = 8
 )
 
 // TransformCPUAssignmentFormat transforms cpu assignment string format to cpuset format


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
The MBWNUMAsPoint constant was removed as it was no longer needed. The logic for calculating memory bandwidth hints was simplified by removing the conditional check based on MBWNUMAsPoint, making the code cleaner and more maintainable.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
