### PR TITLE
feat: support allocate reserve cpu reversely

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/cpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/cpu_plugin.go
@@ -47,6 +47,7 @@ type CPUDynamicPolicyOptions struct {
 	CPUNUMAHintPreferLowThreshold             float64
 	SharedCoresNUMABindingResultAnnotationKey string
 	EnableMetricPreferredNumaAllocation       bool
+	EnableReserveCPUReversely                 bool
 	*hintoptimizer.HintOptimizerOptions
 }
 
@@ -116,6 +117,9 @@ func (o *CPUOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&o.SharedCoresNUMABindingResultAnnotationKey, "shared-cores-numa-binding-result-annotation-key",
 		o.SharedCoresNUMABindingResultAnnotationKey, "the key of shared cores numa binding result annotation, "+
 			"default is katalyst.kubewharf.io/numa_bind_result")
+	fs.BoolVar(&o.EnableReserveCPUReversely, "enable-reserve-cpu-reversely",
+		o.EnableReserveCPUReversely, "by default, the reservation of cpu starts from the cpu with lower id,"+
+			"if set to true, it starts from the cpu with higher id")
 	o.HintOptimizerOptions.AddFlags(fss)
 }
 
@@ -133,6 +137,7 @@ func (o *CPUOptions) ApplyTo(conf *qrmconfig.CPUQRMPluginConfig) error {
 	conf.CPUAllocationOption = o.CPUAllocationOption
 	conf.EnableMetricPreferredNumaAllocation = o.EnableMetricPreferredNumaAllocation
 	conf.SharedCoresNUMABindingResultAnnotationKey = o.SharedCoresNUMABindingResultAnnotationKey
+	conf.EnableReserveCPUReversely = o.EnableReserveCPUReversely
 	if err := o.HintOptimizerOptions.ApplyTo(conf.HintOptimizerConfiguration); err != nil {
 		return err
 	}

--- a/pkg/agent/qrm-plugins/cpu/util/util.go
+++ b/pkg/agent/qrm-plugins/cpu/util/util.go
@@ -68,7 +68,11 @@ func GetCoresReservedForSystem(conf *config.Configuration, metaServer *metaserve
 		general.Infof("get reservedQuantityInt: %d from ReservedCPUCores configuration", reservedQuantityInt)
 	}
 
-	reservedCPUs, _, reserveErr := calculator.TakeHTByNUMABalance(machineInfo, allCPUs, reservedQuantityInt)
+	takeFn := calculator.TakeHTByNUMABalance
+	if conf.EnableReserveCPUReversely {
+		takeFn = calculator.TakeHTByNUMABalanceReversely
+	}
+	reservedCPUs, _, reserveErr := takeFn(machineInfo, allCPUs, reservedQuantityInt)
 	if reserveErr != nil {
 		return reservedCPUs, fmt.Errorf("takeByNUMABalance for reservedCPUsNum: %d failed with error: %v",
 			reservedQuantityInt, reserveErr)

--- a/pkg/agent/qrm-plugins/cpu/util/util_test.go
+++ b/pkg/agent/qrm-plugins/cpu/util/util_test.go
@@ -115,6 +115,33 @@ func TestGetCoresReservedForSystem(t *testing.T) {
 			want:    machine.NewCPUSet(0, 2, 4, 6),
 			wantErr: false,
 		},
+		{
+			name: "GetCoresReservedForSystem with reverse order",
+			args: args{
+				allCPUs: topology.CPUDetails.CPUs(),
+				conf: &config.Configuration{
+					AgentConfiguration: &agent.AgentConfiguration{
+						GenericAgentConfiguration: &agent.GenericAgentConfiguration{
+							GenericQRMPluginConfiguration: &qrm.GenericQRMPluginConfiguration{},
+						},
+						StaticAgentConfiguration: &agent.StaticAgentConfiguration{
+							QRMPluginsConfiguration: &qrm.QRMPluginsConfiguration{
+								CPUQRMPluginConfig: &qrm.CPUQRMPluginConfig{
+									ReservedCPUCores: 4,
+									CPUDynamicPolicyConfig: qrm.CPUDynamicPolicyConfig{
+										EnableReserveCPUReversely: true,
+									},
+								},
+							},
+						},
+					},
+				},
+				metaServer:  &metaserver.MetaServer{},
+				machineInfo: machineInfo,
+			},
+			want:    machine.NewCPUSet(9, 11, 13, 15),
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/config/agent/qrm/cpu_plugin.go
+++ b/pkg/config/agent/qrm/cpu_plugin.go
@@ -54,6 +54,8 @@ type CPUDynamicPolicyConfig struct {
 	// It enables schedulers to specify NUMA binding results, and the plugin will make best efforts to follow these results.
 	// This key must be included in the pod-annotation-kept-keys configuration.
 	SharedCoresNUMABindingResultAnnotationKey string
+	// EnableReserveCPUReversely indicates whether to reserve cpu reversely
+	EnableReserveCPUReversely bool
 
 	*hintoptimizer.HintOptimizerConfiguration
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features
-->

#### What this PR does / why we need it:
By default, the  cpu reserved starts from the cpu with lower id, in some cases, we want to avoiding reserve 0-core, so this PR introduce a switch to enable reserve cpu reversely.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
