### PR TITLE
check cgroup file's existence before apply data for container in applyExternalCgroupParams

### DIFF
--- a/pkg/agent/qrm-plugins/advisorsvc/advisor_svc.pb.go
+++ b/pkg/agent/qrm-plugins/advisorsvc/advisor_svc.pb.go
@@ -417,6 +417,8 @@ func (m *CalculationEntries) GetContainerEntries() map[string]*CalculationInfo {
 	return nil
 }
 
+func (m *CalculationInfo) Reset() { *m = CalculationInfo{} }
+
 type CalculationInfo struct {
 	// eg. "/kubepods/besteffort";
 	// empty for container; non-empty for high level cgroup path; since subsystem may be different for different control knob, so we use relative path here.
@@ -426,7 +428,6 @@ type CalculationInfo struct {
 	XXX_sizecache        int32              `json:"-"`
 }
 
-func (m *CalculationInfo) Reset()      { *m = CalculationInfo{} }
 func (*CalculationInfo) ProtoMessage() {}
 func (*CalculationInfo) Descriptor() ([]byte, []int) {
 	return fileDescriptor_870376c87c2a4145, []int{7}

--- a/pkg/util/cgroup/common/path.go
+++ b/pkg/util/cgroup/common/path.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -164,6 +165,23 @@ func IsContainerCgroupExist(podUID, containerID string) (bool, error) {
 	}
 
 	return general.IsPathExists(containerAbsCGPath), nil
+}
+
+func IsContainerCgroupFileExist(subsys, podUID, containerId, cgroupFileName string) (bool, error) {
+	absCgroupPath, err := GetContainerAbsCgroupPath(subsys, podUID, containerId)
+	if err != nil {
+		return false, fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
+	}
+
+	absCgroupFilePath := filepath.Join(absCgroupPath, cgroupFileName)
+	_, err = os.Stat(absCgroupFilePath)
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
 }
 
 // GetNUMABindingReclaimRelativeRootCgroupPaths returns relative cgroup paths for numa-binding reclaim

--- a/pkg/util/cgroup/common/path_test.go
+++ b/pkg/util/cgroup/common/path_test.go
@@ -69,3 +69,12 @@ func TestIsContainerCgroupExist(t *testing.T) {
 	_, err := IsContainerCgroupExist("fake-pod-uid", "fake-container-id")
 	as.NotNil(err)
 }
+
+func TestIsContainerCgroupFileExist(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+	// test the case that file doesn't exist
+	_, err := IsContainerCgroupFileExist("cpuset", "fake-pod-uid", "fake-container-id", "nonexistentfile")
+	as.NotNil(err)
+}


### PR DESCRIPTION


#### What type of PR is this?

Enhancements


#### What this PR does / why we need it:

check cgroup file's existence before apply data for container in applyExternalCgroupParams to avoid unnecessary health check failed
