### PR TITLE
[WIP] feat(justin): allow cgroup path finding for kata containers

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler.go
@@ -106,7 +106,7 @@ func (p *DynamicPolicy) checkCPUSet(_ *coreconfig.Configuration,
 				continue
 			}
 
-			cpuSetStats, err = cgroupcmutils.GetCPUSetForContainer(podUID, containerId)
+			cpuSetStats, err = cgroupcmutils.GetCPUSetForContainer(podUID, containerId, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 			if err != nil {
 				general.Errorf("GetCPUSet of pod: %s container: name(%s), id(%s) failed with error: %v",
 					podUID, containerName, containerId, err)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_advisor_handler.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_advisor_handler.go
@@ -813,7 +813,7 @@ func (p *DynamicPolicy) doNumaMemoryBalance(ctx context.Context, advice types.Nu
 			continue
 		}
 
-		memoryAbsCGPath, err := cgroupcommon.GetContainerAbsCgroupPath(cgroupcommon.CgroupSubsysMemory, containerInfo.PodUID, containerID)
+		memoryAbsCGPath, err := cgroupcommon.GetContainerAbsCgroupPath(cgroupcommon.CgroupSubsysMemory, containerInfo.PodUID, containerID, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 		if err != nil {
 			general.Errorf("GetContainerAbsCgroupPath of pod: %s container: %s failed with error: %v", containerInfo.PodUID, containerInfo.ContainerName, err)
 			continue
@@ -911,7 +911,7 @@ func (p *DynamicPolicy) handleAdvisorMemoryOffloading(_ *config.Configuration,
 		if err != nil {
 			return fmt.Errorf("GetContainerID failed with error: %v", err)
 		}
-		absCGPath, err = common.GetContainerAbsCgroupPath(common.CgroupSubsysMemory, entryName, containerID)
+		absCGPath, err = common.GetContainerAbsCgroupPath(common.CgroupSubsysMemory, entryName, containerID, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 		if err != nil {
 			return fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
 		}

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_async_handler.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_async_handler.go
@@ -231,7 +231,7 @@ func (p *DynamicPolicy) applyExternalCgroupParams(_ *coreconfig.Configuration,
 					"cgroupSubsysName", entry.CgroupSubsysName,
 					"cgroupIfaceName", cgroupIfaceName)
 
-				exist, err := common.IsContainerCgroupFileExist(entry.CgroupSubsysName, podUID, containerID, cgroupIfaceName)
+				exist, err := common.IsContainerCgroupFileExist(entry.CgroupSubsysName, podUID, containerID, cgroupIfaceName, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 				if err != nil {
 					general.Warningf("check %v/%v cgroup file's existence of pod: %s/%s container: %s failed with error: %v",
 						cgroupIfaceName, entry.CgroupSubsysName,
@@ -247,7 +247,7 @@ func (p *DynamicPolicy) applyExternalCgroupParams(_ *coreconfig.Configuration,
 					continue
 				}
 
-				err = cgroupmgr.ApplyUnifiedDataForContainer(podUID, containerID, entry.CgroupSubsysName, cgroupIfaceName, entry.ControlKnobValue)
+				err = cgroupmgr.ApplyUnifiedDataForContainer(podUID, containerID, entry.CgroupSubsysName, cgroupIfaceName, entry.ControlKnobValue, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 				if err != nil {
 					errList = append(errList, err)
 					general.ErrorS(err, "ApplyUnifiedDataForContainer failed",
@@ -324,7 +324,7 @@ func (p *DynamicPolicy) checkMemorySet(_ *coreconfig.Configuration,
 				continue
 			}
 
-			cpusetStats, err = cgroupmgr.GetCPUSetForContainer(podUID, containerID)
+			cpusetStats, err = cgroupmgr.GetCPUSetForContainer(podUID, containerID, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 			if err != nil {
 				general.Errorf("GetMemorySet of pod: %s container: name(%s), id(%s) failed with error: %v",
 					podUID, containerName, containerID, err)
@@ -568,7 +568,7 @@ func (p *DynamicPolicy) setMemoryMigrate() {
 					general.Infof("start to set cgroup memory migrate for pod: %s, container: %s(%s) and pin memory",
 						podUID, containerName, containerID)
 
-					err = cgroupmgr.ApplyCPUSetForContainer(podUID, containerID, cgData)
+					err = cgroupmgr.ApplyCPUSetForContainer(podUID, containerID, cgData, p.metaServer.GetKataContainerAbsoluteCgroupPath)
 					general.Infof("end to set cgroup memory migrate for pod: %s, container: %s(%s) and pin memory",
 						podUID, containerName, containerID)
 					if err != nil {
@@ -622,7 +622,7 @@ func (p *DynamicPolicy) clearResidualOOMPriority(conf *coreconfig.Configuration,
 				continue
 			}
 
-			if exist, err := common.IsContainerCgroupExist(podUID, containerID); err != nil {
+			if exist, err := common.IsContainerCgroupExist(podUID, containerID, p.metaServer.GetKataContainerAbsoluteCgroupPath); err != nil {
 				general.Errorf("check if container cgroup exists failed, pod: %s, container: %s(%s), err: %v",
 					podUID, containerName, containerID, err)
 				continue
@@ -740,7 +740,7 @@ func (p *DynamicPolicy) syncOOMPriority(conf *coreconfig.Configuration,
 				continue
 			}
 
-			if exist, err := common.IsContainerCgroupExist(podUID, containerID); err != nil {
+			if exist, err := common.IsContainerCgroupExist(podUID, containerID, p.metaServer.GetKataContainerAbsoluteCgroupPath); err != nil {
 				general.Errorf("check if container cgroup exists failed, pod: %s, container: %s(%s), err: %v",
 					podUID, containerName, containerID, err)
 				continue

--- a/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/sockmem/sockmem_linux.go
@@ -91,12 +91,12 @@ func setHostTCPMem(emitter metrics.MetricEmitter, memTotal uint64, sockMemConfig
 	return nil
 }
 
-func setCg1TCPMem(emitter metrics.MetricEmitter, podUID, containerID string, memLimit, memTCPLimit int64, sockMemConfig *SockMemConfig) error {
+func setCg1TCPMem(emitter metrics.MetricEmitter, podUID, containerID string, memLimit, memTCPLimit int64, sockMemConfig *SockMemConfig, metaServer *metaserver.MetaServer) error {
 	newMemTCPLimit := memLimit / 100 * int64(sockMemConfig.cgroupTCPMemRatio)
 	newMemTCPLimit = alignToPageSize(newMemTCPLimit)
 	newMemTCPLimit = int64(general.Clamp(float64(newMemTCPLimit), cgroupTCPMemMin2G, kernSockMemAccountingOn))
 
-	cgroupPath, err := cgroupcm.GetContainerRelativeCgroupPath(podUID, containerID)
+	cgroupPath, err := cgroupcm.GetContainerRelativeCgroupPath(podUID, containerID, metaServer.GetKataContainerRelativeCgroupPath)
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func SetSockMemLimit(conf *coreconfig.Configuration,
 				continue
 			}
 
-			err = setCg1TCPMem(emitter, podUID, containerID, int64(memLimit), int64(memTCPLimit), &sockMemConfig)
+			err = setCg1TCPMem(emitter, podUID, containerID, int64(memLimit), int64(memTCPLimit), &sockMemConfig, metaServer)
 			if err != nil {
 				errList = append(errList, err)
 			}

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
@@ -92,7 +92,7 @@ type StaticPolicy struct {
 
 	CgroupV2Env                                     bool
 	qosLevelToNetClassMap                           map[string]uint32
-	applyNetClassFunc                               func(podUID, containerID string, data *common.NetClsData) error
+	applyNetClassFunc                               func(podUID, containerID string, data *common.NetClsData, handlers ...common.OtherAbsoluteCgroupPathHandler) error
 	applyNetworkGroupsFunc                          func(map[string]*qrmgeneral.NetworkGroup) error
 	podLevelNetClassAnnoKey                         string
 	podLevelNetAttributesAnnoKeys                   []string
@@ -948,7 +948,7 @@ func (p *StaticPolicy) applyNetClass() {
 				continue
 			}
 
-			if exist, err := common.IsContainerCgroupExist(podUID, containerID); err != nil {
+			if exist, err := common.IsContainerCgroupExist(podUID, containerID, p.metaServer.GetKataContainerAbsoluteCgroupPath); err != nil {
 				general.Errorf("check if container cgroup exists failed, pod: %s, container: %s(%s), err: %v",
 					podUID, containerName, containerID, err)
 				continue
@@ -969,7 +969,7 @@ func (p *StaticPolicy) applyNetClass() {
 			}
 
 			go func(podUID, containerName string, netClsData *common.NetClsData) {
-				if err = p.applyNetClassFunc(podUID, containerID, netClsData); err != nil {
+				if err = p.applyNetClassFunc(podUID, containerID, netClsData, p.metaServer.GetKataContainerAbsoluteCgroupPath); err != nil {
 					general.Errorf("apply net class failed, pod: %s, container: %s(%s), netClsData: %+v, err: %v",
 						podUID, containerName, containerID, *netClsData, err)
 					return

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_pod.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_pod.go
@@ -80,7 +80,7 @@ func (c *MalachiteClient) GetPodContainerStats(podUID, containerID string) (*typ
 	if c.relativePathFunc != nil {
 		cgroupPath, err = (*c.relativePathFunc)(podUID, containerID)
 	} else {
-		cgroupPath, err = cgroupcm.GetContainerRelativeCgroupPath(podUID, containerID)
+		cgroupPath, err = cgroupcm.GetContainerRelativeCgroupPath(podUID, containerID, c.fetcher.GetKataContainerRelativeCgroupPath)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("GetPodContainerStats %s/%v get-relative-path err %v", podUID, containerID, err)

--- a/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/client/client_node_test.go
@@ -107,3 +107,11 @@ func (f *FakePodFetcher) GetPod(ctx context.Context, podUID string) (*v1.Pod, er
 func (f *FakePodFetcher) GetPodList(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error) {
 	return nil, nil
 }
+
+func (f *FakePodFetcher) GetKataContainerAbsoluteCgroupPath(subsys, podUID, containerName string) (string, error) {
+	return "", nil
+}
+
+func (f *FakePodFetcher) GetKataContainerRelativeCgroupPath(podUID, containerName string) (string, error) {
+	return "", nil
+}

--- a/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
@@ -200,3 +200,11 @@ func (f *FakePodFetcher) GetPod(ctx context.Context, podUID string) (*v1.Pod, er
 func (f *FakePodFetcher) GetPodList(ctx context.Context, podFilter func(*v1.Pod) bool) ([]*v1.Pod, error) {
 	return f.GetPodListFunc(ctx, podFilter)
 }
+
+func (f *FakePodFetcher) GetKataContainerAbsoluteCgroupPath(subsys, podUID, containerName string) (string, error) {
+	return "", nil
+}
+
+func (f *FakePodFetcher) GetKataContainerRelativeCgroupPath(podUID, containerName string) (string, error) {
+	return "", nil
+}

--- a/pkg/metaserver/agent/pod/pod.go
+++ b/pkg/metaserver/agent/pod/pod.go
@@ -400,7 +400,6 @@ func (w *podFetcherImpl) getKataCgroupPathSuffix(podUID, containerId string) (st
 		return "", fmt.Errorf("failed to get container info, err: %v", err)
 	}
 
-	klog.Infof("container info is %v", infoRaw)
 	var info ContainerInfo
 	if err := json.Unmarshal([]byte(infoRaw["info"]), &info); err != nil {
 		return "", fmt.Errorf("failed to unmarshal info of container into its sandbox id, err: %v", err)

--- a/pkg/metaserver/agent/pod/pod.go
+++ b/pkg/metaserver/agent/pod/pod.go
@@ -395,6 +395,7 @@ func (w *podFetcherImpl) getKataCgroupPathSuffix(podUID, containerId string) (st
 		return "", fmt.Errorf("failed to get container info, err: %v", err)
 	}
 
+	klog.Infof("container info is %v", info)
 	sandboxId, ok := info[common.ContainerSandboxIDKey]
 	if !ok {
 		return "", fmt.Errorf("failed to find sandbox id info of container %s", containerId)

--- a/pkg/metaserver/agent/pod/pod.go
+++ b/pkg/metaserver/agent/pod/pod.go
@@ -19,6 +19,8 @@ package pod
 import (
 	"context"
 	"fmt"
+	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"path"
 	"sync"
 	"time"
 
@@ -64,6 +66,13 @@ type PodFetcher interface {
 	GetContainerSpec(podUID, containerName string) (*v1.Container, error)
 	// GetPod returns Pod by UID
 	GetPod(ctx context.Context, podUID string) (*v1.Pod, error)
+
+	// GetKataContainerAbsoluteCgroupPath attempts to get the absolute cgroup path of a kata container.
+	// It will return an error if the container is not a kata container.
+	GetKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, error)
+
+	// GetKataContainerRelativeCgroupPath attempts to get the
+	GetKataContainerRelativeCgroupPath(podUID, containerId string) (string, error)
 }
 
 type podFetcherImpl struct {
@@ -362,4 +371,34 @@ func (w *podFetcherImpl) checkPodCache() {
 		metrics.ConvertMapToTags(map[string]string{
 			"source": "kubelet",
 		})...)
+}
+
+func (w *podFetcherImpl) GetKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, error) {
+	cgroupPathSuffix, err := w.getKataCgroupPathSuffix(podUID, containerId)
+	if err != nil {
+		return "", fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
+	}
+	return common.GetKubernetesAnyExistAbsCgroupPath(subsys, cgroupPathSuffix)
+}
+
+func (w *podFetcherImpl) GetKataContainerRelativeCgroupPath(podUID, containerId string) (string, error) {
+	cgroupPathSuffix, err := w.getKataCgroupPathSuffix(podUID, containerId)
+	if err != nil {
+		return "", fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
+	}
+	return common.GetKubernetesAnyExistRelativeCgroupPath(cgroupPathSuffix)
+}
+
+func (w *podFetcherImpl) getKataCgroupPathSuffix(podUID, containerId string) (string, error) {
+	info, err := w.runtimePodFetcher.GetContainerInfo(containerId)
+	if err != nil {
+		return "", fmt.Errorf("failed to get container info, err: %v", err)
+	}
+
+	sandboxId, ok := info[common.ContainerSandboxIDKey]
+	if !ok {
+		return "", fmt.Errorf("failed to find sandbox id info of container %s", containerId)
+	}
+	kataPathSuffix := fmt.Sprintf("kata_%s", sandboxId)
+	return path.Join(fmt.Sprintf("%s%s", common.PodCgroupPathPrefix, podUID), kataPathSuffix), nil
 }

--- a/pkg/metaserver/agent/pod/pod.go
+++ b/pkg/metaserver/agent/pod/pod.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"k8s.io/apimachinery/pkg/util/json"
 	"path"
 	"sync"
 	"time"
@@ -45,6 +46,10 @@ const (
 )
 
 type ContextKey string
+
+type ContainerInfo struct {
+	SandboxID string `json:"sandboxID"`
+}
 
 const (
 	BypassCacheKey  ContextKey = "bypass_cache"
@@ -390,16 +395,16 @@ func (w *podFetcherImpl) GetKataContainerRelativeCgroupPath(podUID, containerId 
 }
 
 func (w *podFetcherImpl) getKataCgroupPathSuffix(podUID, containerId string) (string, error) {
-	info, err := w.runtimePodFetcher.GetContainerInfo(containerId)
+	infoRaw, err := w.runtimePodFetcher.GetContainerInfo(containerId)
 	if err != nil {
 		return "", fmt.Errorf("failed to get container info, err: %v", err)
 	}
 
-	klog.Infof("container info is %v", info)
-	sandboxId, ok := info[common.ContainerSandboxIDKey]
-	if !ok {
-		return "", fmt.Errorf("failed to find sandbox id info of container %s", containerId)
+	klog.Infof("container info is %v", infoRaw)
+	var info ContainerInfo
+	if err := json.Unmarshal([]byte(infoRaw["info"]), &info); err != nil {
+		return "", fmt.Errorf("failed to unmarshal info of container into its sandbox id, err: %v", err)
 	}
-	kataPathSuffix := fmt.Sprintf("kata_%s", sandboxId)
+	kataPathSuffix := fmt.Sprintf("kata_%s", info.SandboxID)
 	return path.Join(fmt.Sprintf("%s%s", common.PodCgroupPathPrefix, podUID), kataPathSuffix), nil
 }

--- a/pkg/metaserver/agent/pod/pod_stub.go
+++ b/pkg/metaserver/agent/pod/pod_stub.go
@@ -88,3 +88,29 @@ func (p *PodFetcherStub) GetContainerSpec(podUID, containerName string) (*v1.Con
 
 	return nil, fmt.Errorf("container: %s isn't found in pod: %s spec", containerName, podUID)
 }
+
+func (p *PodFetcherStub) GetKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	for _, pod := range p.PodList {
+		if string(pod.UID) == podUID {
+			return "fakeCgroupAbsolutePath", nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find pod %s in podList", podUID)
+}
+
+func (p *PodFetcherStub) GetKataContainerRelativeCgroupPath(podUID, containerId string) (string, error) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	for _, pod := range p.PodList {
+		if string(pod.UID) == podUID {
+			return "fakeCgroupRelativePath", nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find pod %s in podList", podUID)
+}

--- a/pkg/metaserver/agent/pod/runtime_test.go
+++ b/pkg/metaserver/agent/pod/runtime_test.go
@@ -1,0 +1,1 @@
+package pod

--- a/pkg/metaserver/agent/pod/runtime_test.go
+++ b/pkg/metaserver/agent/pod/runtime_test.go
@@ -1,1 +1,33 @@
 package pod
+
+import (
+	"github.com/stretchr/testify/assert"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	critesting "k8s.io/cri-api/pkg/apis/testing"
+	"testing"
+)
+
+func TestRuntimePodFetcherImpl_GetContainerInfo(t *testing.T) {
+	fakeRuntimeService := critesting.NewFakeRuntimeService()
+
+	// Add a fake container to the fake runtime
+	fakeRuntimeService.Containers["fakeContainerID"] = &critesting.FakeContainer{
+		ContainerStatus: runtimeapi.ContainerStatus{
+			Id: "fakeContainerID",
+		},
+	}
+
+	fakeRuntimePodFetcher := &runtimePodFetcherImpl{
+		runtimeService: fakeRuntimeService,
+	}
+
+	// Should throw an error because the containerID is invalid
+	resp, err := fakeRuntimePodFetcher.GetContainerInfo("invalidContainerID")
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+
+	// Should throw an error because the containerStatus has no info
+	resp, err = fakeRuntimePodFetcher.GetContainerInfo("fakeContainerID")
+	assert.Nil(t, resp)
+	assert.Error(t, err)
+}

--- a/pkg/util/cgroup/common/path_test.go
+++ b/pkg/util/cgroup/common/path_test.go
@@ -58,7 +58,7 @@ func TestGetContainerAbsCgroupPath(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
-	_, err := GetContainerAbsCgroupPath("cpuset", "", "")
+	_, err := GetContainerAbsCgroupPath("cpuset", "", "", nil)
 	as.NotNil(err)
 }
 
@@ -66,7 +66,7 @@ func TestIsContainerCgroupExist(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
-	_, err := IsContainerCgroupExist("fake-pod-uid", "fake-container-id")
+	_, err := IsContainerCgroupExist("fake-pod-uid", "fake-container-id", nil)
 	as.NotNil(err)
 }
 
@@ -75,6 +75,6 @@ func TestIsContainerCgroupFileExist(t *testing.T) {
 
 	as := require.New(t)
 	// test the case that file doesn't exist
-	_, err := IsContainerCgroupFileExist("cpuset", "fake-pod-uid", "fake-container-id", "nonexistentfile")
+	_, err := IsContainerCgroupFileExist("cpuset", "fake-pod-uid", "fake-container-id", "nonexistentfile", nil)
 	as.NotNil(err)
 }

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -45,6 +45,9 @@ const (
 	SystemdRootPath           = "/kubepods.slice"
 	SystemdRootPathBestEffort = "/kubepods.slice/kubepods-besteffort.slice"
 	SystemdRootPathBurstable  = "/kubepods.slice/kubepods-burstable.slice"
+
+	// ContainerSandboxIDKey is the key of sandbox id in container info
+	ContainerSandboxIDKey = "sandboxID"
 )
 
 const (
@@ -240,3 +243,7 @@ type CgroupResources struct {
 	SkipDevices     bool `json:"-"`
 	SkipFreezeOnSet bool `json:"-"`
 }
+
+type OtherAbsoluteCgroupPathHandler func(subsys, podUID, containerId string) (string, error)
+
+type OtherRelativeCgroupPathHandler func(podUID, containerId string) (string, error)

--- a/pkg/util/cgroup/manager/cgroup.go
+++ b/pkg/util/cgroup/manager/cgroup.go
@@ -80,12 +80,12 @@ func ApplyCPUSetWithAbsolutePath(absCgroupPath string, data *common.CPUSetData) 
 	return GetManager().ApplyCPUSet(absCgroupPath, data)
 }
 
-func ApplyCPUSetForContainer(podUID, containerId string, data *common.CPUSetData) error {
+func ApplyCPUSetForContainer(podUID, containerId string, data *common.CPUSetData, handlers ...common.OtherAbsoluteCgroupPathHandler) error {
 	if data == nil {
 		return fmt.Errorf("ApplyCPUSetForContainer with nil cgroup data")
 	}
 
-	cpusetAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysCPUSet, podUID, containerId)
+	cpusetAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysCPUSet, podUID, containerId, handlers...)
 	if err != nil {
 		return fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
 	}
@@ -111,12 +111,12 @@ func ApplyNetClsWithAbsolutePath(absCgroupPath string, data *common.NetClsData) 
 }
 
 // ApplyNetClsForContainer applies the net_cls config for a container.
-func ApplyNetClsForContainer(podUID, containerId string, data *common.NetClsData) error {
+func ApplyNetClsForContainer(podUID, containerId string, data *common.NetClsData, handlers ...common.OtherAbsoluteCgroupPathHandler) error {
 	if data == nil {
 		return fmt.Errorf("ApplyNetClass with nil cgroup data")
 	}
 
-	netClsAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysNetCls, podUID, containerId)
+	netClsAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysNetCls, podUID, containerId, handlers...)
 	if err != nil {
 		return fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
 	}
@@ -172,8 +172,8 @@ func ApplyUnifiedDataWithAbsolutePath(absCgroupPath, cgroupFileName, data string
 }
 
 // ApplyUnifiedDataForContainer applies the data to cgroupFileName in subsys for a container.
-func ApplyUnifiedDataForContainer(podUID, containerId, subsys, cgroupFileName, data string) error {
-	absCgroupPath, err := common.GetContainerAbsCgroupPath(subsys, podUID, containerId)
+func ApplyUnifiedDataForContainer(podUID, containerId, subsys, cgroupFileName, data string, handlers ...common.OtherAbsoluteCgroupPathHandler) error {
+	absCgroupPath, err := common.GetContainerAbsCgroupPath(subsys, podUID, containerId, handlers...)
 	if err != nil {
 		return fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
 	}
@@ -285,8 +285,8 @@ func GetTasksWithAbsolutePath(absCgroupPath string) ([]string, error) {
 	return GetManager().GetTasks(absCgroupPath)
 }
 
-func GetCPUSetForContainer(podUID, containerId string) (*common.CPUSetStats, error) {
-	cpusetAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysCPUSet, podUID, containerId)
+func GetCPUSetForContainer(podUID, containerId string, handlers ...common.OtherAbsoluteCgroupPathHandler) (*common.CPUSetStats, error) {
+	cpusetAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysCPUSet, podUID, containerId, handlers...)
 	if err != nil {
 		return nil, fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
 	}
@@ -294,8 +294,8 @@ func GetCPUSetForContainer(podUID, containerId string) (*common.CPUSetStats, err
 	return GetCPUSetWithAbsolutePath(cpusetAbsCGPath)
 }
 
-func DropCacheWithTimeoutForContainer(ctx context.Context, podUID, containerId string, timeoutSecs int, nbytes int64) error {
-	memoryAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysMemory, podUID, containerId)
+func DropCacheWithTimeoutForContainer(ctx context.Context, podUID, containerId string, timeoutSecs int, nbytes int64, handlers ...common.OtherAbsoluteCgroupPathHandler) error {
+	memoryAbsCGPath, err := common.GetContainerAbsCgroupPath(common.CgroupSubsysMemory, podUID, containerId, handlers...)
 	if err != nil {
 		return fmt.Errorf("GetContainerAbsCgroupPath failed with error: %v", err)
 	}

--- a/pkg/util/external/network/manager.go
+++ b/pkg/util/external/network/manager.go
@@ -43,7 +43,7 @@ type NetworkManagerStub struct {
 	NetClassMap map[string]map[string]*common.NetClsData
 }
 
-func (n *NetworkManagerStub) ApplyNetClass(podUID, containerId string, data *common.NetClsData) error {
+func (n *NetworkManagerStub) ApplyNetClass(podUID, containerId string, data *common.NetClsData, handlers ...common.OtherAbsoluteCgroupPathHandler) error {
 	n.Lock()
 	defer n.Unlock()
 	if _, ok := n.NetClassMap[podUID]; !ok {

--- a/pkg/util/external/network/manager.go
+++ b/pkg/util/external/network/manager.go
@@ -27,7 +27,7 @@ import (
 // NetworkManager provides methods that control network resources.
 type NetworkManager interface {
 	// ApplyNetClass applies the net class config for a container.
-	ApplyNetClass(podUID, containerId string, data *common.NetClsData) error
+	ApplyNetClass(podUID, containerId string, data *common.NetClsData, handlers ...common.OtherAbsoluteCgroupPathHandler) error
 	// ListNetClass lists the net class config for all containers managed by kubernetes.
 	ListNetClass() ([]*common.NetClsData, error)
 	// ClearNetClass clears the net class config for a container.

--- a/pkg/util/external/network/manager_linux.go
+++ b/pkg/util/external/network/manager_linux.go
@@ -35,7 +35,7 @@ func NewNetworkManager() NetworkManager {
 }
 
 // ApplyNetClass applies the net class config for a container.
-func (*defaultNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData) error {
+func (*defaultNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData, _ ...common.OtherAbsoluteCgroupPathHandler) error {
 	// TODO: implement traffic tagging by using eBPF
 	return errors.New("not implemented yet")
 }

--- a/pkg/util/external/network/manager_unsupported.go
+++ b/pkg/util/external/network/manager_unsupported.go
@@ -34,7 +34,7 @@ func NewNetworkManager() NetworkManager {
 }
 
 // ApplyNetClass applies the net class config for a container.
-func (*unsupportedNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData) error {
+func (*unsupportedNetworkManager) ApplyNetClass(podUID, containerId string, data *common.NetClsData, handlers ...common.OtherAbsoluteCgroupPathHandler) error {
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Kata containers are like virtual machines, the cgroup path reported by crictl can be considered as virtual cgroup paths. We need to find the real cgroup path by extracting some info through container runtime interface.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
