### PR TITLE
feat(evictionmanager): add pod uid to eviction key and fetcher support

### DIFF
--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -169,7 +169,7 @@ func NewEvictionManager(genericClient *client.GenericClientSet, recorder events.
 		return nil, fmt.Errorf("unsupported pod killer %v", conf.PodKiller)
 	}
 
-	podKiller := podkiller.NewAsynchronizedPodKiller(killer, genericClient.KubeClient)
+	podKiller := podkiller.NewAsynchronizedPodKiller(killer, metaServer.PodFetcher, genericClient.KubeClient)
 
 	cnrTaintReporter, err := control.NewGenericReporterPlugin(cnrTaintReporterPluginName, conf, emitter)
 	if err != nil {

--- a/pkg/agent/evictionmanager/podkiller/podkiller.go
+++ b/pkg/agent/evictionmanager/podkiller/podkiller.go
@@ -38,6 +38,7 @@ import (
 	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
 	"github.com/kubewharf/katalyst-core/pkg/agent/evictionmanager/rule"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
+	metaserverpod "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 )
 
 // PodKiller implements the killing actions for given pods.
@@ -129,7 +130,8 @@ func (s *SynchronizedPodKiller) EvictPods(rpList rule.RuledEvictPodList) error {
 type AsynchronizedPodKiller struct {
 	killer Killer
 
-	client kubernetes.Interface
+	podFetcher metaserverpod.PodFetcher
+	client     kubernetes.Interface
 
 	// use map to act as a limited queue
 	queue workqueue.RateLimitingInterface
@@ -155,9 +157,10 @@ func getEvictPodInfo(rp *rule.RuledEvictPod) *evictPodInfo {
 	}
 }
 
-func NewAsynchronizedPodKiller(killer Killer, client kubernetes.Interface) PodKiller {
+func NewAsynchronizedPodKiller(killer Killer, podFetcher metaserverpod.PodFetcher, client kubernetes.Interface) PodKiller {
 	a := &AsynchronizedPodKiller{
 		killer:         killer,
+		podFetcher:     podFetcher,
 		client:         client,
 		processingPods: make(map[string]map[int64]*evictPodInfo),
 	}
@@ -200,7 +203,7 @@ func (a *AsynchronizedPodKiller) EvictPod(rp *rule.RuledEvictPod) error {
 	if err != nil {
 		return fmt.Errorf("getGracefulDeletionPeriod for pod: %s/%s failed with error: %v", rp.Pod.Namespace, rp.Pod.Name, err)
 	}
-	podKey := podKeyFunc(rp.Pod.Namespace, rp.Pod.Name)
+	podKey := podKeyFunc(rp.Pod.Namespace, rp.Pod.Name, string(rp.Pod.UID))
 
 	a.Lock()
 	if a.processingPods[podKey] != nil {
@@ -296,12 +299,12 @@ func (a *AsynchronizedPodKiller) processNextItem() bool {
 }
 
 func (a *AsynchronizedPodKiller) sync(key string) (retError error, requeue bool) {
-	namespace, name, gracePeriodSeconds, err := splitEvictionKey(key)
+	namespace, name, uid, gracePeriodSeconds, err := splitEvictionKey(key)
 	if err != nil {
 		return fmt.Errorf("[asynchronous] invalid resource key: %s got error: %v", key, err), false
 	}
 
-	podKey := podKeyFunc(namespace, name)
+	podKey := podKeyFunc(namespace, name, uid)
 	defer func() {
 		if !requeue {
 			a.Lock()
@@ -317,10 +320,16 @@ func (a *AsynchronizedPodKiller) sync(key string) (retError error, requeue bool)
 	// todo: actually, this function is safe enough without comparing with pod uid
 	//  if the same pod is created just after the last one exists
 	//  handle with more filters in the future
-	pod, err := a.client.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	ctx := context.Background()
+	pod, err := a.client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.Infof("[asynchronous] %s/%s has already been deleted, skip", namespace, name)
+			// try to get pod from metaserver bypassing cache to get the latest pod info
+			_, err := a.podFetcher.GetPod(context.WithValue(ctx, metaserverpod.BypassCacheKey, metaserverpod.BypassCacheTrue), uid)
+			if err != nil {
+				klog.Errorf("[asynchronous] get pod %s/%s/%s from metaserver failed with error: %v", namespace, name, uid, err)
+			}
 			return nil, false
 		}
 		return err, true
@@ -344,27 +353,27 @@ func (a *AsynchronizedPodKiller) sync(key string) (retError error, requeue bool)
 	}
 }
 
-func podKeyFunc(podNamespace, podName string) string {
-	return strings.Join([]string{podNamespace, podName}, consts.KeySeparator)
+func podKeyFunc(podNamespace, podName string, uid string) string {
+	return strings.Join([]string{podNamespace, podName, uid}, consts.KeySeparator)
 }
 
 func evictionKeyFunc(podKey string, gracePeriodSeconds int64) string {
 	return strings.Join([]string{podKey, fmt.Sprintf("%d", gracePeriodSeconds)}, consts.KeySeparator)
 }
 
-func splitEvictionKey(key string) (string, string, int64, error) {
+func splitEvictionKey(key string) (string, string, string, int64, error) {
 	parts := strings.Split(key, consts.KeySeparator)
 
-	if len(parts) != 3 {
-		return "", "", 0, fmt.Errorf("unexpected key format: %s", key)
+	if len(parts) != 4 {
+		return "", "", "", 0, fmt.Errorf("unexpected key format: %s", key)
 	}
 
-	gracePeriodSeconds, err := strconv.ParseInt(parts[2], 10, 64)
+	gracePeriodSeconds, err := strconv.ParseInt(parts[3], 10, 64)
 	if err != nil {
-		return "", "", 0, fmt.Errorf("unexpected gracePeriodSeconds: %s", parts[2])
+		return "", "", "", 0, fmt.Errorf("unexpected gracePeriodSeconds: %s", parts[3])
 	}
 
-	return parts[0], parts[1], gracePeriodSeconds, nil
+	return parts[0], parts[1], parts[2], gracePeriodSeconds, nil
 }
 
 func getGracefulDeletionPeriod(pod *v1.Pod, options *pluginapi.DeletionOptions) (int64, error) {

--- a/pkg/agent/evictionmanager/podkiller/podkiller_test.go
+++ b/pkg/agent/evictionmanager/podkiller/podkiller_test.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podkiller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	. "github.com/smartystreets/goconvey/convey"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+)
+
+func TestPodKeyFunc(t *testing.T) {
+	t.Parallel()
+	Convey("TestPodKeyFunc", t, func() {
+		key := podKeyFunc("namespace", "name", "uid")
+		So(key, ShouldEqual, "namespace/name/uid")
+	})
+}
+
+func TestEvictionKeyFunc(t *testing.T) {
+	t.Parallel()
+	Convey("TestEvictionKeyFunc", t, func() {
+		key := evictionKeyFunc("podKey", 10)
+		So(key, ShouldEqual, "podKey/10")
+	})
+}
+
+func TestSplitEvictionKey(t *testing.T) {
+	t.Parallel()
+	Convey("TestSplitEvictionKey", t, func() {
+		Convey("ValidKey", func() {
+			key := "part1/part2/part3/12345"
+			p1, p2, p3, gp, err := splitEvictionKey(key)
+			So(err, ShouldBeNil)
+			So(p1, ShouldEqual, "part1")
+			So(p2, ShouldEqual, "part2")
+			So(p3, ShouldEqual, "part3")
+			So(gp, ShouldEqual, 12345)
+		})
+
+		Convey("InvalidKeyFormat", func() {
+			key := "part1/part2"
+			_, _, _, _, err := splitEvictionKey(key)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "unexpected key format: "+key)
+		})
+
+		Convey("InvalidGracePeriod", func() {
+			key := "part1/part2/part3/not-a-number"
+			_, _, _, _, err := splitEvictionKey(key)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "unexpected gracePeriodSeconds: not-a-number")
+		})
+	})
+}
+
+// mock implementations for interfaces
+
+type mockKiller struct {
+	EvictFunc func(ctx context.Context, pod *v1.Pod, gracePeriodSeconds int64, reason, plugin string) error
+}
+
+func (m *mockKiller) Name() string {
+	return "mock-killer"
+}
+
+func (m *mockKiller) Evict(ctx context.Context, pod *v1.Pod, gracePeriodSeconds int64, reason, plugin string) error {
+	if m.EvictFunc != nil {
+		return m.EvictFunc(ctx, pod, gracePeriodSeconds, reason, plugin)
+	}
+	return nil
+}
+
+// TestAsynchronizedPodKiller_sync tests the sync method of AsynchronizedPodKiller
+func TestAsynchronizedPodKiller_sync(t *testing.T) {
+	t.Parallel()
+	mockey.PatchConvey("When pod is successfully evicted", t, func() {
+		// Arrange
+		mockKiller := &mockKiller{}
+
+		// Prepare test data
+		namespace := "default"
+		name := "test-pod"
+		uid := types.UID("test-uid")
+		gracePeriodSeconds := int64(30)
+		reason := "test-reason"
+		plugin := "test-plugin"
+
+		testPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+				UID:       uid,
+			},
+		}
+
+		// Create an AsynchronizedPodKiller instance
+		killer := &AsynchronizedPodKiller{
+			killer:         mockKiller,
+			podFetcher:     &pod.PodFetcherStub{PodList: []*v1.Pod{testPod}},
+			client:         fake.NewSimpleClientset(testPod),
+			processingPods: make(map[string]map[int64]*evictPodInfo),
+		}
+
+		// Add pod to processingPods
+		podKey := podKeyFunc(namespace, name, string(uid))
+		killer.processingPods[podKey] = make(map[int64]*evictPodInfo)
+		killer.processingPods[podKey][gracePeriodSeconds] = &evictPodInfo{
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					UID:       uid,
+				},
+			},
+			Reason: reason,
+			Plugin: plugin,
+		}
+
+		// Mock killer.Evict to return nil (success)
+		mockKiller.EvictFunc = func(ctx context.Context, pod *v1.Pod, gracePeriodSeconds int64, reason, plugin string) error {
+			return nil
+		}
+
+		// Create eviction key
+		evictionKey := fmt.Sprintf("%s%s%d", podKey, consts.KeySeparator, gracePeriodSeconds)
+
+		// Act
+		err, requeue := killer.sync(evictionKey)
+
+		// Assert
+		So(err, ShouldBeNil)
+		So(requeue, ShouldBeFalse)
+		// Check that the pod is removed from processingPods
+		So(killer.processingPods[podKey], ShouldBeNil)
+	})
+
+	mockey.PatchConvey("When pod is not found", t, func() {
+		// Arrange
+		mockKiller := &mockKiller{}
+
+		// Prepare test data
+		namespace := "default"
+		name := "test-pod"
+		uid := types.UID("test-uid")
+		gracePeriodSeconds := int64(30)
+		reason := "test-reason"
+		plugin := "test-plugin"
+
+		// Create an AsynchronizedPodKiller instance
+		killer := &AsynchronizedPodKiller{
+			killer:         mockKiller,
+			podFetcher:     &pod.PodFetcherStub{},
+			client:         fake.NewSimpleClientset(),
+			processingPods: make(map[string]map[int64]*evictPodInfo),
+		}
+
+		// Add pod to processingPods
+		podKey := podKeyFunc(namespace, name, string(uid))
+		killer.processingPods[podKey] = make(map[int64]*evictPodInfo)
+		killer.processingPods[podKey][gracePeriodSeconds] = &evictPodInfo{
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					UID:       uid,
+				},
+			},
+			Reason: reason,
+			Plugin: plugin,
+		}
+
+		// Create eviction key
+		evictionKey := fmt.Sprintf("%s%s%d", podKey, consts.KeySeparator, gracePeriodSeconds)
+
+		// Act
+		err, requeue := killer.sync(evictionKey)
+
+		// Assert
+		So(err, ShouldBeNil)
+		So(requeue, ShouldBeFalse)
+		// Check that the pod is removed from processingPods
+		So(killer.processingPods[podKey], ShouldBeNil)
+	})
+
+	mockey.PatchConvey("When evict pod is not found in processingPods", t, func() {
+		// Arrange
+		mockKiller := &mockKiller{}
+
+		// Prepare test data
+		namespace := "default"
+		name := "test-pod"
+		uid := types.UID("test-uid")
+		gracePeriodSeconds := int64(30)
+
+		testPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+				UID:       uid,
+			},
+		}
+
+		// Create an AsynchronizedPodKiller instance
+		killer := &AsynchronizedPodKiller{
+			killer:         mockKiller,
+			podFetcher:     &pod.PodFetcherStub{PodList: []*v1.Pod{testPod}},
+			client:         fake.NewSimpleClientset(testPod),
+			processingPods: make(map[string]map[int64]*evictPodInfo),
+		}
+
+		// Don't add pod to processingPods to simulate the error condition
+		podKey := podKeyFunc(namespace, name, string(uid))
+
+		// Create eviction key
+		evictionKey := fmt.Sprintf("%s%s%d", podKey, consts.KeySeparator, gracePeriodSeconds)
+
+		// Act
+		err, requeue := killer.sync(evictionKey)
+
+		// Assert
+		So(err, ShouldNotBeNil)
+		So(requeue, ShouldBeFalse)
+		// Check error message
+		So(err.Error(), ShouldContainSubstring, "evict pod can't be found")
+	})
+
+	mockey.PatchConvey("When there is an error during eviction", t, func() {
+		// Arrange
+		mockKiller := &mockKiller{}
+
+		// Prepare test data
+		namespace := "default"
+		name := "test-pod"
+		uid := types.UID("test-uid")
+		gracePeriodSeconds := int64(30)
+		reason := "test-reason"
+		plugin := "test-plugin"
+
+		testPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+				UID:       uid,
+			},
+		}
+
+		// Create an AsynchronizedPodKiller instance
+		killer := &AsynchronizedPodKiller{
+			killer:         mockKiller,
+			podFetcher:     &pod.PodFetcherStub{PodList: []*v1.Pod{testPod}},
+			client:         fake.NewSimpleClientset(testPod),
+			processingPods: make(map[string]map[int64]*evictPodInfo),
+		}
+
+		// Add pod to processingPods
+		podKey := podKeyFunc(namespace, name, string(uid))
+		killer.processingPods[podKey] = make(map[int64]*evictPodInfo)
+		killer.processingPods[podKey][gracePeriodSeconds] = &evictPodInfo{
+			Pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					UID:       uid,
+				},
+			},
+			Reason: reason,
+			Plugin: plugin,
+		}
+
+		// Mock killer.Evict to return an error
+		evictionError := fmt.Errorf("eviction failed")
+		mockKiller.EvictFunc = func(ctx context.Context, pod *v1.Pod, gracePeriodSeconds int64, reason, plugin string) error {
+			return evictionError
+		}
+
+		// Create eviction key
+		evictionKey := fmt.Sprintf("%s%s%d", podKey, consts.KeySeparator, gracePeriodSeconds)
+
+		// Act
+		err, requeue := killer.sync(evictionKey)
+
+		// Assert
+		So(err, ShouldNotBeNil)
+		So(err, ShouldEqual, evictionError)
+		So(requeue, ShouldBeTrue)
+		// Check that the pod is still in processingPods (because of requeue)
+		So(killer.processingPods[podKey][gracePeriodSeconds], ShouldNotBeNil)
+	})
+
+	mockey.PatchConvey("When eviction key is invalid", t, func() {
+		// Arrange
+		mockKiller := &mockKiller{}
+
+		// Create an AsynchronizedPodKiller instance
+		killer := &AsynchronizedPodKiller{
+			killer:         mockKiller,
+			podFetcher:     &pod.PodFetcherStub{},
+			client:         fake.NewSimpleClientset(),
+			processingPods: make(map[string]map[int64]*evictPodInfo),
+		}
+
+		// Use an invalid key
+		invalidKey := "invalid-key"
+
+		// Act
+		err, requeue := killer.sync(invalidKey)
+
+		// Assert
+		So(err, ShouldNotBeNil)
+		So(requeue, ShouldBeFalse)
+		// Check error message
+		So(err.Error(), ShouldContainSubstring, "invalid resource key")
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Add pod UID to eviction key to ensure uniqueness and prevent conflicts with same-named pods. Include pod fetcher from meta server to verify pod existence during eviction process.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
