### PR TITLE
refactor(hintoptimizer): move metric preferred numa allocation to hint optimizer config

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/cpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/cpu_plugin.go
@@ -46,7 +46,6 @@ type CPUDynamicPolicyOptions struct {
 	CPUNUMAHintPreferPolicy                   string
 	CPUNUMAHintPreferLowThreshold             float64
 	SharedCoresNUMABindingResultAnnotationKey string
-	EnableMetricPreferredNumaAllocation       bool
 	EnableReserveCPUReversely                 bool
 	*hintoptimizer.HintOptimizerOptions
 }
@@ -74,7 +73,6 @@ func NewCPUOptions() *CPUOptions {
 				commonstate.PoolNameReserve,
 			},
 			SharedCoresNUMABindingResultAnnotationKey: consts.PodAnnotationNUMABindResultKey,
-			EnableMetricPreferredNumaAllocation:       false,
 			HintOptimizerOptions:                      hintoptimizer.NewHintOptimizerOptions(),
 		},
 		CPUNativePolicyOptions: CPUNativePolicyOptions{
@@ -106,8 +104,6 @@ func (o *CPUOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.BoolVar(&o.EnableCPUIdle, "enable-cpu-idle", o.EnableCPUIdle,
 		"if set true, we will enable cpu idle for "+
 			"specific cgroup paths and it requires --enable-syncing-cpu-idle=true to make effect")
-	fs.BoolVar(&o.EnableMetricPreferredNumaAllocation, "enable-metric-preferred-numa-allocation", o.EnableMetricPreferredNumaAllocation,
-		"if set true, we will enable metric preferred numa")
 	fs.StringVar(&o.CPUAllocationOption, "cpu-allocation-option",
 		o.CPUAllocationOption, "The allocation option of cpu (packed/distributed). The default value is packed."+
 			"in cases where more than one NUMA node is required to satisfy the allocation.")
@@ -135,7 +131,6 @@ func (o *CPUOptions) ApplyTo(conf *qrmconfig.CPUQRMPluginConfig) error {
 	conf.EnableCPUIdle = o.EnableCPUIdle
 	conf.EnableFullPhysicalCPUsOnly = o.EnableFullPhysicalCPUsOnly
 	conf.CPUAllocationOption = o.CPUAllocationOption
-	conf.EnableMetricPreferredNumaAllocation = o.EnableMetricPreferredNumaAllocation
 	conf.SharedCoresNUMABindingResultAnnotationKey = o.SharedCoresNUMABindingResultAnnotationKey
 	conf.EnableReserveCPUReversely = o.EnableReserveCPUReversely
 	if err := o.HintOptimizerOptions.ApplyTo(conf.HintOptimizerConfiguration); err != nil {

--- a/cmd/katalyst-agent/app/options/qrm/hintoptimizer/metricbased.go
+++ b/cmd/katalyst-agent/app/options/qrm/hintoptimizer/metricbased.go
@@ -22,15 +22,24 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm/hintoptimizer"
 )
 
-type MetricBasedHintOptimizerOptions struct{}
+type MetricBasedHintOptimizerOptions struct {
+	EnableMetricPreferredNumaAllocation bool
+}
 
 func NewMetricBasedHintOptimizerOptions() *MetricBasedHintOptimizerOptions {
-	return &MetricBasedHintOptimizerOptions{}
+	return &MetricBasedHintOptimizerOptions{
+		EnableMetricPreferredNumaAllocation: false,
+	}
 }
 
 func (o *MetricBasedHintOptimizerOptions) AddFlags(fss *cliflag.NamedFlagSets) {
+	fs := fss.FlagSet("metric_based_hint_optimizer")
+
+	fs.BoolVar(&o.EnableMetricPreferredNumaAllocation, "enable-metric-preferred-numa-allocation", o.EnableMetricPreferredNumaAllocation,
+		"if set true, we will enable metric preferred numa")
 }
 
 func (o *MetricBasedHintOptimizerOptions) ApplyTo(conf *hintoptimizer.MetricBasedHintOptimizerConfig) error {
+	conf.EnableMetricPreferredNumaAllocation = o.EnableMetricPreferredNumaAllocation
 	return nil
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -128,7 +128,6 @@ type DynamicPolicy struct {
 	podLabelKeptKeys                          []string
 	sharedCoresNUMABindingResultAnnotationKey string
 	transitionPeriod                          time.Duration
-	enableMetricPreferredNumaAllocation       bool
 
 	reservedReclaimedCPUsSize                 int
 	reservedReclaimedCPUSet                   machine.CPUSet
@@ -194,21 +193,20 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 
 		cpuPressureEviction: cpuPressureEviction,
 
-		conf:                                conf,
-		qosConfig:                           conf.QoSConfiguration,
-		dynamicConfig:                       conf.DynamicAgentConfiguration,
-		cpuAdvisorSocketAbsPath:             conf.CPUAdvisorSocketAbsPath,
-		cpuPluginSocketAbsPath:              conf.CPUPluginSocketAbsPath,
-		enableReclaimNUMABinding:            conf.EnableReclaimNUMABinding,
-		enableSNBHighNumaPreference:         conf.EnableSNBHighNumaPreference,
-		enableCPUAdvisor:                    conf.CPUQRMPluginConfig.EnableCPUAdvisor,
-		getAdviceInterval:                   conf.CPUQRMPluginConfig.GetAdviceInterval,
-		enableMetricPreferredNumaAllocation: conf.CPUQRMPluginConfig.EnableMetricPreferredNumaAllocation,
-		reservedCPUs:                        reservedCPUs,
-		extraStateFileAbsPath:               conf.ExtraStateFileAbsPath,
-		enableSyncingCPUIdle:                conf.CPUQRMPluginConfig.EnableSyncingCPUIdle,
-		enableCPUIdle:                       conf.CPUQRMPluginConfig.EnableCPUIdle,
-		reclaimRelativeRootCgroupPath:       conf.ReclaimRelativeRootCgroupPath,
+		conf:                          conf,
+		qosConfig:                     conf.QoSConfiguration,
+		dynamicConfig:                 conf.DynamicAgentConfiguration,
+		cpuAdvisorSocketAbsPath:       conf.CPUAdvisorSocketAbsPath,
+		cpuPluginSocketAbsPath:        conf.CPUPluginSocketAbsPath,
+		enableReclaimNUMABinding:      conf.EnableReclaimNUMABinding,
+		enableSNBHighNumaPreference:   conf.EnableSNBHighNumaPreference,
+		enableCPUAdvisor:              conf.CPUQRMPluginConfig.EnableCPUAdvisor,
+		getAdviceInterval:             conf.CPUQRMPluginConfig.GetAdviceInterval,
+		reservedCPUs:                  reservedCPUs,
+		extraStateFileAbsPath:         conf.ExtraStateFileAbsPath,
+		enableSyncingCPUIdle:          conf.CPUQRMPluginConfig.EnableSyncingCPUIdle,
+		enableCPUIdle:                 conf.CPUQRMPluginConfig.EnableCPUIdle,
+		reclaimRelativeRootCgroupPath: conf.ReclaimRelativeRootCgroupPath,
 		numaBindingReclaimRelativeRootCgroupPaths: common.GetNUMABindingReclaimRelativeRootCgroupPaths(conf.ReclaimRelativeRootCgroupPath,
 			agentCtx.CPUDetails.NUMANodes().ToSliceNoSortInt()),
 		podDebugAnnoKeys:                          conf.PodDebugAnnoKeys,

--- a/pkg/config/agent/qrm/cpu_plugin.go
+++ b/pkg/config/agent/qrm/cpu_plugin.go
@@ -48,8 +48,6 @@ type CPUDynamicPolicyConfig struct {
 	EnableSyncingCPUIdle bool
 	// EnableCPUIdle indicates whether enabling cpu idle
 	EnableCPUIdle bool
-	// EnableMetricPreferredNumaAllocation indicates whether to enable metric preferred numa allocation
-	EnableMetricPreferredNumaAllocation bool
 	// SharedCoresNUMABindingResultAnnotationKey is the annotation key for storing NUMA binding results of shared_cores QoS pods.
 	// It enables schedulers to specify NUMA binding results, and the plugin will make best efforts to follow these results.
 	// This key must be included in the pod-annotation-kept-keys configuration.

--- a/pkg/config/agent/qrm/hintoptimizer/metricbased.go
+++ b/pkg/config/agent/qrm/hintoptimizer/metricbased.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package hintoptimizer
 
-type MetricBasedHintOptimizerConfig struct{}
+type MetricBasedHintOptimizerConfig struct {
+	// EnableMetricPreferredNumaAllocation indicates whether to enable metric preferred numa allocation
+	EnableMetricPreferredNumaAllocation bool
+}
 
 func NewMetricBasedHintOptimizerConfig() *MetricBasedHintOptimizerConfig {
 	return &MetricBasedHintOptimizerConfig{}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Move EnableMetricPreferredNumaAllocation flag from CPU plugin config to hint optimizer config Add flag configuration for metric based hint optimizer Remove unused EnableMetricPreferredNumaAllocation references from CPU plugin
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
