### PR TITLE
fix: remove redundant numa exclusive check for memory offloading

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/memory_offloading.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/memory_offloading.go
@@ -525,8 +525,9 @@ func (tmo *transparentMemoryOffloading) Reconcile(status *types.MemoryPressureSt
 
 			// disable TMO if the Pod is numa exclusive and is not reclaimable
 			enableReclaim, _ := helper.PodEnableReclaim(context.Background(), tmo.metaServer, containerInfo.PodUID, true)
-			if containerInfo.IsNumaExclusive() && !enableReclaim {
+			if !enableReclaim {
 				tmo.containerTmoEngines[podContainerName].GetConf().EnableTMO = false
+				tmo.containerTmoEngines[podContainerName].GetConf().EnableSwap = false
 				general.Infof("container with podContainerName: %s is required to disable TMO since it is not reclaimable", podContainerName)
 			}
 
@@ -539,6 +540,7 @@ func (tmo *transparentMemoryOffloading) Reconcile(status *types.MemoryPressureSt
 			for tmoBlockFnName, tmoBlockFn := range funcs {
 				if tmoBlockFn(containerInfo, tmo.extraConf, tmo.conf.GetDynamicConfiguration().BlockConfig) {
 					tmo.containerTmoEngines[podContainerName].GetConf().EnableTMO = false
+					tmo.containerTmoEngines[podContainerName].GetConf().EnableSwap = false
 					general.Infof("container with podContainerName: %s is required to disable TMO by TMOBlockFn: %s", podContainerName, tmoBlockFnName)
 				}
 			}


### PR DESCRIPTION


#### What type of PR is this?
Bug fixes


#### What this PR does / why we need it:
The numa exclusive check was redundant since we already check for reclaimability. This simplifies the condition while maintaining the same behavior.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
