### PR TITLE
enhance(advisor): power_aware advisor - cpufreq as dvfs limiter

### DIFF
--- a/cmd/katalyst-agent/app/options/metaserver/metric.go
+++ b/cmd/katalyst-agent/app/options/metaserver/metric.go
@@ -55,8 +55,11 @@ func NewMetricFetcherOptions() *MetricFetcherOptions {
 		MetricInsurancePeriod: defaultMetricInsurancePeriod,
 		MetricProvisions:      []string{metaserver.MetricProvisionerMalachite, metaserver.MetricProvisionerKubelet},
 
-		DefaultInterval:         time.Second * 5,
-		ProvisionerIntervalSecs: map[string]int{metaserver.MetricProvisionerMalachiteRealtime: 1},
+		DefaultInterval: time.Second * 5,
+		ProvisionerIntervalSecs: map[string]int{
+			metaserver.MetricProvisionerMalachiteRealtime:     1,
+			metaserver.MetricProvisionerMalachiteRealtimeFreq: 1,
+		},
 
 		MalachiteOptions: &MalachiteOptions{},
 		CgroupOptions:    &CgroupOptions{},

--- a/cmd/katalyst-agent/app/options/sysadvisor/poweraware/power_aware_plugin.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/poweraware/power_aware_plugin.go
@@ -28,6 +28,7 @@ type PowerAwarePluginOptions struct {
 	DisablePowerPressureEvict        bool
 	PowerCappingAdvisorSocketAbsPath string
 	AnnotationKeyPrefix              string
+	DVFSIndication                   string
 }
 
 func (p *PowerAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
@@ -37,6 +38,7 @@ func (p *PowerAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.BoolVar(&p.DisablePowerCapping, "power-capping-Disabled", p.DisablePowerCapping, "flag for power aware plugin disabling power capping")
 	fs.StringVar(&p.PowerCappingAdvisorSocketAbsPath, "power-capping-advisor-sock-abs-path", p.PowerCappingAdvisorSocketAbsPath, "absolute path of unix socket file for power capping advisor served in sys-advisor")
 	fs.StringVar(&p.AnnotationKeyPrefix, "power-aware-annotation-key-prefix", p.AnnotationKeyPrefix, "prefix of node annotation keys used by power aware plugin")
+	fs.StringVar(&p.DVFSIndication, "power-aware-dvfs-indication", p.DVFSIndication, "indication metric name of dvfs effect")
 }
 
 func (p *PowerAwarePluginOptions) ApplyTo(o *poweraware.PowerAwarePluginConfiguration) error {
@@ -45,11 +47,14 @@ func (p *PowerAwarePluginOptions) ApplyTo(o *poweraware.PowerAwarePluginConfigur
 	o.DisablePowerCapping = p.DisablePowerCapping
 	o.PowerCappingAdvisorSocketAbsPath = p.PowerCappingAdvisorSocketAbsPath
 	o.AnnotationKeyPrefix = p.AnnotationKeyPrefix
+	o.DVFSIndication = p.DVFSIndication
 
 	return nil
 }
 
 // NewPowerAwarePluginOptions creates a new Options with a default config.
 func NewPowerAwarePluginOptions() *PowerAwarePluginOptions {
-	return &PowerAwarePluginOptions{}
+	return &PowerAwarePluginOptions{
+		DVFSIndication: poweraware.DVFSIndicationPower,
+	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change.go
@@ -85,9 +85,9 @@ func (c *cpuFreqChangeAssessor) AssessTarget(actualWatt, desiredWatt int, maxDec
 	return desiredWatt
 }
 
-func NewCPUFreqChangeAssessor(initMhz int, nodeMetricGetter reader.NodeMetricGetter) Assessor {
+func NewCPUFreqChangeAssessor(initKHZ int, nodeMetricGetter reader.NodeMetricGetter) Assessor {
 	return &cpuFreqChangeAssessor{
-		initFreqKHZ:   initMhz,
+		initFreqKHZ:   initKHZ,
 		cpuFreqReader: reader.NewCPUFreqReader(nodeMetricGetter),
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assess
+
+import "fmt"
+
+const minMHZ = 800
+
+type cpuFreqChangeAssessor struct {
+	initFreqMhz int
+}
+
+func (c *cpuFreqChangeAssessor) Clear() {
+	c.initFreqMhz = 0
+}
+
+func (c *cpuFreqChangeAssessor) AssessEffect(current int) (int, error) {
+	if c.initFreqMhz < minMHZ {
+		return 0, fmt.Errorf("invalid initial frequency %d mhz", c.initFreqMhz)
+	}
+
+	if current < minMHZ {
+		return 0, fmt.Errorf("invalid current frequency %d mhz", current)
+	}
+
+	if current >= c.initFreqMhz {
+		return 0, nil
+	}
+
+	return 100 - current*100/c.initFreqMhz, nil
+}
+
+func (c *cpuFreqChangeAssessor) Update(actual int) {
+	// no need to keep track of the change, as we always compare with the initial frequency
+}
+
+func (c *cpuFreqChangeAssessor) AssessTarget(actualWatt, desiredWatt int, maxDecreasePercent int) int {
+	// keep as is if there is no room to decrease
+	if maxDecreasePercent <= 0 {
+		return actualWatt
+	}
+
+	// when there is decrease room for cpu frequency, lower the power in smaller portion to avoid the misstep
+	lowerLimit := (100 - maxDecreasePercent/2) * actualWatt / 100
+	if lowerLimit > desiredWatt {
+		return lowerLimit
+	}
+
+	return desiredWatt
+}
+
+func NewCPUFreqChangeAssessor(initMhz int) Assessor {
+	return &cpuFreqChangeAssessor{
+		initFreqMhz: initMhz,
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
@@ -72,7 +72,7 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &cpuFreqChangeAssessor{
-				initFreqKHZ: tt.fields.initFreqKHZ,
+				highFreqKHZ: tt.fields.initFreqKHZ,
 			}
 			got, err := c.assessEffectByFreq(tt.args.current)
 			if (err != nil) != tt.wantErr {
@@ -132,7 +132,7 @@ func Test_cpuFreqChangeAssessor_AssessTarget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &cpuFreqChangeAssessor{
-				initFreqKHZ: tt.fields.initFreqMhz,
+				highFreqKHZ: tt.fields.initFreqMhz,
 			}
 			if got := c.AssessTarget(tt.args.actualWatt, tt.args.desiredWatt, tt.args.maxDecreasePercent); got != tt.want {
 				t.Errorf("AssessTarget() = %v, want %v", got, tt.want)

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
@@ -56,7 +56,7 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "higher freq no change",
+			name: "fine for higher freq no change as temporary spike",
 			fields: fields{
 				initFreqKHZ: 2500_000,
 			},
@@ -64,7 +64,7 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 				current: 2600_000,
 			},
 			want:    0,
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
@@ -21,7 +21,7 @@ import "testing"
 func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 	t.Parallel()
 	type fields struct {
-		initFreqMhz int
+		initFreqKHZ int
 	}
 	type args struct {
 		current int
@@ -36,10 +36,10 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 		{
 			name: "happy path",
 			fields: fields{
-				initFreqMhz: 2500,
+				initFreqKHZ: 2500_000,
 			},
 			args: args{
-				current: 2000,
+				current: 2000_000,
 			},
 			want:    20,
 			wantErr: false,
@@ -47,10 +47,10 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 		{
 			name: "negative low current freq",
 			fields: fields{
-				initFreqMhz: 2500,
+				initFreqKHZ: 2500_000,
 			},
 			args: args{
-				current: 777,
+				current: 777_000,
 			},
 			want:    0,
 			wantErr: true,
@@ -58,13 +58,13 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 		{
 			name: "higher freq no change",
 			fields: fields{
-				initFreqMhz: 2500,
+				initFreqKHZ: 2500_000,
 			},
 			args: args{
-				current: 2600,
+				current: 2600_000,
 			},
 			want:    0,
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -72,9 +72,9 @@ func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &cpuFreqChangeAssessor{
-				initFreqMhz: tt.fields.initFreqMhz,
+				initFreqKHZ: tt.fields.initFreqKHZ,
 			}
-			got, err := c.AssessEffect(tt.args.current)
+			got, err := c.assessEffectByFreq(tt.args.current)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AssessEffect() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -132,7 +132,7 @@ func Test_cpuFreqChangeAssessor_AssessTarget(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &cpuFreqChangeAssessor{
-				initFreqMhz: tt.fields.initFreqMhz,
+				initFreqKHZ: tt.fields.initFreqMhz,
 			}
 			if got := c.AssessTarget(tt.args.actualWatt, tt.args.desiredWatt, tt.args.maxDecreasePercent); got != tt.want {
 				t.Errorf("AssessTarget() = %v, want %v", got, tt.want)

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assess
+
+import "testing"
+
+func Test_cpuFreqChangeAssessor_AccumulateEffect(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		initFreqMhz int
+	}
+	type args struct {
+		current int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				initFreqMhz: 2500,
+			},
+			args: args{
+				current: 2000,
+			},
+			want:    20,
+			wantErr: false,
+		},
+		{
+			name: "negative low current freq",
+			fields: fields{
+				initFreqMhz: 2500,
+			},
+			args: args{
+				current: 777,
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "higher freq no change",
+			fields: fields{
+				initFreqMhz: 2500,
+			},
+			args: args{
+				current: 2600,
+			},
+			want:    0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &cpuFreqChangeAssessor{
+				initFreqMhz: tt.fields.initFreqMhz,
+			}
+			got, err := c.AssessEffect(tt.args.current)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AssessEffect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("AssessEffect() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_cpuFreqChangeAssessor_AssessTarget(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		initFreqMhz int
+	}
+	type args struct {
+		actualWatt         int
+		desiredWatt        int
+		maxDecreasePercent int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				initFreqMhz: 2500,
+			},
+			args: args{
+				actualWatt:         100,
+				desiredWatt:        80,
+				maxDecreasePercent: 10,
+			},
+			want: 95,
+		},
+		{
+			name: "happy path",
+			fields: fields{
+				initFreqMhz: 2500,
+			},
+			args: args{
+				actualWatt:         100,
+				desiredWatt:        80,
+				maxDecreasePercent: 0,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &cpuFreqChangeAssessor{
+				initFreqMhz: tt.fields.initFreqMhz,
+			}
+			if got := c.AssessTarget(tt.args.actualWatt, tt.args.desiredWatt, tt.args.maxDecreasePercent); got != tt.want {
+				t.Errorf("AssessTarget() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/cpufreq_change_test.go
@@ -140,3 +140,42 @@ func Test_cpuFreqChangeAssessor_AssessTarget(t *testing.T) {
 		})
 	}
 }
+
+func Test_effectKeeper_Update(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		value int
+	}
+	type args struct {
+		curr int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   int
+	}{
+		{
+			name: "happy path to smooth out old spike",
+			fields: fields{
+				value: 100,
+			},
+			args: args{
+				curr: 80,
+			},
+			want: 92,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := &effectKeeper{
+				effectiveValue: tt.fields.value,
+			}
+			if got := h.Update(tt.args.curr); got != tt.want {
+				t.Errorf("Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/power_change.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/power_change.go
@@ -33,22 +33,22 @@ func (p *powerChangeAssessor) AssessTarget(actualWatt, desiredWatt int, maxDecre
 	return desiredWatt
 }
 
-func (p *powerChangeAssessor) Update(currValue int) {
-	p.prevPower = currValue
+func (p *powerChangeAssessor) Update(currPower int) {
+	p.prevPower = currPower
 }
 
-func (p *powerChangeAssessor) AssessEffect(current int) (int, error) {
-	if current <= 0 {
-		return 0, fmt.Errorf("invalid cuurent value %d", current)
+func (p *powerChangeAssessor) AssessEffect(currentPower int) (int, error) {
+	if currentPower <= 0 {
+		return 0, fmt.Errorf("invalid cuurent value %d", currentPower)
 	}
 
 	// if actual power is more than previous, likely previous round dvfs took no effect;
 	// not to take into account
-	if current >= p.prevPower {
+	if currentPower >= p.prevPower {
 		return p.accumulatedEffect, nil
 	}
 
-	change := (p.prevPower - current) * 100 / p.prevPower
+	change := (p.prevPower - currentPower) * 100 / p.prevPower
 	p.accumulatedEffect += change
 	return p.accumulatedEffect, nil
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/power_change.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/power_change.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package assess
 
+import "fmt"
+
 // powerChangeAssessor assesses change effect by power consumption
 type powerChangeAssessor struct {
 	accumulatedEffect int
@@ -35,16 +37,20 @@ func (p *powerChangeAssessor) Update(currValue int) {
 	p.prevPower = currValue
 }
 
-func (p *powerChangeAssessor) AccumulateEffect(current int) int {
-	change := 0
-	// if actual power is more than previous, likely previous round dvfs took no effect;
-	// not to take into account
-	if current > 0 && current < p.prevPower {
-		change = (p.prevPower - current) * 100 / p.prevPower
+func (p *powerChangeAssessor) AssessEffect(current int) (int, error) {
+	if current <= 0 {
+		return 0, fmt.Errorf("invalid cuurent value %d", current)
 	}
 
+	// if actual power is more than previous, likely previous round dvfs took no effect;
+	// not to take into account
+	if current >= p.prevPower {
+		return p.accumulatedEffect, nil
+	}
+
+	change := (p.prevPower - current) * 100 / p.prevPower
 	p.accumulatedEffect += change
-	return p.accumulatedEffect
+	return p.accumulatedEffect, nil
 }
 
 func (p *powerChangeAssessor) Clear() {

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/power_change.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/power_change.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assess
+
+// powerChangeAssessor assesses change effect by power consumption
+type powerChangeAssessor struct {
+	accumulatedEffect int
+	prevPower         int
+}
+
+func (p *powerChangeAssessor) AssessTarget(actualWatt, desiredWatt int, maxDecreasePercent int) int {
+	lowerLimit := (100 - maxDecreasePercent) * actualWatt / 100
+	if lowerLimit > desiredWatt {
+		return lowerLimit
+	}
+
+	return desiredWatt
+}
+
+func (p *powerChangeAssessor) Update(currValue int) {
+	p.prevPower = currValue
+}
+
+func (p *powerChangeAssessor) AccumulateEffect(current int) int {
+	change := 0
+	// if actual power is more than previous, likely previous round dvfs took no effect;
+	// not to take into account
+	if current > 0 && current < p.prevPower {
+		change = (p.prevPower - current) * 100 / p.prevPower
+	}
+
+	p.accumulatedEffect += change
+	return p.accumulatedEffect
+}
+
+func (p *powerChangeAssessor) Clear() {
+	p.prevPower = 0
+}
+
+func NewPowerChangeAssessor(effect, preValue int) Assessor {
+	return &powerChangeAssessor{
+		accumulatedEffect: effect,
+		prevPower:         preValue,
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
@@ -18,7 +18,7 @@ package assess
 
 type Assessor interface {
 	Clear()
-	AssessEffect(current int) (int, error)
-	Update(currValue int)
+	AssessEffect(currentPower int) (int, error)
+	Update(power int)
 	AssessTarget(actualWatt int, desiredWatt int, maxDecreasePercent int) int
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
@@ -18,7 +18,7 @@ package assess
 
 type Assessor interface {
 	Clear()
-	AccumulateEffect(current int) int
+	AssessEffect(current int) (int, error)
 	Update(currValue int)
 	AssessTarget(actualWatt int, desiredWatt int, maxDecreasePercent int) int
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assess
+
+type Assessor interface {
+	Clear()
+	AccumulateEffect(current int) int
+	Update(currValue int)
+	AssessTarget(actualWatt int, desiredWatt int, maxDecreasePercent int) int
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess/types.go
@@ -17,8 +17,10 @@ limitations under the License.
 package assess
 
 type Assessor interface {
+	Init() error
+	IsInitialized() bool
 	Clear()
-	AssessEffect(currentPower int) (int, error)
 	Update(power int)
+	AssessEffect(currentPower int, inDVFS, capperAvailable bool) (int, error)
 	AssessTarget(actualWatt int, desiredWatt int, maxDecreasePercent int) int
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
@@ -25,7 +25,7 @@ import (
 // the limit of dvfs effect a voluntary dvfs plan is allowed
 const voluntaryDVFSEffectMaximum = 10
 
-// dvfsTracker keeps track and accumulates the effect lowering power by means of dvfs
+// dvfsTracker keeps track and accumulates the effect lowering power or cpu frequency by means of dvfs
 type dvfsTracker struct {
 	dvfsAccumEffect int
 	inDVFS          bool
@@ -51,19 +51,18 @@ func (d *dvfsTracker) isCapperAvailable() bool {
 	return d.capperProber != nil && d.capperProber.IsCapperReady()
 }
 
-func (d *dvfsTracker) update(currIndicateValue int) {
+func (d *dvfsTracker) update(currPower int) {
 	// only accumulate when dvfs is engaged
 	if d.inDVFS && d.isCapperAvailable() {
-		val, err := d.assessor.AssessEffect(currIndicateValue)
+		val, err := d.assessor.AssessEffect(currPower)
 		if err != nil {
 			general.Errorf("pap: failed to get accumulated effect: %v", err)
-			return
+		} else {
+			d.dvfsAccumEffect = val
 		}
-
-		d.dvfsAccumEffect = val
 	}
 
-	d.assessor.Update(currIndicateValue)
+	d.assessor.Update(currPower)
 }
 
 func (d *dvfsTracker) dvfsEnter() {

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package strategy
 
+import (
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess"
+)
+
 // DVFS: Dynamic Voltage Frequency Scaling, is a technique servers use to manage the power consumption.
 // the limit of dvfs effect a voluntary dvfs plan is allowed
 const voluntaryDVFSEffectMaximum = 10
@@ -24,9 +28,9 @@ const voluntaryDVFSEffectMaximum = 10
 type dvfsTracker struct {
 	dvfsAccumEffect int
 	inDVFS          bool
-	prevPower       int
 
 	capperProber CapperProber
+	assessor     assess.Assessor
 }
 
 func (d *dvfsTracker) getDVFSAllowPercent() int {
@@ -37,21 +41,22 @@ func (d *dvfsTracker) getDVFSAllowPercent() int {
 	return leftPercentage
 }
 
+// adjustTargetWatt yields the target value taking into account the limiting indicator value.
+func (d *dvfsTracker) adjustTargetWatt(actualWatt, desiredWatt int) int {
+	return d.assessor.AssessTarget(actualWatt, desiredWatt, d.getDVFSAllowPercent())
+}
+
 func (d *dvfsTracker) isCapperAvailable() bool {
 	return d.capperProber != nil && d.capperProber.IsCapperReady()
 }
 
-func (d *dvfsTracker) update(actualWatt, desiredWatt int) {
+func (d *dvfsTracker) update(currIndicateValue int) {
 	// only accumulate when dvfs is engaged
-	if d.prevPower >= 0 && d.inDVFS && d.isCapperAvailable() {
-		// if actual power is more than previous, likely previous round dvfs took no effect; not to take into account
-		if actualWatt < d.prevPower {
-			dvfsEffect := (d.prevPower - actualWatt) * 100 / d.prevPower
-			d.dvfsAccumEffect += dvfsEffect
-		}
+	if d.inDVFS && d.isCapperAvailable() {
+		d.dvfsAccumEffect = d.assessor.AccumulateEffect(currIndicateValue)
 	}
 
-	d.prevPower = actualWatt
+	d.assessor.Update(currIndicateValue)
 }
 
 func (d *dvfsTracker) dvfsEnter() {
@@ -64,6 +69,6 @@ func (d *dvfsTracker) dvfsExit() {
 
 func (d *dvfsTracker) clear() {
 	d.dvfsAccumEffect = 0
-	d.prevPower = 0
 	d.inDVFS = false
+	d.assessor.Clear()
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker.go
@@ -18,6 +18,7 @@ package strategy
 
 import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
 
 // DVFS: Dynamic Voltage Frequency Scaling, is a technique servers use to manage the power consumption.
@@ -53,7 +54,13 @@ func (d *dvfsTracker) isCapperAvailable() bool {
 func (d *dvfsTracker) update(currIndicateValue int) {
 	// only accumulate when dvfs is engaged
 	if d.inDVFS && d.isCapperAvailable() {
-		d.dvfsAccumEffect = d.assessor.AccumulateEffect(currIndicateValue)
+		val, err := d.assessor.AssessEffect(currIndicateValue)
+		if err != nil {
+			general.Errorf("pap: failed to get accumulated effect: %v", err)
+			return
+		}
+
+		d.dvfsAccumEffect = val
 	}
 
 	d.assessor.Update(currIndicateValue)

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker_test.go
@@ -56,7 +56,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 		wantDVFSTracker dvfsTracker
 	}{
 		{
-			name: "not in dvfs, not to accumulate",
+			name: "not in dvfs, not to accumulate, and effect is refreshed anyway",
 			fields: fields{
 				dvfsUsed:  3,
 				indvfs:    false,
@@ -69,6 +69,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 			wantDVFSTracker: dvfsTracker{
 				capperProber:    mockProber,
 				dvfsAccumEffect: 3,
+				isEffectCurrent: true,
 				inDVFS:          false,
 				assessor:        assess.NewPowerChangeAssessor(3, 90),
 			},
@@ -87,6 +88,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 			wantDVFSTracker: dvfsTracker{
 				capperProber:    mockProber,
 				dvfsAccumEffect: 13,
+				isEffectCurrent: true,
 				inDVFS:          true,
 				assessor:        assess.NewPowerChangeAssessor(13, 90),
 			},
@@ -105,6 +107,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 			wantDVFSTracker: dvfsTracker{
 				capperProber:    mockProber,
 				dvfsAccumEffect: 3,
+				isEffectCurrent: true,
 				inDVFS:          true,
 				assessor:        assess.NewPowerChangeAssessor(3, 101),
 			},

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/dvfs_tracker_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess"
 )
 
 type mockCapperProber struct {
@@ -68,7 +70,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 				capperProber:    mockProber,
 				dvfsAccumEffect: 3,
 				inDVFS:          false,
-				prevPower:       90,
+				assessor:        assess.NewPowerChangeAssessor(3, 90),
 			},
 		},
 		{
@@ -86,7 +88,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 				capperProber:    mockProber,
 				dvfsAccumEffect: 13,
 				inDVFS:          true,
-				prevPower:       90,
+				assessor:        assess.NewPowerChangeAssessor(13, 90),
 			},
 		},
 		{
@@ -104,7 +106,7 @@ func Test_dvfsTracker_update(t *testing.T) {
 				capperProber:    mockProber,
 				dvfsAccumEffect: 3,
 				inDVFS:          true,
-				prevPower:       101,
+				assessor:        assess.NewPowerChangeAssessor(3, 101),
 			},
 		},
 	}
@@ -116,9 +118,9 @@ func Test_dvfsTracker_update(t *testing.T) {
 				capperProber:    mockProber,
 				dvfsAccumEffect: tt.fields.dvfsUsed,
 				inDVFS:          tt.fields.indvfs,
-				prevPower:       tt.fields.prevPower,
+				assessor:        assess.NewPowerChangeAssessor(3, tt.fields.prevPower),
 			}
-			d.update(tt.args.actualWatt, tt.args.desiredWatt)
+			d.update(tt.args.actualWatt)
 			assert.Equal(t, &tt.wantDVFSTracker, d)
 		})
 	}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first.go
@@ -146,7 +146,6 @@ func (e *evictFirstStrategy) yieldActionPlan(op, internalOp spec.InternalOp, act
 }
 
 func (e *evictFirstStrategy) RecommendAction(actualWatt int, desiredWatt int, alert spec.PowerAlert, internalOp spec.InternalOp, ttl time.Duration) action.PowerAction {
-	// todo: what if indicator of cpu freq?
 	e.dvfsTracker.update(actualWatt)
 
 	e.emitDVFSAccumulatedEffect(e.dvfsTracker.dvfsAccumEffect)

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first.go
@@ -170,7 +170,9 @@ func (e *evictFirstStrategy) emitDVFSAccumulatedEffect(percentage int) {
 	_ = e.emitter.StoreInt64(metricPowerAwareDVFSEffect, int64(percentage), metrics.MetricTypeNameRaw)
 }
 
-func NewEvictFirstStrategy(emitter metrics.MetricEmitter, prober EvictableProber, metricsReader metrictypes.MetricsReader, capper capper.PowerCapper) PowerActionStrategy {
+func NewEvictFirstStrategy(emitter metrics.MetricEmitter, prober EvictableProber,
+	metricsReader metrictypes.MetricsReader, capper capper.PowerCapper, assessor assess.Assessor,
+) PowerActionStrategy {
 	general.Infof("pap: using EvictFirst strategy")
 	capperProber, _ := capper.(CapperProber)
 	return &evictFirstStrategy{
@@ -180,7 +182,7 @@ func NewEvictFirstStrategy(emitter metrics.MetricEmitter, prober EvictableProber
 		dvfsTracker: dvfsTracker{
 			dvfsAccumEffect: 0,
 			capperProber:    capperProber,
-			assessor:        assess.NewPowerChangeAssessor(0, 0),
+			assessor:        assessor,
 		},
 		metricsReader: metricsReader,
 	}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
@@ -52,6 +52,7 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 		coefficient     exponentialDecay
 		evictableProber EvictableProber
 		dvfsUsed        int
+		effectCurrent   bool
 		prevPower       int
 		inDVFS          bool
 	}
@@ -90,9 +91,8 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 		{
 			name: "plan of p0 is constraint when allowing dvfs only",
 			fields: fields{
-				coefficient:     exponentialDecay{},
-				evictableProber: nil,
-				dvfsUsed:        0,
+				dvfsUsed:      0,
+				effectCurrent: true,
 			},
 			args: args{
 				alert:       spec.PowerAlertP0,
@@ -155,6 +155,7 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 			fields: fields{
 				evictableProber: mockPorberFalse,
 				dvfsUsed:        0,
+				effectCurrent:   true,
 			},
 			args: args{
 				actualWatt:  100,
@@ -172,6 +173,7 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 			fields: fields{
 				evictableProber: mockPorberFalse,
 				dvfsUsed:        8,
+				effectCurrent:   true,
 			},
 			args: args{
 				actualWatt:  100,
@@ -202,6 +204,26 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 			},
 			wantInDVFS: false,
 		},
+		{
+			name: "being previously not current effect should be refreshed by current anyway",
+			fields: fields{
+				evictableProber: mockPorberFalse,
+				dvfsUsed:        8,
+				effectCurrent:   false,
+				prevPower:       100,
+				inDVFS:          true,
+			},
+			args: args{
+				actualWatt:  100,
+				desiredWatt: 80,
+				alert:       spec.PowerAlertP0,
+			},
+			want: action.PowerAction{
+				Op:  spec.InternalOpFreqCap,
+				Arg: 98,
+			},
+			wantInDVFS: true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -213,7 +235,8 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 				evictableProber: tt.fields.evictableProber,
 				dvfsTracker: dvfsTracker{
 					dvfsAccumEffect: tt.fields.dvfsUsed,
-					assessor:        assess.NewPowerChangeAssessor(10, 0),
+					isEffectCurrent: tt.fields.effectCurrent,
+					assessor:        assess.NewPowerChangeAssessor(tt.fields.dvfsUsed, 0),
 				},
 				metricsReader: nil,
 			}

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/evict_first_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor/action/strategy/assess"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
@@ -210,8 +211,11 @@ func Test_evictFirstStrategy_RecommendAction(t *testing.T) {
 				emitter:         &metrics.DummyMetrics{},
 				coefficient:     tt.fields.coefficient,
 				evictableProber: tt.fields.evictableProber,
-				dvfsTracker:     dvfsTracker{dvfsAccumEffect: tt.fields.dvfsUsed},
-				metricsReader:   nil,
+				dvfsTracker: dvfsTracker{
+					dvfsAccumEffect: tt.fields.dvfsUsed,
+					assessor:        assess.NewPowerChangeAssessor(10, 0),
+				},
+				metricsReader: nil,
 			}
 			if got := e.RecommendAction(tt.args.actualWatt, tt.args.desiredWatt, tt.args.alert, tt.args.internalOp, tt.args.ttl); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("RecommendAction() = %v, want %v", got, tt.want)

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
@@ -29,10 +29,7 @@ import (
 	powermetric "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/metric"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/reader"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
-	"github.com/kubewharf/katalyst-core/pkg/config/generic"
-	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/node"
-	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
@@ -181,20 +178,17 @@ func NewAdvisor(dryRun bool,
 	podEvictor evictor.PodEvictor,
 	emitter metrics.MetricEmitter,
 	nodeFetcher node.NodeFetcher,
-	qosConfig *generic.QoSConfiguration,
-	podFetcher pod.PodFetcher,
 	reader reader.PowerReader,
 	capper capper.PowerCapper,
-	metricsReader metrictypes.MetricsReader,
+	reconciler PowerReconciler,
 ) PowerAwareAdvisor {
-	percentageEvictor := evictor.NewPowerLoadEvict(qosConfig, emitter, podFetcher, podEvictor)
 	return &powerAwareAdvisor{
 		emitter:     emitter,
 		specFetcher: spec.NewFetcher(nodeFetcher, annotationKeyPrefix),
 		powerReader: reader,
 		podEvictor:  podEvictor,
 		powerCapper: capper,
-		reconciler:  newReconciler(dryRun, metricsReader, emitter, percentageEvictor, capper),
+		reconciler:  reconciler,
 		inFreqCap:   false,
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/reconciler.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/reconciler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/capper"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/evictor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
-	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
@@ -91,13 +90,15 @@ func (p *powerReconciler) Reconcile(ctx context.Context, desired *spec.PowerSpec
 	}
 }
 
-func newReconciler(dryRun bool, metricsReader metrictypes.MetricsReader, emitter metrics.MetricEmitter, evictor evictor.PercentageEvictor, capper capper.PowerCapper) PowerReconciler {
+func NewReconciler(dryRun bool, emitter metrics.MetricEmitter,
+	evictor evictor.PercentageEvictor, capper capper.PowerCapper, strategy strategy.PowerActionStrategy,
+) PowerReconciler {
 	return &powerReconciler{
 		dryRun:      dryRun,
 		priorAction: action.PowerAction{},
 		evictor:     evictor,
 		capper:      capper,
-		strategy:    strategy.NewEvictFirstStrategy(emitter, evictor, metricsReader, capper),
+		strategy:    strategy,
 		emitter:     emitter,
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
@@ -99,8 +99,10 @@ func NewPowerAwarePlugin(
 
 	var assessor assess.Assessor
 	if conf.PowerAwarePluginConfiguration.DVFSIndication == poweraware.DVFSIndicationPower {
+		general.Infof("pap: power as dvfs indication")
 		assessor = assess.NewPowerChangeAssessor(0, 0)
 	} else {
+		general.Infof("pap: cpufreq as dvfs indication")
 		assessor = assess.NewCPUFreqChangeAssessor(0, metaServer)
 	}
 

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware_test.go
@@ -232,3 +232,52 @@ func Test_powerAwarePlugin_Run(t *testing.T) {
 		})
 	}
 }
+
+func TestNewPowerAwarePlugin(t *testing.T) {
+	t.Parallel()
+	stubMetaServer := &metaserver.MetaServer{
+		MetaAgent: &agent.MetaAgent{
+			NodeFetcher: &stubNodeFetcher{},
+		},
+	}
+	type args struct {
+		pluginName string
+		conf       *config.Configuration
+		metaServer *metaserver.MetaServer
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantNil bool
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			args: args{
+				pluginName: "test",
+				conf: &config.Configuration{
+					GenericConfiguration: generic.NewGenericConfiguration(),
+					AgentConfiguration:   agentconf.NewAgentConfiguration(),
+				},
+				metaServer: stubMetaServer,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := NewPowerAwarePlugin(tt.args.pluginName,
+				tt.args.conf, nil, &metricspool.DummyMetricsEmitterPool{},
+				tt.args.metaServer, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewPowerAwarePlugin() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if (got == nil) != tt.wantNil {
+				t.Errorf("NewPowerAwarePlugin() got unexpected value %v", got)
+			}
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/cpufreq_reader.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/cpufreq_reader.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+// malachite realtime freq server imposes delay of up to 2 seconds coupled with sampling interval of 1 sec
+const cpuFreqTolerationTime = 3 * time.Second
+
+type cpuFreqReader struct {
+	NodeMetricGetter
+}
+
+func (c *cpuFreqReader) Init() error {
+	return nil
+}
+
+func (c *cpuFreqReader) Get(ctx context.Context) (int, error) {
+	return c.get(ctx, time.Now())
+}
+
+func (m *cpuFreqReader) get(ctx context.Context, now time.Time) (int, error) {
+	data, err := m.GetNodeMetric(consts.MetricScalingCPUFreqKHZ)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get cpu freq from metric store")
+	}
+
+	// 0 actually is error, typically caused by null response from malachite realtime power service
+	if data.Value == 0 {
+		return 0, errors.New("got invalid 0 cpu freq from metric store")
+	}
+
+	if !isCPUFreqDataFresh(data, now) {
+		return 0, errors.New("cpu freq in metric store is stale")
+	}
+
+	return int(data.Value), nil
+}
+
+func isCPUFreqDataFresh(data utilmetric.MetricData, now time.Time) bool {
+	if data.Time == nil {
+		return false
+	}
+	return now.Before(data.Time.Add(cpuFreqTolerationTime))
+}
+
+func (c *cpuFreqReader) Cleanup() {}
+
+func NewCPUFreqReader(nodeMetricGetter NodeMetricGetter) MetricReader {
+	return &cpuFreqReader{
+		NodeMetricGetter: nodeMetricGetter,
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/cpufreq_reader_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/cpufreq_reader_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+type mockFreqReader struct {
+	mock.Mock
+}
+
+func (m *mockFreqReader) GetNodeMetric(metricName string) (metric.MetricData, error) {
+	args := m.Called(metricName)
+	return args.Get(0).(metric.MetricData), args.Error(1)
+}
+
+func TestCPUFreqReader_get(t *testing.T) {
+	moment := time.Date(2025, 5, 27, 6, 7, 30, 0, time.UTC)
+	TwoSecBefore := time.Date(2025, 5, 27, 6, 7, 28, 0, time.UTC)
+
+	mockFreqReader := new(mockFreqReader)
+	mockFreqReader.On("GetNodeMetric", "scaling.cur.freq.khz").Return(
+		metric.MetricData{
+			Value: 25000_000,
+			Time:  &TwoSecBefore,
+		},
+		nil,
+	)
+
+	t.Parallel()
+	type fields struct {
+		NodeMetricGetter NodeMetricGetter
+	}
+	type args struct {
+		ctx context.Context
+		now time.Time
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    int
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				NodeMetricGetter: mockFreqReader,
+			},
+			args: args{
+				ctx: context.TODO(),
+				now: moment,
+			},
+			want:    25000_000,
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &cpuFreqReader{
+				NodeMetricGetter: tt.fields.NodeMetricGetter,
+			}
+			got, err := m.get(tt.args.ctx, tt.args.now)
+			if !tt.wantErr(t, err, fmt.Sprintf("get(%v, %v)", tt.args.ctx, tt.args.now)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "get(%v, %v)", tt.args.ctx, tt.args.now)
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/metric_store_power_reader.go
@@ -29,19 +29,19 @@ import (
 // malachite realtime power metric server imposes delay of up to 2 seconds coupled with sampling interval of 1 sec
 const powerTolerationTime = 3 * time.Second
 
-type nodeMetricGetter interface {
+type NodeMetricGetter interface {
 	GetNodeMetric(metricName string) (utilmetric.MetricData, error)
 }
 
 type metricStorePowerReader struct {
-	nodeMetricGetter
+	NodeMetricGetter
 }
 
 func (m *metricStorePowerReader) Init() error {
 	return nil
 }
 
-func isDataFresh(data utilmetric.MetricData, now time.Time) bool {
+func isPowerDataFresh(data utilmetric.MetricData, now time.Time) bool {
 	if data.Time == nil {
 		return false
 	}
@@ -63,7 +63,7 @@ func (m *metricStorePowerReader) get(ctx context.Context, now time.Time) (int, e
 		return 0, errors.New("got invalid 0 power usage from metric store")
 	}
 
-	if !isDataFresh(data, now) {
+	if !isPowerDataFresh(data, now) {
 		return 0, errors.New("power data in metric store is stale")
 	}
 
@@ -72,8 +72,8 @@ func (m *metricStorePowerReader) get(ctx context.Context, now time.Time) (int, e
 
 func (m *metricStorePowerReader) Cleanup() {}
 
-func NewMetricStorePowerReader(nodeMetricGetter nodeMetricGetter) PowerReader {
+func NewMetricStorePowerReader(nodeMetricGetter NodeMetricGetter) PowerReader {
 	return &metricStorePowerReader{
-		nodeMetricGetter: nodeMetricGetter,
+		NodeMetricGetter: nodeMetricGetter,
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/reader/reader.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/reader/reader.go
@@ -24,6 +24,10 @@ import (
 var errNotRealReader = errors.New("not a real power reader")
 
 type PowerReader interface {
+	MetricReader
+}
+
+type MetricReader interface {
 	Init() error
 	Get(ctx context.Context) (int, error)
 	Cleanup()

--- a/pkg/config/agent/metaserver/agent.go
+++ b/pkg/config/agent/metaserver/agent.go
@@ -23,11 +23,16 @@ import (
 )
 
 const (
-	MetricProvisionerMalachite         = "malachite"
-	MetricProvisionerMalachiteRealtime = "malachite_realtime"
-	MetricProvisionerCgroup            = "cgroup"
-	MetricProvisionerKubelet           = "kubelet"
-	MetricProvisionerRodan             = "rodan"
+	MetricProvisionerMalachite = "malachite"
+
+	// MetricProvisionerMalachiteRealtime is for power metric due to historical reason
+	// todo: consider rename it to malachite_realtime_power
+	MetricProvisionerMalachiteRealtime     = "malachite_realtime"
+	MetricProvisionerMalachiteRealtimeFreq = "malachite_realtime_freq"
+
+	MetricProvisionerCgroup  = "cgroup"
+	MetricProvisionerKubelet = "kubelet"
+	MetricProvisionerRodan   = "rodan"
 )
 
 type MetricConfiguration struct {

--- a/pkg/config/agent/sysadvisor/poweraware/power_aware_plugin.go
+++ b/pkg/config/agent/sysadvisor/poweraware/power_aware_plugin.go
@@ -16,12 +16,18 @@ limitations under the License.
 
 package poweraware
 
+const (
+	DVFSIndicationPower   = "power"
+	DVFSIndicationCPUFreq = "cpufreq"
+)
+
 type PowerAwarePluginConfiguration struct {
 	DryRun                           bool
 	DisablePowerCapping              bool
 	DisablePowerPressureEvict        bool
 	PowerCappingAdvisorSocketAbsPath string
 	AnnotationKeyPrefix              string
+	DVFSIndication                   string
 }
 
 // NewPowerAwarePluginConfiguration creates a default config

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -138,9 +138,10 @@ const (
 	MetricsNodeFsInodesUsed = "used.inodes.fs.node"
 )
 
-// System Power metrics
+// System Power and CPUFreq metrics
 const (
 	MetricTotalPowerUsedWatts = "total.power.used.watts"
+	MetricScalingCPUFreqKHZ   = "scaling.cur.freq.khz"
 )
 
 // Image filesystem metrics

--- a/pkg/metaserver/agent/metric/metric_provisoner.go
+++ b/pkg/metaserver/agent/metric/metric_provisoner.go
@@ -34,7 +34,8 @@ import (
 
 func init() {
 	RegisterProvisioners(metaserver.MetricProvisionerMalachite, malachite.NewMalachiteMetricsProvisioner)
-	RegisterProvisioners(metaserver.MetricProvisionerMalachiteRealtime, malachite.NewMalachiteRealtimeMetricsProvisioner)
+	RegisterProvisioners(metaserver.MetricProvisionerMalachiteRealtime, malachite.NewRealtimePowerMetricsProvisioner)
+	RegisterProvisioners(metaserver.MetricProvisionerMalachiteRealtimeFreq, malachite.NewRealtimeFreqMetricsProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerKubelet, kubelet.NewKubeletSummaryProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerCgroup, cgroup.NewCGroupMetricsProvisioner)
 	RegisterProvisioners(metaserver.MetricProvisionerRodan, rodan.NewRodanMetricsProvisioner)

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
@@ -37,7 +37,8 @@ const (
 	SystemComputeResource = "system/compute"
 	SystemInfoResource    = "system/info"
 
-	RealtimePowerResource = "realtime/power"
+	RealtimePowerResource   = "realtime/power"
+	RealtimeSysFreqResource = "realtime/freq"
 )
 
 const (
@@ -82,6 +83,7 @@ func NewMalachiteClient(fetcher pod.PodFetcher, emitter metrics.MetricEmitter) *
 		SystemComputeResource,
 		SystemMemoryResource,
 		RealtimePowerResource,
+		RealtimeSysFreqResource,
 	} {
 		urls[path] = fmt.Sprintf("http://localhost:%d/api/v1/%s", malachiteServicePort, path)
 	}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_power.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_power.go
@@ -26,25 +26,25 @@ import (
 )
 
 func (c *MalachiteClient) GetPowerData() (*types.PowerData, error) {
-	payload, err := c.getRealtimePowerPayload(RealtimePowerResource)
+	payload, err := c.getRealtimePayload(RealtimePowerResource)
 	if err != nil {
 		return nil, err
 	}
 
 	rsp := &types.MalachitePowerResponse{}
 	if err := json.Unmarshal(payload, rsp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal system compute stats raw data, err %s", err)
+		return nil, fmt.Errorf("failed to unmarshal raw data, err %s", err)
 	}
 
 	if rsp.Status != 0 {
-		return nil, fmt.Errorf("system compute stats status is not ok, %d", rsp.Status)
+		return nil, fmt.Errorf("realtime power status is not ok, %d", rsp.Status)
 	}
 
 	c.checkSystemStatsOutOfDate("power", RealtimeUpdateTimeout, rsp.Data.Sensors.UpdateTime)
 	return &rsp.Data, nil
 }
 
-func (c *MalachiteClient) getRealtimePowerPayload(resource string) ([]byte, error) {
+func (c *MalachiteClient) getRealtimePayload(resource string) ([]byte, error) {
 	c.RLock()
 	defer c.RUnlock()
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_sysfreq.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_sysfreq.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+)
+
+func (c *MalachiteClient) GetSysFreqData() (*types.SysFreqData, error) {
+	payload, err := c.getRealtimePayload(RealtimeSysFreqResource)
+	if err != nil {
+		return nil, err
+	}
+
+	rsp := &types.MalachiteSysFreqResponse{}
+	if err := json.Unmarshal(payload, rsp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal raw data, err %s", err)
+	}
+
+	if rsp.Status != 0 {
+		return nil, fmt.Errorf("realtime sysfreq status is not ok, %d", rsp.Status)
+	}
+
+	c.checkSystemStatsOutOfDate("sysfreq", RealtimeUpdateTimeout, rsp.Data.SysFreq.UpdateTime)
+
+	return &rsp.Data, nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_sysfreq_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_sysfreq_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+func TestMalachiteClient_GetSysFreqData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		respBody string
+		want     *types.SysFreqData
+		wantErr  assert.ErrorAssertionFunc
+	}{
+		{
+			name: "happy path",
+			respBody: `{"status":0,
+				"data":{
+					"sysfreq":{
+						"cpu_freq":[{"scaling_cur_freq":2598884}],
+						"update_time":1748574860
+					}
+				}
+			}`,
+			want: &types.SysFreqData{
+				SysFreq: types.SysFreq{
+					CPUFreq: []types.ScalingCurFreq{
+						{FreqKHZ: 2598884},
+					},
+					UpdateTime: 1748574860,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(tt.respBody))
+			}))
+			defer s.Close()
+
+			c := &MalachiteClient{
+				emitter: metrics.DummyMetrics{},
+				urls:    map[string]string{"realtime/freq": s.URL},
+			}
+			got, err := c.GetSysFreqData()
+			if !tt.wantErr(t, err, fmt.Sprintf("GetSysFreqData()")) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetSysFreqData()")
+		})
+	}
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_sysfreq_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_sysfreq_test.go
@@ -49,8 +49,8 @@ func TestMalachiteClient_GetSysFreqData(t *testing.T) {
 			}`,
 			want: &types.SysFreqData{
 				SysFreq: types.SysFreq{
-					CPUFreq: []types.ScalingCurFreq{
-						{FreqKHZ: 2598884},
+					CPUFreq: []types.CurFreq{
+						{ScalingCurFreqKHZ: 2598884},
 					},
 					UpdateTime: 1748574860,
 				},

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_freq_provisoner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_freq_provisoner.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package malachite
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/client"
+	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+const (
+	realtimeFreqProvisioner                         = "malachite_realtime_freq"
+	metricsNameMalachiteRealtimeFreqUnHealthy       = "malachite_realtime_freq_unhealthy"
+	malachiteRealtimeFreqProvisionerHealthCheckName = "malachite_realtime_freq_provisioner_sample"
+	metricsNameMalachiteGetRealtimeFreqFailed       = "malachite_get_realtime_freq_failed"
+)
+
+func NewRealtimeFreqMetricsProvisioner(baseConf *global.BaseConfiguration, _ *metaserver.MetricConfiguration,
+	emitter metrics.MetricEmitter, fetcher pod.PodFetcher, metricStore *utilmetric.MetricStore, _ *machine.KatalystMachineInfo,
+) types.MetricsProvisioner {
+	inner := &MalachiteMetricsProvisioner{
+		malachiteClient: client.NewMalachiteClient(fetcher, emitter),
+		metricStore:     metricStore,
+		emitter:         emitter,
+		baseConf:        baseConf,
+	}
+
+	return &RealtimeFreqMetricsProvisioner{
+		dataGetter:                  inner.malachiteClient,
+		MalachiteMetricsProvisioner: inner,
+	}
+}
+
+type RealtimeFreqMetricsProvisioner struct {
+	dataGetter sysFreqDataGetter
+	*MalachiteMetricsProvisioner
+}
+
+func (m *RealtimeFreqMetricsProvisioner) Run(ctx context.Context) {
+	m.startOnce.Do(func() {
+		general.RegisterHeartbeatCheck(malachiteRealtimeFreqProvisionerHealthCheckName,
+			malachiteRealtimeProvisionTolerationTime,
+			general.HealthzCheckStateNotReady,
+			malachiteRealtimeProvisionTolerationTime)
+	})
+	m.sample(ctx)
+}
+
+func (m *RealtimeFreqMetricsProvisioner) sample(ctx context.Context) {
+	klog.V(4).Infof("[%s] heartbeat", realtimeFreqProvisioner)
+
+	// todo: consolidate check healthy and update with single get data call
+	if !m.checkMalachiteHealthy() {
+		_ = general.UpdateHealthzState(malachiteRealtimeFreqProvisionerHealthCheckName,
+			general.HealthzCheckStateNotReady, "malachite realtime freq is not healthy")
+		return
+	}
+
+	errList := make([]error, 0)
+	if err := m.updateSystemCPUFreq(); err != nil {
+		errList = append(errList, err)
+	}
+
+	_ = general.UpdateHealthzStateByError(malachiteRealtimeFreqProvisionerHealthCheckName, errors.NewAggregate(errList))
+}
+
+func (m *RealtimeFreqMetricsProvisioner) checkMalachiteHealthy() bool {
+	_, err := m.dataGetter.GetSysFreqData()
+	if err != nil {
+		klog.Errorf("[%s] service is unhealthy: %v", realtimeFreqProvisioner, err)
+		_ = m.emitter.StoreInt64(metricsNameMalachiteRealtimeFreqUnHealthy, 1, metrics.MetricTypeNameRaw)
+		return false
+	}
+
+	return true
+}
+
+func (m *RealtimeFreqMetricsProvisioner) updateSystemCPUFreq() error {
+	errList := make([]error, 0)
+	data, err := m.dataGetter.GetSysFreqData()
+	if err != nil {
+		errList = append(errList, err)
+		klog.Errorf("[%s] get cpufreq data failed, err %v", realtimeFreqProvisioner, err)
+		_ = m.emitter.StoreInt64(metricsNameMalachiteGetRealtimeFreqFailed, 1, metrics.MetricTypeNameCount,
+			metrics.MetricTag{Key: "kind", Val: "power"})
+	} else {
+		m.processSystemCPUFreqData(data)
+	}
+
+	return errors.NewAggregate(errList)
+}
+
+func (m *RealtimeFreqMetricsProvisioner) processSystemCPUFreqData(data *malachitetypes.SysFreqData) {
+	if data == nil {
+		return
+	}
+
+	cpuFreqKHZ, err := getScalingCurFreq(data)
+	if err != nil {
+		general.Warningf("[%s] pap: failed to get freq: %v", realtimeFreqProvisioner, err)
+		return
+	}
+
+	updateTime := time.Unix(data.SysFreq.UpdateTime, 0)
+	m.metricStore.SetNodeMetric(consts.MetricScalingCPUFreqKHZ,
+		utilmetric.MetricData{Value: float64(cpuFreqKHZ.ScalingCurFreqKHZ), Time: &updateTime})
+}
+
+func getScalingCurFreq(data *malachitetypes.SysFreqData) (*malachitetypes.CurFreq, error) {
+	cpuFreqs := data.SysFreq.CPUFreq
+	if len(cpuFreqs) == 0 {
+		return nil, fmt.Errorf("empty cpufreq data")
+	}
+
+	// always use element 0
+	return &cpuFreqs[0], nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_freq_provisoner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_freq_provisoner_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package malachite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+
+	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+type mockSysFreqDataGetter struct {
+	mock.Mock
+}
+
+func (m *mockSysFreqDataGetter) GetSysFreqData() (*malachitetypes.SysFreqData, error) {
+	args := m.Called()
+	return args.Get(0).(*malachitetypes.SysFreqData), args.Error(1)
+}
+
+func TestRealtimeFreqMetricsProvisioner_Run(t *testing.T) {
+	t.Parallel()
+
+	mockClient := new(mockSysFreqDataGetter)
+	mockClient.On("GetSysFreqData").Return(
+		&malachitetypes.SysFreqData{
+			SysFreq: malachitetypes.SysFreq{
+				CPUFreq: []malachitetypes.CurFreq{
+					{ScalingCurFreqKHZ: 1_234_000},
+				},
+				UpdateTime: 77777,
+			},
+		},
+		nil,
+	)
+
+	type fields struct {
+		dataGetter                  *mockSysFreqDataGetter
+		MalachiteMetricsProvisioner *MalachiteMetricsProvisioner
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				dataGetter: mockClient,
+				MalachiteMetricsProvisioner: &MalachiteMetricsProvisioner{
+					emitter:     &metrics.DummyMetrics{},
+					metricStore: utilmetric.NewMetricStore(),
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &RealtimeFreqMetricsProvisioner{
+				dataGetter:                  tt.fields.dataGetter,
+				MalachiteMetricsProvisioner: tt.fields.MalachiteMetricsProvisioner,
+			}
+			m.Run(tt.args.ctx)
+			tt.fields.dataGetter.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner.go
@@ -174,10 +174,10 @@ func (m *MalachiteRealtimeMetricsProvisioner) processSystemCPUFreqData(data *mal
 
 	updateTime := time.Unix(data.SysFreq.UpdateTime, 0)
 	m.metricStore.SetNodeMetric(consts.MetricScalingCPUFreqKHZ,
-		utilmetric.MetricData{Value: float64(cpuFreqKHZ.FreqKHZ), Time: &updateTime})
+		utilmetric.MetricData{Value: float64(cpuFreqKHZ.ScalingCurFreqKHZ), Time: &updateTime})
 }
 
-func getScalingCurFreq(data *malachitetypes.SysFreqData) (*malachitetypes.ScalingCurFreq, error) {
+func getScalingCurFreq(data *malachitetypes.SysFreqData) (*malachitetypes.CurFreq, error) {
 	cpuFreqs := data.SysFreq.CPUFreq
 	if len(cpuFreqs) == 0 {
 		return nil, fmt.Errorf("empty cpufreq data")

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
@@ -108,12 +108,28 @@ func (m *mockPowerDataGetter) GetPowerData() (*malachitetypes.PowerData, error) 
 	return args.Get(0).(*malachitetypes.PowerData), args.Error(1)
 }
 
+func (m *mockPowerDataGetter) GetSysFreqData() (*malachitetypes.SysFreqData, error) {
+	args := m.Called()
+	return args.Get(0).(*malachitetypes.SysFreqData), args.Error(1)
+}
+
 func TestMalachiteRealtimeMetricsProvisioner_Run(t *testing.T) {
 	t.Parallel()
 
 	mockPowerDataClient := new(mockPowerDataGetter)
 	mockPowerDataClient.On("GetPowerData").Return(
 		&malachitetypes.PowerData{Sensors: malachitetypes.SensorData{TotalPowerWatt: 345, UpdateTime: 77777}},
+		nil,
+	)
+	mockPowerDataClient.On("GetSysFreqData").Return(
+		&malachitetypes.SysFreqData{
+			SysFreq: malachitetypes.SysFreq{
+				CPUFreq: []malachitetypes.ScalingCurFreq{
+					{FreqKHZ: 1_234_000},
+				},
+				UpdateTime: 77777,
+			},
+		},
 		nil,
 	)
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
@@ -124,8 +124,8 @@ func TestMalachiteRealtimeMetricsProvisioner_Run(t *testing.T) {
 	mockPowerDataClient.On("GetSysFreqData").Return(
 		&malachitetypes.SysFreqData{
 			SysFreq: malachitetypes.SysFreq{
-				CPUFreq: []malachitetypes.ScalingCurFreq{
-					{FreqKHZ: 1_234_000},
+				CPUFreq: []malachitetypes.CurFreq{
+					{ScalingCurFreqKHZ: 1_234_000},
 				},
 				UpdateTime: 77777,
 			},

--- a/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/realtime_provisioner_test.go
@@ -29,7 +29,7 @@ import (
 	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
 )
 
-func TestMalachiteRealtimeMetricsProvisioner_processSystemPowerData(t *testing.T) {
+func TestRealtimePowerMetricsProvisioner_processSystemPowerData(t *testing.T) {
 	t.Parallel()
 
 	testTimestamp := time.Date(2024, 11, 12, 0, 0, 0, 0, time.Local)
@@ -86,7 +86,7 @@ func TestMalachiteRealtimeMetricsProvisioner_processSystemPowerData(t *testing.T
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := &MalachiteRealtimeMetricsProvisioner{
+			m := &RealtimePowerMetricsProvisioner{
 				MalachiteMetricsProvisioner: tt.fields.MalachiteMetricsProvisioner,
 			}
 			m.processSystemPowerData(tt.args.data)
@@ -108,28 +108,12 @@ func (m *mockPowerDataGetter) GetPowerData() (*malachitetypes.PowerData, error) 
 	return args.Get(0).(*malachitetypes.PowerData), args.Error(1)
 }
 
-func (m *mockPowerDataGetter) GetSysFreqData() (*malachitetypes.SysFreqData, error) {
-	args := m.Called()
-	return args.Get(0).(*malachitetypes.SysFreqData), args.Error(1)
-}
-
 func TestMalachiteRealtimeMetricsProvisioner_Run(t *testing.T) {
 	t.Parallel()
 
 	mockPowerDataClient := new(mockPowerDataGetter)
 	mockPowerDataClient.On("GetPowerData").Return(
 		&malachitetypes.PowerData{Sensors: malachitetypes.SensorData{TotalPowerWatt: 345, UpdateTime: 77777}},
-		nil,
-	)
-	mockPowerDataClient.On("GetSysFreqData").Return(
-		&malachitetypes.SysFreqData{
-			SysFreq: malachitetypes.SysFreq{
-				CPUFreq: []malachitetypes.CurFreq{
-					{ScalingCurFreqKHZ: 1_234_000},
-				},
-				UpdateTime: 77777,
-			},
-		},
 		nil,
 	)
 
@@ -163,8 +147,8 @@ func TestMalachiteRealtimeMetricsProvisioner_Run(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := &MalachiteRealtimeMetricsProvisioner{
-				malachiteClient:             tt.fields.malachiteClient,
+			m := &RealtimePowerMetricsProvisioner{
+				dataGetter:                  tt.fields.malachiteClient,
 				MalachiteMetricsProvisioner: tt.fields.MalachiteMetricsProvisioner,
 			}
 			m.Run(tt.args.ctx)

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/sysfreq.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/sysfreq.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+type MalachiteSysFreqResponse struct {
+	Status int         `json:"status"`
+	Data   SysFreqData `json:"data"`
+}
+
+type SysFreqData struct {
+	SysFreq SysFreq `json:"sysfreq"`
+}
+
+type SysFreq struct {
+	CPUFreq    []ScalingCurFreq `json:"cpu_freq"`
+	UpdateTime int64            `json:"update_time"`
+}
+
+type ScalingCurFreq struct {
+	FreqKHZ int64 `json:"scaling_cur_freq"`
+}

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/sysfreq.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/sysfreq.go
@@ -26,10 +26,10 @@ type SysFreqData struct {
 }
 
 type SysFreq struct {
-	CPUFreq    []ScalingCurFreq `json:"cpu_freq"`
-	UpdateTime int64            `json:"update_time"`
+	CPUFreq    []CurFreq `json:"cpu_freq"`
+	UpdateTime int64     `json:"update_time"`
 }
 
-type ScalingCurFreq struct {
-	FreqKHZ int64 `json:"scaling_cur_freq"`
+type CurFreq struct {
+	ScalingCurFreqKHZ int64 `json:"scaling_cur_freq"`
 }


### PR DESCRIPTION
#### What type of PR is this?
Enhancements - major change to existing feature of power aware advisor

#### What this PR does / why we need it:
this PR introduces a new way to safeguard compute while lowering power with at most 10% cpu freq decrease.

The current way is attempt to limit power decrease up to 10%; however it may lead to excessive compute loss as power is indirect indication of compute and it is hard to ensure cpu frequency above certain level. 

This enhancement leverages malachite realtime/freq service, which provides cpuFreq in realtime latency, as the direct indication of compute.  

#### Special notes for your reviewer:
* to deploy on cluster w/o realtime/freq: no extra setting needed as is;
* to deploy w/ realtime/freq enabling cpufreq feature:  add statr-up arg (as defined by helm chart values) 
  * --power-aware-dvfs-indication=cpufreq
  * --metric-provisioners=...,malachite_realtime_freq