### PR TITLE
fix(qrm): fix numa cpu eviction metrics collect

### DIFF
--- a/pkg/metaserver/agent/metric/helper/system.go
+++ b/pkg/metaserver/agent/metric/helper/system.go
@@ -116,15 +116,10 @@ func GetIsVm(metricsFetcher types.MetricsFetcher) (bool, string) {
 		general.Warningf("isVM metric not found")
 		return false, ""
 	}
-	isVMStr, ok := isVMInterface.(string)
+	isVMBool, ok := isVMInterface.(bool)
 	if !ok {
 		general.Warningf("parse is vm %v failed", isVMInterface)
 		return false, ""
 	}
-	parseBool, err := strconv.ParseBool(isVMStr)
-	if err != nil {
-		general.Warningf("parse is vm %v failed %v", isVMInterface, err)
-		return false, ""
-	}
-	return parseBool, isVMStr
+	return isVMBool, strconv.FormatBool(isVMBool)
 }

--- a/pkg/metaserver/agent/metric/helper/system_test.go
+++ b/pkg/metaserver/agent/metric/helper/system_test.go
@@ -73,7 +73,7 @@ func TestGetIsVm(t *testing.T) {
 		{
 			name: "test",
 			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
-				store.SetByStringIndex(consts.MetricInfoIsVM, "true")
+				store.SetByStringIndex(consts.MetricInfoIsVM, true)
 			},
 			wantBool: true,
 			wantStr:  "true",
@@ -81,7 +81,7 @@ func TestGetIsVm(t *testing.T) {
 		{
 			name: "test",
 			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
-				store.SetByStringIndex(consts.MetricInfoIsVM, "false")
+				store.SetByStringIndex(consts.MetricInfoIsVM, false)
 			},
 			wantBool: false,
 			wantStr:  "false",


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
After fixing the adaptation of MetricThreshold, the data collection logic issue caused by inconsistent metrics has been resolved.
