### PR TITLE
fix(cpu/assembler): correct condition for overlap share pool sizes

### DIFF
--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/provisionassembler/assembler_common.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/provisionassembler/assembler_common.go
@@ -282,14 +282,15 @@ func (pa *ProvisionAssemblerCommon) assembleWithoutNUMAExclusivePool(
 			if !nodeEnableReclaim {
 				reclaimedCoresSize = general.Min(reclaimedCoresSize, general.SumUpMapValues(sharePoolSizes))
 				var overlapSharePoolSizes map[string]int
-				if reclaimedCoresSize >= general.SumUpMapValues(reclaimableSharePoolSizes) {
+				if reclaimedCoresSize <= general.SumUpMapValues(reclaimableSharePoolSizes) {
 					overlapSharePoolSizes = reclaimableSharePoolSizes
 				} else {
 					overlapSharePoolSizes = sharePoolSizes
 				}
+
 				reclaimSizes, err := regulateOverlapReclaimPoolSize(overlapSharePoolSizes, reclaimedCoresSize)
 				if err != nil {
-					return fmt.Errorf("failed to calculate sharedOverlapReclaimSize")
+					return fmt.Errorf("failed to regulateOverlapReclaimPoolSize: %w", err)
 				}
 				sharedOverlapReclaimSize = reclaimSizes
 			} else {
@@ -308,7 +309,7 @@ func (pa *ProvisionAssemblerCommon) assembleWithoutNUMAExclusivePool(
 					reclaimedCoresSize = reservedForReclaim
 					regulatedOverlapReclaimPoolSize, err := regulateOverlapReclaimPoolSize(sharePoolSizes, reclaimedCoresSize)
 					if err != nil {
-						return fmt.Errorf("failed to regulateOverlapReclaimPoolSize for non-binding NUMAs reserved for reclaim")
+						return fmt.Errorf("failed to regulateOverlapReclaimPoolSize for NUMAs reserved for reclaim: %w", err)
 					}
 					sharedOverlapReclaimSize = regulatedOverlapReclaimPoolSize
 				}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Fix incorrect comparison operator that determined which share pool sizes to use for reclaiming. Also improve error handling by adding detailed error logging when regulateOverlapReclaimPoolSize fails.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
