### PR TITLE
fix: correct metric type for checkpoint load failure

### DIFF
--- a/pkg/metaserver/kcc/manager.go
+++ b/pkg/metaserver/kcc/manager.go
@@ -278,7 +278,7 @@ func (c *DynamicConfigManager) writeCheckpoint(kind string, configData reflect.V
 	data, err := c.readCheckpoint()
 	if err != nil {
 		klog.Errorf("load checkpoint from %q failed: %v, try to overwrite it", configManagerCheckpoint, err)
-		_ = c.emitter.StoreInt64(metricsNameLoadCheckpoint, 1, metrics.MetricTypeNameCount, []metrics.MetricTag{
+		_ = c.emitter.StoreInt64(metricsNameLoadCheckpoint, 1, metrics.MetricTypeNameRaw, []metrics.MetricTag{
 			{Key: "status", Val: metricsValueStatusCheckpointNotFoundOrCorrupted},
 			{Key: "kind", Val: kind},
 		}...)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Use MetricTypeNameRaw instead of MetricTypeNameCount for checkpoint load failure metric to properly reflect the metric type
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
