### PR TITLE
refactor(cgroup): replace libcontainer configs.Resources with custom CgroupResources

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_advisor_handler.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_advisor_handler.go
@@ -25,7 +25,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/samber/lo"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
@@ -520,7 +519,7 @@ func (p *DynamicPolicy) applyCgroupConfigs(resp *advisorapi.ListAndWatchResponse
 			continue
 		}
 
-		resources := &configs.Resources{}
+		resources := &common.CgroupResources{}
 		err := json.Unmarshal([]byte(cgConf), resources)
 		if err != nil {
 			return fmt.Errorf("unmarshal %s: %s failed with error: %v",

--- a/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server.go
@@ -25,7 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/samber/lo"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
@@ -353,7 +352,7 @@ func (cs *cpuServer) assembleCgroupConfig(advisorResp *types.InternalCPUCalculat
 			if ok && cpuResource.Quota > 0 {
 				quota = int64(cpuResource.Quota * DefaultCFSCPUPeriod)
 			}
-			resourceConf := &configs.Resources{
+			resourceConf := &common.CgroupResources{
 				CpuQuota:  quota,
 				CpuPeriod: DefaultCFSCPUPeriod,
 			}
@@ -723,7 +722,7 @@ func (cs *cpuServer) assemblePoolEntries(advisorResp *types.InternalCPUCalculati
 
 			overlapSize := advisorResp.GetPoolOverlapInfo(commonstate.PoolNameReclaim, numaID)
 			if len(overlapSize) == 0 {
-				// If share pool not exists，join reclaim pool directly
+				// If share pool not exists, join reclaim pool directly
 				block := NewBlock(uint64(reclaimCPU.Size), "")
 				numaCalculationResult := &cpuadvisor.NumaCalculationResult{Blocks: []*cpuadvisor.Block{block}}
 

--- a/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server_linux_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/server/cpu_server_linux_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -48,7 +47,7 @@ import (
 func TestCPUServerUpdate(t *testing.T) {
 	t.Parallel()
 
-	cgResource := configs.Resources{CpuQuota: -1, CpuPeriod: 100000}
+	cgResource := common.CgroupResources{CpuQuota: -1, CpuPeriod: 100000}
 	tmp, err := json.Marshal(&cgResource)
 	assert.NoError(t, err)
 	defaultCgroupConfig := string(tmp)

--- a/pkg/util/cgroup/common/cgroup_linux.go
+++ b/pkg/util/cgroup/common/cgroup_linux.go
@@ -183,8 +183,8 @@ func IsCPUIdleSupported() bool {
 	return err == nil
 }
 
-// apply cgroup resource
-func ApplyCgroupConfigs(cgroupPath string, resources *configs.Resources) error {
+// ApplyCgroupConfigs apply cgroup resources
+func ApplyCgroupConfigs(cgroupPath string, resources *CgroupResources) error {
 	subSystems, err := libcontainer.GetCgroupSubsystems(nil)
 	if err != nil {
 		return fmt.Errorf("GetCgroupSubsystems failed with error: %v", err)
@@ -200,10 +200,23 @@ func ApplyCgroupConfigs(cgroupPath string, resources *configs.Resources) error {
 		return fmt.Errorf("NewCgroupManager failed with error: %v", err)
 	}
 
-	if err := manager.Set(resources); err != nil {
+	if err := manager.Set(toConfigsResources(resources)); err != nil {
 		return fmt.Errorf("set cgroup resources failed with error: %#v, %v",
 			resources, err)
 	}
 
 	return nil
+}
+
+func toConfigsResources(resources *CgroupResources) *configs.Resources {
+	if resources == nil {
+		return nil
+	}
+
+	return &configs.Resources{
+		CpuQuota:        resources.CpuQuota,
+		CpuPeriod:       resources.CpuPeriod,
+		SkipDevices:     resources.SkipDevices,
+		SkipFreezeOnSet: resources.SkipFreezeOnSet,
+	}
 }

--- a/pkg/util/cgroup/common/cgroup_unsupported.go
+++ b/pkg/util/cgroup/common/cgroup_unsupported.go
@@ -21,8 +21,6 @@ package common
 
 import (
 	"fmt"
-
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func ReadTasksFile(file string) ([]string, error) {
@@ -45,6 +43,6 @@ func CheckCgroup2UnifiedMode() bool {
 	return false
 }
 
-func ApplyCgroupConfigs(cgroupPath string, resources *configs.Resources) error {
+func ApplyCgroupConfigs(cgroupPath string, resources *CgroupResources) error {
 	return nil
 }

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -232,3 +232,11 @@ type CgroupMetrics struct {
 	Memory *MemoryMetrics
 	Pid    *PidMetrics
 }
+
+type CgroupResources struct {
+	CpuQuota  int64  `json:"cpu_quota"`
+	CpuPeriod uint64 `json:"cpu_period"`
+
+	SkipDevices     bool `json:"-"`
+	SkipFreezeOnSet bool `json:"-"`
+}


### PR DESCRIPTION




#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Introduce a custom CgroupResources type to decouple from the libcontainer configs.Resources dependency. This improves maintainability and reduces external dependencies. The toConfigsResources helper function is added to convert ConfigResources to libcontainer's configs.Resources when necessary.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
