### PR TITLE
fix(memory): copy missing annotations in sidecar allocation

### DIFF
--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/util.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/util.go
@@ -97,9 +97,19 @@ func getReservedMemory(conf *config.Configuration, metaServer *metaserver.MetaSe
 }
 
 func applySidecarAllocationInfoFromMainContainer(sidecarAllocationInfo, mainAllocationInfo *state.AllocationInfo) bool {
+	changed := false
 	if !sidecarAllocationInfo.NumaAllocationResult.Equals(mainAllocationInfo.NumaAllocationResult) {
 		sidecarAllocationInfo.NumaAllocationResult = mainAllocationInfo.NumaAllocationResult.Clone()
-		return true
+		changed = true
 	}
-	return false
+
+	// Copy missing annotations from main container
+	for key, value := range mainAllocationInfo.Annotations {
+		if _, ok := sidecarAllocationInfo.Annotations[key]; !ok {
+			sidecarAllocationInfo.Annotations[key] = value
+			changed = true
+		}
+	}
+
+	return changed
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Ensure sidecar containers inherit all annotations from their main containers by copying missing annotations when applying allocation info. This prevents potential inconsistencies in container configurations.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
