### PR TITLE
refactor(network): move UnknownNumaNode constant to common file

### DIFF
--- a/pkg/util/machine/network.go
+++ b/pkg/util/machine/network.go
@@ -46,6 +46,8 @@ const (
 	NicDriverUnknown   NicDriver = "unknown"
 )
 
+const UnknownNumaNode = -1
+
 type ExtraNetworkInfo struct {
 	// Interface info list of all network interface.
 	Interface []InterfaceInfo

--- a/pkg/util/machine/network_linux.go
+++ b/pkg/util/machine/network_linux.go
@@ -81,8 +81,6 @@ const (
 	SoftIrqsFile       = "/proc/softirqs"
 )
 
-const UnknownNumaNode = -1
-
 var netnsMutex sync.Mutex
 
 // GetExtraNetworkInfo collects network interface information from /sys/class/net and net.Interfaces.


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Move the UnknownNumaNode constant from network_linux.go to network.go to make it available across all platforms and avoid duplication
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
