### PR TITLE
fix(*): the interrupt pool is initialized only when irqtuner is enabled

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -265,8 +265,10 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		return false, agent.ComponentStub{}, fmt.Errorf("dynamic policy initReclaimPool failed with error: %v", err)
 	}
 
-	if err := policyImplement.initInterruptPool(); err != nil {
-		return false, agent.ComponentStub{}, fmt.Errorf("dynamic policy initInterruptPool failed with error: %v", err)
+	if conf.EnableIRQTuner {
+		if err := policyImplement.initInterruptPool(); err != nil {
+			return false, agent.ComponentStub{}, fmt.Errorf("dynamic policy initInterruptPool failed with error: %v", err)
+		}
 	}
 
 	err = agentCtx.MetaServer.ConfigurationManager.AddConfigWatcher(crd.AdminQoSConfigurationGVR)


### PR DESCRIPTION
#### What type of PR is this?
fixes
#### What this PR does / why we need it:
The interrupt pool will be initialized by default. If only qrm is upgraded, the order will be stuck.
#### Which issue(s) this PR fixes:
the interrupt pool is initialized only when irqtuner is enabled
#### Special notes for your reviewer:
