### PR TITLE
feat(advisor): update borwein offset calculation

### DIFF
--- a/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression.go
+++ b/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression.go
@@ -141,8 +141,15 @@ func MatchSlotOffset(nodeAvgNet float64, clusterStrategy ClusterStrategy, indica
 			return slot.Offset
 		}
 	}
-	general.Infof("match no slot, use max offset")
-	return borweinParameter.OffsetMax
+
+	if len(slots) > 0 {
+		lastSlot := slots[len(slots)-1]
+		general.Infof("match no slot, use last slot's offset: %v", lastSlot.Offset)
+		return lastSlot.Offset
+	}
+
+	general.Warningf("slots is empty for indicator %v", indicator)
+	return 0
 }
 
 func MatchSpecialTimes(clusterSpecialTimeStrategy ClusterSpecialTimeStrategy, indicator string) (float64, bool) {

--- a/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression_test.go
+++ b/pkg/agent/sysadvisor/plugin/inference/modelresultfetcher/borwein/latencyregression/latency_regression_test.go
@@ -332,7 +332,7 @@ func TestMatchSlotOffset(t *testing.T) {
 		want float64
 	}{
 		{
-			name: "test1",
+			name: "nodeAvgNet in middle range, matches corresponding slot",
 			args: args{
 				nodeAvgNet: 1.0,
 				clusterStrategy: ClusterStrategy{
@@ -368,7 +368,7 @@ func TestMatchSlotOffset(t *testing.T) {
 			want: 0.18,
 		},
 		{
-			name: "test2",
+			name: "nodeAvgNet less than all slot NET, matches first slot",
 			args: args{
 				nodeAvgNet: -1.3,
 				clusterStrategy: ClusterStrategy{
@@ -404,7 +404,7 @@ func TestMatchSlotOffset(t *testing.T) {
 			want: -0.15,
 		},
 		{
-			name: "test3",
+			name: "indicator not exists, returns 0",
 			args: args{
 				nodeAvgNet: -1.3,
 				clusterStrategy: ClusterStrategy{
@@ -413,21 +413,6 @@ func TestMatchSlotOffset(t *testing.T) {
 							Slot:   5,
 							NET:    -1.1,
 							Offset: -0.15,
-						},
-						{
-							Slot:   20,
-							NET:    -0.5,
-							Offset: -0.08,
-						},
-						{
-							Slot:   50,
-							NET:    0.2,
-							Offset: 0.07,
-						},
-						{
-							Slot:   90,
-							NET:    1.1,
-							Offset: 0.18,
 						},
 					},
 				},
@@ -440,7 +425,7 @@ func TestMatchSlotOffset(t *testing.T) {
 			want: 0,
 		},
 		{
-			name: "test3",
+			name: "nodeAvgNet greater than all slot NET, returns last slot offset",
 			args: args{
 				nodeAvgNet: 2.1,
 				clusterStrategy: ClusterStrategy{
@@ -473,7 +458,22 @@ func TestMatchSlotOffset(t *testing.T) {
 					OffsetMax: 0.2,
 				},
 			},
-			want: 0.2,
+			want: 0.18,
+		},
+		{
+			name: "slots is empty, returns 0",
+			args: args{
+				nodeAvgNet: 1.0,
+				clusterStrategy: ClusterStrategy{
+					"cpu_usage_ratio": StrategySlots{},
+				},
+				indicator: "cpu_usage_ratio",
+				borweinParameter: &borweintypes.BorweinParameter{
+					OffsetMin: -0.2,
+					OffsetMax: 0.2,
+				},
+			},
+			want: 0,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein.go
@@ -126,15 +126,12 @@ func updateCPUUsageIndicatorOffset(podSet types.PodSet, _ float64, borweinParame
 	targetOffset := latencyregression.MatchSlotOffset(predictAvg, strategy.StrategySlots,
 		string(v1alpha1.ServiceSystemIndicatorNameCPUUsageRatio), borweinParameter)
 
-	offsetMin := borweinParameter.OffsetMin
 	if specialOffset, match := latencyregression.MatchSpecialTimes(strategy.StrategySpecialTime,
 		string(v1alpha1.ServiceSystemIndicatorNameCPUUsageRatio)); match {
 		targetOffset = specialOffset
-		// expand min bound
-		offsetMin = specialOffset
 	}
 
-	targetOffset = general.Clamp(targetOffset, offsetMin, borweinParameter.OffsetMax)
+	targetOffset = general.Clamp(targetOffset, borweinParameter.OffsetMin, borweinParameter.OffsetMax)
 	general.InfoS("offset update by borwein",
 		"indicator", string(v1alpha1.ServiceSystemIndicatorNameCPUUsageRatio),
 		"predictedAvg", predictAvg,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
@@ -378,7 +378,7 @@ func Test_updateCPUUsageIndicatorOffset(t *testing.T) {
 					},
 				},
 			},
-			want:    0.18,
+			want:    0.15,
 			wantErr: false,
 		},
 		{
@@ -448,7 +448,7 @@ func Test_updateCPUUsageIndicatorOffset(t *testing.T) {
 					},
 				},
 			},
-			want:    -0.15,
+			want:    -0.12,
 			wantErr: false,
 		},
 	}

--- a/pkg/config/agent/sysadvisor/qosaware/model/borwein/borwein.go
+++ b/pkg/config/agent/sysadvisor/qosaware/model/borwein/borwein.go
@@ -35,11 +35,11 @@ func NewBorweinConfiguration() *BorweinConfiguration {
 	return &BorweinConfiguration{
 		BorweinParameters: map[string]*borweintypes.BorweinParameter{
 			string(v1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): {
-				OffsetMax:    0.2,
-				OffsetMin:    -0.17,
+				OffsetMax:    0.15,
+				OffsetMin:    -0.12,
 				Version:      "default",
-				IndicatorMax: 0.87,
-				IndicatorMin: 0.5,
+				IndicatorMax: 0.85,
+				IndicatorMin: 0.55,
 			},
 		},
 		NodeFeatureNames:      []string{},


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
1. update borwein parameters
2. when current NET met no strategy slot, use latest one, not indicator max, to 
3. during special time, do not expand indicator min (no need to do that)
