### PR TITLE
fix(sysadvisor): fix kcmas resctrl reported memory bandwidth calculation issue

### DIFF
--- a/pkg/consts/common.go
+++ b/pkg/consts/common.go
@@ -101,12 +101,25 @@ const (
 )
 
 const (
-	AMDMilanArch = "Zen3"
-	AMDGenoaArch = "Zen4"
+	PlatformGeona   = "geona"
+	PlatformMilan   = "milan"
+	PlatformRome    = "rome"
+	PlatformRapids  = "intel_rapids"
+	PlatformLake    = "intel_lake"
+	PlatformUnknown = "unknown"
 )
 
 const (
-	BytesPerGB = 1024 * 1024 * 1024
+	AMDRomeArch     = "Zen2"
+	AMDMilanArch    = "Zen3"
+	AMDGenoaArch    = "Zen4"
+	IntelRapidsArch = "Rapids"
+	IntelLakeArch   = "Lake"
+)
+
+const (
+	BytesPerGB = 1e9
 	MaxMBMDiff = 50 * BytesPerGB
 	MaxMBMStep = 3 * BytesPerGB
+	MaxMBGBps  = 400 * BytesPerGB // 400 GB/s is the maximum bandwidth of L3 cache in Milan, Genoa, and Rapids platforms
 )

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -177,6 +177,10 @@ const (
 
 	MetricCPUUsageNuma = "cpu.usage.numa"
 
+	MetricL3MonNuma = "resctrl.l3mon.numa"
+
+	MetricL3MbmTotalPs = "mbm.total.ps.l3cache"
+
 	MetricTotalMemBandwidthNuma  = "mbm.total.numa"
 	MetricLocalMemBandwidthNuma  = "mbm.local.numa"
 	MetricVictimMemBandwidthNuma = "mbm.victim.numa"
@@ -282,6 +286,7 @@ const (
 	MetricMbmTotalPsContainer  = "mbm.total.ps.container"
 	MetricMbmlocalPsContainer  = "mbm.local.ps.container"
 	MetricMbmVictimPsContainer = "mbm.victim.ps.container"
+	MetricResctrlDataContainer = "resctrl.data.container"
 )
 
 // container blkio metrics

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/common.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/common.go
@@ -117,7 +117,7 @@ type MbmbandData struct {
 }
 
 type MBMItem struct {
-	ID            uint64  `json:"id"`
-	MBMLocalBytes *uint64 `json:"mbm_local_bytes"`
-	MBMTotalBytes *uint64 `json:"mbm_total_bytes"`
+	ID            uint64 `json:"id"`
+	MBMLocalBytes uint64 `json:"mbm_local_bytes"`
+	MBMTotalBytes uint64 `json:"mbm_total_bytes"`
 }

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/system.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/system.go
@@ -127,6 +127,14 @@ type L3Mon struct {
 	Llcoccupancy         uint64 `json:"llc_occupancy"`
 }
 
+type L3CacheBytesPS struct {
+	NumaID           int
+	MbmTotalBytesPS  uint64
+	MbmLocalBytesPS  uint64
+	MbmVictimBytesPS uint64
+	MBMMaxBytesPS    uint64
+}
+
 type Load struct {
 	One     float64 `json:"one"`
 	Five    float64 `json:"five"`


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

- fixed the issue to calculate the numa memory bandwidth using malachite-core raw data.
    - calculate the bps per l3 cache
    - aggregate numa bps using l3 cache bps  

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
