### PR TITLE
feat(eviction): update ThresholdMet to accept GetThresholdMetRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,6 +173,7 @@ require (
 )
 
 replace (
+	github.com/kubewharf/katalyst-api => github.com/luomingmeng/katalyst-api v0.0.0-20250806044927-ce8b9106e332
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.6-0.20250723073136-24e693f5681c h1:klz9kaaT0KHR/9K2xzTiSAs5tDhcqYk7QfCf/tOWc+4=
-github.com/kubewharf/katalyst-api v0.5.6-0.20250723073136-24e693f5681c/go.mod h1:Y2IeIorxQamF2a3oa0+URztl5QCSty6Jj3zD83R8J9k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.9 h1:jOTYZt7h/J7I8xQMKMUcJjKf5UFBv37jHWvNp5VRFGc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf.9/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
@@ -586,6 +584,8 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
+github.com/luomingmeng/katalyst-api v0.0.0-20250806044927-ce8b9106e332 h1:f9T8aPjWKQk9HaPEWYPDSmqshTFuf6NqupgX653pNTw=
+github.com/luomingmeng/katalyst-api v0.0.0-20250806044927-ce8b9106e332/go.mod h1:Y2IeIorxQamF2a3oa0+URztl5QCSty6Jj3zD83R8J9k=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/agent/evictionmanager/endpoint/endpoint.go
+++ b/pkg/agent/evictionmanager/endpoint/endpoint.go
@@ -44,7 +44,7 @@ const (
 // Endpoint represents a single registered plugin. It is responsible
 // for managing gRPC communications with the eviction plugin and caching eviction states.
 type Endpoint interface {
-	ThresholdMet(c context.Context) (*pluginapi.ThresholdMetResponse, error)
+	ThresholdMet(c context.Context, request *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error)
 	// GetTopEvictionPods notice: this function only be called when plugin's threshold is met
 	GetTopEvictionPods(c context.Context, request *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error)
 	GetEvictPods(c context.Context, request *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error)
@@ -106,13 +106,13 @@ func (e *RemoteEndpointImpl) SetStopTime(t time.Time) {
 }
 
 // ThresholdMet is used to call remote endpoint ThresholdMet
-func (e *RemoteEndpointImpl) ThresholdMet(c context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (e *RemoteEndpointImpl) ThresholdMet(c context.Context, request *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	if e.IsStopped() {
 		return nil, fmt.Errorf(errEndpointStopped, e)
 	}
 	ctx, cancel := context.WithTimeout(c, consts.EvictionPluginThresholdMetRPCTimeoutInSecs*time.Second)
 	defer cancel()
-	return e.client.ThresholdMet(ctx, &pluginapi.Empty{})
+	return e.client.ThresholdMet(ctx, request)
 }
 
 // GetTopEvictionPods is used to call remote endpoint GetTopEvictionPods

--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -309,7 +309,9 @@ func (m *EvictionManger) collectEvictionResult(pods []*v1.Pod) (*evictionRespCol
 			collector.collectEvictPods(dynamicConfig.DryRun, pluginName, getEvictResp)
 		}
 
-		metResp, err := ep.ThresholdMet(context.Background())
+		metResp, err := ep.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+			ActivePods: pods,
+		})
 		if err != nil {
 			general.Errorf(" calling ThresholdMet of plugin: %s failed with error: %v", pluginName, err)
 			errList = append(errList, err)

--- a/pkg/agent/evictionmanager/manager_test.go
+++ b/pkg/agent/evictionmanager/manager_test.go
@@ -130,7 +130,7 @@ type plugin1 struct {
 	pluginSkeleton
 }
 
-func (p *plugin1) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (p *plugin1) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{
 		MetType: pluginapi.ThresholdMetType_NOT_MET,
 	}, nil
@@ -187,7 +187,7 @@ type plugin2 struct {
 	pluginSkeleton
 }
 
-func (p plugin2) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (p plugin2) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{
 		MetType:            pluginapi.ThresholdMetType_HARD_MET,
 		ThresholdValue:     0.8,

--- a/pkg/agent/evictionmanager/plugin/memory/numa_pressure.go
+++ b/pkg/agent/evictionmanager/plugin/memory/numa_pressure.go
@@ -112,7 +112,7 @@ func (n *NumaMemoryPressurePlugin) Name() string {
 	return n.pluginName
 }
 
-func (n *NumaMemoryPressurePlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (n *NumaMemoryPressurePlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	var err error
 	defer func() {
 		_ = general.UpdateHealthzStateByError(EvictionPluginNameNumaMemoryPressure, err)

--- a/pkg/agent/evictionmanager/plugin/memory/numa_pressure_test.go
+++ b/pkg/agent/evictionmanager/plugin/memory/numa_pressure_test.go
@@ -241,7 +241,7 @@ func TestNumaMemoryPressurePlugin_ThresholdMet(t *testing.T) {
 		for numaID, numaFree := range tt.numaFree {
 			fakeMetricsFetcher.SetNumaMetric(numaID, consts.MetricMemFreeNuma, utilMetric.MetricData{Value: numaFree, Time: &now})
 		}
-		metResp, err := plugin.ThresholdMet(context.TODO())
+		metResp, err := plugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 		assert.NoError(t, err)
 		assert.NotNil(t, metResp)
 		assert.Equal(t, tt.wantMetType, metResp.MetType)

--- a/pkg/agent/evictionmanager/plugin/memory/rss_overuse.go
+++ b/pkg/agent/evictionmanager/plugin/memory/rss_overuse.go
@@ -93,7 +93,7 @@ func (r *RssOveruseEvictionPlugin) Name() string {
 	return r.pluginName
 }
 
-func (r *RssOveruseEvictionPlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (r *RssOveruseEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{
 		MetType: pluginapi.ThresholdMetType_NOT_MET,
 	}, nil

--- a/pkg/agent/evictionmanager/plugin/memory/system_pressure.go
+++ b/pkg/agent/evictionmanager/plugin/memory/system_pressure.go
@@ -130,7 +130,7 @@ func (s *SystemPressureEvictionPlugin) Start() {
 	go wait.UntilWithContext(context.TODO(), s.detectSystemPressures, s.syncPeriod)
 }
 
-func (s *SystemPressureEvictionPlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (s *SystemPressureEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	resp := &pluginapi.ThresholdMetResponse{
 		MetType: pluginapi.ThresholdMetType_NOT_MET,
 	}

--- a/pkg/agent/evictionmanager/plugin/memory/system_pressure_test.go
+++ b/pkg/agent/evictionmanager/plugin/memory/system_pressure_test.go
@@ -201,7 +201,7 @@ func TestSystemPressureEvictionPlugin_ThresholdMet(t *testing.T) {
 		fakeMetricsFetcher.SetNodeMetric(consts.MetricMemKswapdstealSystem, utilMetric.MetricData{Value: tt.systemKswapSteal, Time: &now})
 
 		plugin.detectSystemPressures(context.TODO())
-		metResp, err := plugin.ThresholdMet(context.TODO())
+		metResp, err := plugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 		assert.NoError(t, err)
 		assert.NotNil(t, metResp)
 		assert.Equal(t, tt.wantMetType, metResp.MetType)

--- a/pkg/agent/evictionmanager/plugin/network/network.go
+++ b/pkg/agent/evictionmanager/plugin/network/network.go
@@ -96,7 +96,7 @@ func (n *nicEvictionPlugin) Start() {
 	go wait.UntilWithContext(context.TODO(), n.syncUnhealthyNICState, time.Second*10)
 }
 
-func (n *nicEvictionPlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (n *nicEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{
 		MetType: pluginapi.ThresholdMetType_NOT_MET,
 	}, nil

--- a/pkg/agent/evictionmanager/plugin/plugin.go
+++ b/pkg/agent/evictionmanager/plugin/plugin.go
@@ -52,7 +52,7 @@ type DummyEvictionPlugin struct {
 }
 
 func (_ DummyEvictionPlugin) Name() string { return fakePluginName }
-func (_ DummyEvictionPlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (_ DummyEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return nil, nil
 }
 

--- a/pkg/agent/evictionmanager/plugin/resource/reclaimed_resources_test.go
+++ b/pkg/agent/evictionmanager/plugin/resource/reclaimed_resources_test.go
@@ -137,7 +137,7 @@ func TestNewReclaimedResourcesEvictionPlugin(t *testing.T) {
 		metrics.DummyMetrics{}, testConf)
 	assert.NoError(t, err)
 
-	met, err := plugin.ThresholdMet(context.TODO())
+	met, err := plugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, met)
 

--- a/pkg/agent/evictionmanager/plugin/resource/resources.go
+++ b/pkg/agent/evictionmanager/plugin/resource/resources.go
@@ -103,7 +103,7 @@ func (b *ResourcesEvictionPlugin) Start() {
 
 // ThresholdMet evict pods when the beset effort resources usage is greater than
 // the supply (after considering toleration).
-func (b *ResourcesEvictionPlugin) ThresholdMet(ctx context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (b *ResourcesEvictionPlugin) ThresholdMet(ctx context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	activePods, err := b.metaServer.GetPodList(ctx, native.PodIsActive)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to list pods from metaServer: %v", err)

--- a/pkg/agent/evictionmanager/plugin/rootfs/rootfs_overuse.go
+++ b/pkg/agent/evictionmanager/plugin/rootfs/rootfs_overuse.go
@@ -84,7 +84,7 @@ func (r *PodRootfsOveruseEvictionPlugin) Name() string {
 
 func (r *PodRootfsOveruseEvictionPlugin) Start() {}
 
-func (r *PodRootfsOveruseEvictionPlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (r *PodRootfsOveruseEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{
 		MetType: pluginapi.ThresholdMetType_NOT_MET,
 	}, nil

--- a/pkg/agent/evictionmanager/plugin/rootfs/rootfs_pressure.go
+++ b/pkg/agent/evictionmanager/plugin/rootfs/rootfs_pressure.go
@@ -88,7 +88,7 @@ func (r *PodRootfsPressureEvictionPlugin) Start() {
 	return
 }
 
-func (r *PodRootfsPressureEvictionPlugin) ThresholdMet(_ context.Context) (*pluginapi.ThresholdMetResponse, error) {
+func (r *PodRootfsPressureEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	resp := &pluginapi.ThresholdMetResponse{
 		MetType:       pluginapi.ThresholdMetType_NOT_MET,
 		EvictionScope: EvictionScopeSystemRootfs,

--- a/pkg/agent/evictionmanager/plugin/rootfs/rootfs_pressure_test.go
+++ b/pkg/agent/evictionmanager/plugin/rootfs/rootfs_pressure_test.go
@@ -79,7 +79,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetNoMetricDataNoConf(t *testi
 	fakeFetcher := metric.NewFakeMetricsFetcher(emitter).(*metric.FakeMetricsFetcher)
 	tc := &testConf{}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 }
@@ -93,7 +93,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetNoMetricData(t *testing.T) 
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Percentage: 0.9},
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 }
@@ -117,7 +117,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetNotMet(t *testing.T) {
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 
@@ -126,7 +126,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetNotMet(t *testing.T) {
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Quantity: resource.NewQuantity(1000, resource.DecimalSI)},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 }
@@ -150,7 +150,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetUsedMet(t *testing.T) {
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -159,7 +159,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetUsedMet(t *testing.T) {
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Quantity: resource.NewQuantity(1000, resource.DecimalSI)},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 }
@@ -183,7 +183,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetInodesMet(t *testing.T) {
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -192,7 +192,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetInodesMet(t *testing.T) {
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Quantity: resource.NewQuantity(3000, resource.DecimalSI)},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 }
@@ -216,7 +216,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMet(t *testing.T) {
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -225,7 +225,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMet(t *testing.T) {
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Quantity: resource.NewQuantity(3000, resource.DecimalSI)},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 }
@@ -251,7 +251,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetMetricDataExpire(t *testing
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 
@@ -260,7 +260,7 @@ func TestPodRootfsPressureEvictionPlugin_ThresholdMetMetricDataExpire(t *testing
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Quantity: resource.NewQuantity(7000, resource.DecimalSI)},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 }
@@ -312,7 +312,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsNotMet(t *testing.T) 
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_NOT_MET, res.MetType)
 
@@ -346,7 +346,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsMet(t *testing.T) {
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -388,7 +388,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsUsedMet(t *testing.T)
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -430,7 +430,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMet(t *testing.
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -473,7 +473,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsUsedMetProtection(t *
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -502,7 +502,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsUsedMetProtection(t *
 		podMinimumUsedThreshold:           &evictionapi.ThresholdValue{Percentage: 0.1},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -537,7 +537,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsUsedMetProtection(t *
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Percentage: 0.1},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -579,7 +579,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMetProtection(t
 		podMinimumInodesUsedThreshold:     &evictionapi.ThresholdValue{Quantity: resource.NewQuantity(900, resource.DecimalSI)},
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -607,7 +607,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMetProtection(t
 		podMinimumInodesUsedThreshold:     &evictionapi.ThresholdValue{Percentage: 0.1},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -642,7 +642,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMetProtection(t
 		minimumImageFsInodesFreeThreshold: &evictionapi.ThresholdValue{Percentage: 0.3},
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -685,7 +685,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsMetReclaimedPriority(
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -741,7 +741,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsMetReclaimedPriority(
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -795,7 +795,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsMetReclaimedPriority(
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -842,7 +842,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMetReclaimedPri
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -898,7 +898,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMetReclaimedPri
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -952,7 +952,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsInodesMetReclaimedPri
 	}
 	rootfsPlugin = createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err = rootfsPlugin.ThresholdMet(context.TODO())
+	res, err = rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 
@@ -1000,7 +1000,7 @@ func TestPodRootfsPressureEvictionPlugin_GetTopEvictionPodsMetExpire(t *testing.
 	}
 	rootfsPlugin := createRootfsPressureEvictionPlugin(tc, emitter, fakeFetcher)
 
-	res, err := rootfsPlugin.ThresholdMet(context.TODO())
+	res, err := rootfsPlugin.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 	assert.NoError(t, err)
 	assert.Equal(t, pluginapi.ThresholdMetType_HARD_MET, res.MetType)
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure.go
@@ -39,7 +39,7 @@ type CPUPressureEviction interface {
 	Start(context.Context) (err error)
 	Name() string
 	GetEvictPods(context.Context, *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error)
-	ThresholdMet(context.Context, *pluginapi.Empty) (*pluginapi.ThresholdMetResponse, error)
+	ThresholdMet(context.Context, *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error)
 	GetTopEvictionPods(context.Context, *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error)
 }
 
@@ -59,7 +59,7 @@ func (d *DummyCPUPressureEviction) GetEvictPods(_ context.Context, _ *pluginapi.
 	return &pluginapi.GetEvictPodsResponse{}, nil
 }
 
-func (d *DummyCPUPressureEviction) ThresholdMet(_ context.Context, _ *pluginapi.Empty) (*pluginapi.ThresholdMetResponse, error) {
+func (d *DummyCPUPressureEviction) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{}, nil
 }
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
@@ -133,7 +133,7 @@ func (p *CPUPressureLoadEviction) GetEvictPods(_ context.Context, _ *pluginapi.G
 }
 
 func (p *CPUPressureLoadEviction) ThresholdMet(_ context.Context,
-	_ *pluginapi.Empty,
+	_ *pluginapi.GetThresholdMetRequest,
 ) (*pluginapi.ThresholdMetResponse, error) {
 	p.Lock()
 	defer p.Unlock()

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load_test.go
@@ -404,7 +404,7 @@ func TestThresholdMet(t *testing.T) {
 
 		plugin.(*CPUPressureLoadEviction).collectMetrics(context.Background())
 
-		metResp, err := plugin.ThresholdMet(context.Background(), &evictionpluginapi.Empty{})
+		metResp, err := plugin.ThresholdMet(context.Background(), &evictionpluginapi.GetThresholdMetRequest{})
 		as.Nil(err)
 		as.NotNil(t, metResp)
 
@@ -801,7 +801,7 @@ func TestGetTopEvictionPods(t *testing.T) {
 
 		plugin.(*CPUPressureLoadEviction).collectMetrics(context.Background())
 
-		metResp, err := plugin.ThresholdMet(context.Background(), &evictionpluginapi.Empty{})
+		metResp, err := plugin.ThresholdMet(context.Background(), &evictionpluginapi.GetThresholdMetRequest{})
 		as.Nil(err)
 		as.NotNil(t, metResp)
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_numa.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_numa.go
@@ -201,7 +201,7 @@ func (p *NumaCPUPressureEviction) GetEvictPods(_ context.Context, request *plugi
 	return resp, nil
 }
 
-func (p *NumaCPUPressureEviction) ThresholdMet(_ context.Context, _ *pluginapi.Empty,
+func (p *NumaCPUPressureEviction) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest,
 ) (*pluginapi.ThresholdMetResponse, error) {
 	p.RLock()
 	defer p.RUnlock()

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_numa_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_numa_test.go
@@ -1211,7 +1211,7 @@ func TestNumaCPUPressureEviction_ThresholdMet(t *testing.T) {
 				enabled:            tt.fields.enabled,
 				emitter:            metrics.DummyMetrics{},
 			}
-			got, err := p.ThresholdMet(context.TODO(), nil)
+			got, err := p.ThresholdMet(context.TODO(), &pluginapi.GetThresholdMetRequest{})
 			if !tt.wantErr(t, err, fmt.Sprintf("ThresholdMet")) {
 				return
 			}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_suppression.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_suppression.go
@@ -67,7 +67,7 @@ func NewCPUPressureSuppressionEviction(_ metrics.MetricEmitter, metaServer *meta
 
 func (p *CPUPressureSuppression) Start(context.Context) error { return nil }
 func (p *CPUPressureSuppression) Name() string                { return EvictionNameSuppression }
-func (p *CPUPressureSuppression) ThresholdMet(_ context.Context, _ *pluginapi.Empty) (*pluginapi.ThresholdMetResponse, error) {
+func (p *CPUPressureSuppression) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{}, nil
 }
 

--- a/pkg/agent/sysadvisor/plugin/poweraware/evictor/server/evictor_service.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/evictor/server/evictor_service.go
@@ -135,7 +135,7 @@ func (p *powerPressureEvictPlugin) GetToken(ctx context.Context, empty *pluginap
 	return &pluginapi.GetTokenResponse{Token: ""}, nil
 }
 
-func (p *powerPressureEvictPlugin) ThresholdMet(ctx context.Context, empty *pluginapi.Empty) (*pluginapi.ThresholdMetResponse, error) {
+func (p *powerPressureEvictPlugin) ThresholdMet(ctx context.Context, request *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{}, nil
 }
 

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/memory_balancer.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/plugin/memory_balancer.go
@@ -199,6 +199,8 @@ type memoryBalancer struct {
 	balanceInfo     *BalanceInfo
 }
 
+var _ skeleton.EvictionPlugin = &memoryBalancer{}
+
 func (m *memoryBalancer) Name() string {
 	return EvictionPluginNameMemoryBalancer
 }
@@ -215,7 +217,7 @@ func (m *memoryBalancer) GetToken(_ context.Context, _ *pluginapi.Empty) (*plugi
 	return &pluginapi.GetTokenResponse{Token: ""}, nil
 }
 
-func (m *memoryBalancer) ThresholdMet(_ context.Context, _ *pluginapi.Empty) (*pluginapi.ThresholdMetResponse, error) {
+func (m *memoryBalancer) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
 	return &pluginapi.ThresholdMetResponse{}, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features
#### What this PR does / why we need it:
Update all implementations of ThresholdMet to accept GetThresholdMetRequest parameter instead of Empty. This allows passing active pods information to eviction plugins for more informed decisions.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
