### PR TITLE
WIP: feat(advisor):  apply cpu headroom discount when power level is present 

### DIFF
--- a/cmd/katalyst-agent/app/options/sysadvisor/poweraware/power_aware_plugin.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/poweraware/power_aware_plugin.go
@@ -29,6 +29,10 @@ type PowerAwarePluginOptions struct {
 	PowerCappingAdvisorSocketAbsPath string
 	AnnotationKeyPrefix              string
 	DVFSIndication                   string
+
+	CPUHeadroomPowerDiscountP1 float64
+	CPUHeadroomPowerDiscountP2 float64
+	CPUHeadroomPowerDiscountP3 float64
 }
 
 func (p *PowerAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
@@ -39,6 +43,9 @@ func (p *PowerAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&p.PowerCappingAdvisorSocketAbsPath, "power-capping-advisor-sock-abs-path", p.PowerCappingAdvisorSocketAbsPath, "absolute path of unix socket file for power capping advisor served in sys-advisor")
 	fs.StringVar(&p.AnnotationKeyPrefix, "power-aware-annotation-key-prefix", p.AnnotationKeyPrefix, "prefix of node annotation keys used by power aware plugin")
 	fs.StringVar(&p.DVFSIndication, "power-aware-dvfs-indication", p.DVFSIndication, "indication metric name of dvfs effect")
+	fs.Float64Var(&p.CPUHeadroomPowerDiscountP1, "cpu-headroom-power-discount-p1", p.CPUHeadroomPowerDiscountP1, "discount rate of cpu headroom when power level is p1")
+	fs.Float64Var(&p.CPUHeadroomPowerDiscountP2, "cpu-headroom-power-discount-p2", p.CPUHeadroomPowerDiscountP2, "discount rate of cpu headroom when power level is p2")
+	fs.Float64Var(&p.CPUHeadroomPowerDiscountP3, "cpu-headroom-power-discount-p3", p.CPUHeadroomPowerDiscountP3, "discount rate of cpu headroom when power level is p3")
 }
 
 func (p *PowerAwarePluginOptions) ApplyTo(o *poweraware.PowerAwarePluginConfiguration) error {
@@ -49,12 +56,19 @@ func (p *PowerAwarePluginOptions) ApplyTo(o *poweraware.PowerAwarePluginConfigur
 	o.AnnotationKeyPrefix = p.AnnotationKeyPrefix
 	o.DVFSIndication = p.DVFSIndication
 
+	o.CPUHeadroomPowerDiscountP1 = p.CPUHeadroomPowerDiscountP1
+	o.CPUHeadroomPowerDiscountP2 = p.CPUHeadroomPowerDiscountP2
+	o.CPUHeadroomPowerDiscountP3 = p.CPUHeadroomPowerDiscountP3
+
 	return nil
 }
 
 // NewPowerAwarePluginOptions creates a new Options with a default config.
 func NewPowerAwarePluginOptions() *PowerAwarePluginOptions {
 	return &PowerAwarePluginOptions{
-		DVFSIndication: poweraware.DVFSIndicationPower,
+		DVFSIndication:             poweraware.DVFSIndicationPower,
+		CPUHeadroomPowerDiscountP1: 0.2,
+		CPUHeadroomPowerDiscountP2: 0.4,
+		CPUHeadroomPowerDiscountP3: 0.6,
 	}
 }

--- a/cmd/katalyst-agent/app/options/sysadvisor/poweraware/power_aware_plugin.go
+++ b/cmd/katalyst-agent/app/options/sysadvisor/poweraware/power_aware_plugin.go
@@ -30,9 +30,10 @@ type PowerAwarePluginOptions struct {
 	AnnotationKeyPrefix              string
 	DVFSIndication                   string
 
-	CPUHeadroomPowerDiscountP1 float64
-	CPUHeadroomPowerDiscountP2 float64
-	CPUHeadroomPowerDiscountP3 float64
+	CPUHeadroomPowerDiscountEnabled bool
+	CPUHeadroomPowerDiscountP1      float64
+	CPUHeadroomPowerDiscountP2      float64
+	CPUHeadroomPowerDiscountP3      float64
 }
 
 func (p *PowerAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
@@ -43,6 +44,7 @@ func (p *PowerAwarePluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&p.PowerCappingAdvisorSocketAbsPath, "power-capping-advisor-sock-abs-path", p.PowerCappingAdvisorSocketAbsPath, "absolute path of unix socket file for power capping advisor served in sys-advisor")
 	fs.StringVar(&p.AnnotationKeyPrefix, "power-aware-annotation-key-prefix", p.AnnotationKeyPrefix, "prefix of node annotation keys used by power aware plugin")
 	fs.StringVar(&p.DVFSIndication, "power-aware-dvfs-indication", p.DVFSIndication, "indication metric name of dvfs effect")
+	fs.BoolVar(&p.CPUHeadroomPowerDiscountEnabled, "cpu-headroom-power-discount-enable", p.CPUHeadroomPowerDiscountEnabled, "to enable cpu headroom discount when power level is present")
 	fs.Float64Var(&p.CPUHeadroomPowerDiscountP1, "cpu-headroom-power-discount-p1", p.CPUHeadroomPowerDiscountP1, "discount rate of cpu headroom when power level is p1")
 	fs.Float64Var(&p.CPUHeadroomPowerDiscountP2, "cpu-headroom-power-discount-p2", p.CPUHeadroomPowerDiscountP2, "discount rate of cpu headroom when power level is p2")
 	fs.Float64Var(&p.CPUHeadroomPowerDiscountP3, "cpu-headroom-power-discount-p3", p.CPUHeadroomPowerDiscountP3, "discount rate of cpu headroom when power level is p3")
@@ -56,6 +58,7 @@ func (p *PowerAwarePluginOptions) ApplyTo(o *poweraware.PowerAwarePluginConfigur
 	o.AnnotationKeyPrefix = p.AnnotationKeyPrefix
 	o.DVFSIndication = p.DVFSIndication
 
+	o.CPUHeadroomPowerDiscountEnabled = p.CPUHeadroomPowerDiscountEnabled
 	o.CPUHeadroomPowerDiscountP1 = p.CPUHeadroomPowerDiscountP1
 	o.CPUHeadroomPowerDiscountP2 = p.CPUHeadroomPowerDiscountP2
 	o.CPUHeadroomPowerDiscountP3 = p.CPUHeadroomPowerDiscountP3
@@ -66,9 +69,10 @@ func (p *PowerAwarePluginOptions) ApplyTo(o *poweraware.PowerAwarePluginConfigur
 // NewPowerAwarePluginOptions creates a new Options with a default config.
 func NewPowerAwarePluginOptions() *PowerAwarePluginOptions {
 	return &PowerAwarePluginOptions{
-		DVFSIndication:             poweraware.DVFSIndicationPower,
-		CPUHeadroomPowerDiscountP1: 0.2,
-		CPUHeadroomPowerDiscountP2: 0.4,
-		CPUHeadroomPowerDiscountP3: 0.6,
+		DVFSIndication:                  poweraware.DVFSIndicationPower,
+		CPUHeadroomPowerDiscountEnabled: true,
+		CPUHeadroomPowerDiscountP1:      0.2,
+		CPUHeadroomPowerDiscountP2:      0.4,
+		CPUHeadroomPowerDiscountP3:      0.6,
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
@@ -32,6 +32,8 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/evictor"
 	evictserver "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/evictor/server"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/reader"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/types"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/poweraware"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
@@ -125,6 +127,9 @@ func NewPowerAwarePlugin(
 }
 
 func newPluginWithAdvisor(pluginName string, conf *config.Configuration, advisor advisor.PowerAwareAdvisor) (plugin.SysAdvisorPlugin, error) {
+	general.Infof("enable cpu headroom assembler discount decorator")
+	decorator.EnablePlugin(types.CPUHeadroomAssemblerDecoratorDiscount)
+
 	return &powerAwarePlugin{
 		name:    pluginName,
 		dryRun:  conf.PowerAwarePluginConfiguration.DryRun,

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
@@ -127,8 +127,10 @@ func NewPowerAwarePlugin(
 }
 
 func newPluginWithAdvisor(pluginName string, conf *config.Configuration, advisor advisor.PowerAwareAdvisor) (plugin.SysAdvisorPlugin, error) {
-	general.Infof("enable cpu headroom assembler discount decorator")
-	decorator.EnablePlugin(types.CPUHeadroomAssemblerDecoratorDiscount)
+	if conf.CPUHeadroomPowerDiscountEnabled {
+		general.Infof("enable cpu headroom assembler discount decorator")
+		decorator.EnablePlugin(types.CPUHeadroomAssemblerDecoratorDiscount)
+	}
 
 	return &powerAwarePlugin{
 		name:    pluginName,

--- a/pkg/agent/sysadvisor/plugin/poweraware/spec/spec.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/spec/spec.go
@@ -37,6 +37,7 @@ const (
 	PowerAlertP0 PowerAlert = "p0"
 	PowerAlertP1 PowerAlert = "p1"
 	PowerAlertP2 PowerAlert = "p2"
+	PowerAlertP3 PowerAlert = "p3"
 
 	// PowerAlertOK is derivative power alert code which corresponds to NON-existent power alert annotation
 	PowerAlertOK PowerAlert = "ok"

--- a/pkg/agent/sysadvisor/plugin/qosaware/qos_aware.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/qos_aware.go
@@ -148,7 +148,7 @@ func (qap *QoSAwarePlugin) Name() string {
 
 // Init initializes the qos aware plugin
 func (qap *QoSAwarePlugin) Init() error {
-	return nil
+	return qap.resourceAdvisor.Init()
 }
 
 func (qap *QoSAwarePlugin) periodicWork(_ context.Context) {

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor.go
@@ -117,6 +117,11 @@ type cpuResourceAdvisor struct {
 	emitter    metrics.MetricEmitter
 }
 
+func (cra *cpuResourceAdvisor) Init() error {
+	// to decorate headroom assembler if applicable decorator is enabled
+	return cra.decorateHeadroomAssembler()
+}
+
 // NewCPUResourceAdvisor returns a cpuResourceAdvisor instance
 func NewCPUResourceAdvisor(conf *config.Configuration, extraConf interface{}, metaCache metacache.MetaCache,
 	metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter,
@@ -146,6 +151,7 @@ func NewCPUResourceAdvisor(conf *config.Configuration, extraConf interface{}, me
 	if err := cra.initializeProvisionAssembler(); err != nil {
 		klog.Errorf("[qosaware-cpu] initialize provision assembler failed: %v", err)
 	}
+
 	if err := cra.initializeHeadroomAssembler(); err != nil {
 		klog.Errorf("[qosaware-cpu] initialize headroom assembler failed: %v", err)
 	}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/provisionassembler"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/isolation"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/region"
@@ -81,6 +82,8 @@ func init() {
 	headroomassembler.RegisterInitializer(types.CPUHeadroomAssemblerCommon, headroomassembler.NewHeadroomAssemblerCommon)
 	// TODO: CPUHeadroomAssemblerDedicated policy has removed, its name is retained for compatibility.
 	headroomassembler.RegisterInitializer(types.CPUHeadroomAssemblerDedicated, headroomassembler.NewHeadroomAssemblerCommon)
+
+	decorator.RegisterInitializer(types.CPUHeadroomAssemblerDecoratorDiscount, decorator.NewAssemblerDiscountDecorator)
 }
 
 // cpuResourceAdvisor is the entrance of updating cpu resource provision advice for

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_helper.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_helper.go
@@ -143,16 +143,7 @@ func (cra *cpuResourceAdvisor) initializeProvisionAssembler() error {
 	return nil
 }
 
-func (cra *cpuResourceAdvisor) initializeHeadroomAssembler() error {
-	assemblerName := cra.conf.CPUAdvisorConfiguration.HeadroomAssembler
-	initializers := headroomassembler.GetRegisteredInitializers()
-
-	initializer, ok := initializers[assemblerName]
-	if !ok {
-		return fmt.Errorf("unsupported headroom assembler %v", assemblerName)
-	}
-	cra.headroomAssembler = initializer(cra.conf, cra.extraConf, &cra.regionMap, &cra.reservedForReclaim, &cra.numaAvailable, &cra.nonBindingNumas, cra.metaCache, cra.metaServer, cra.emitter)
-
+func (cra *cpuResourceAdvisor) decorateHeadroomAssembler() error {
 	decorateName := decorator.GetEnabledPlugin()
 	if len(decorateName) > 0 {
 		initializers := decorator.GetRegisteredInitializers()
@@ -164,6 +155,19 @@ func (cra *cpuResourceAdvisor) initializeHeadroomAssembler() error {
 		general.InfoS("cpu headroom assembler: decorated by %q", decorateName)
 		cra.headroomAssembler = decoratorInitializer(cra.headroomAssembler, cra.conf, cra.extraConf, cra.metaCache, cra.metaServer, cra.emitter)
 	}
+
+	return nil
+}
+
+func (cra *cpuResourceAdvisor) initializeHeadroomAssembler() error {
+	assemblerName := cra.conf.CPUAdvisorConfiguration.HeadroomAssembler
+	initializers := headroomassembler.GetRegisteredInitializers()
+
+	initializer, ok := initializers[assemblerName]
+	if !ok {
+		return fmt.Errorf("unsupported headroom assembler %v", assemblerName)
+	}
+	cra.headroomAssembler = initializer(cra.conf, cra.extraConf, &cra.regionMap, &cra.reservedForReclaim, &cra.numaAvailable, &cra.nonBindingNumas, cra.metaCache, cra.metaServer, cra.emitter)
 
 	return nil
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_helper.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_helper.go
@@ -152,7 +152,7 @@ func (cra *cpuResourceAdvisor) decorateHeadroomAssembler() error {
 			return fmt.Errorf("unsupported headroom assembler decorator %v", decorateName)
 		}
 
-		general.InfoS("cpu headroom assembler: decorated by %q", decorateName)
+		general.Infof("cpu headroom assembler: decorated by %q", decorateName)
 		cra.headroomAssembler = decoratorInitializer(cra.headroomAssembler, cra.conf, cra.extraConf, cra.metaCache, cra.metaServer, cra.emitter)
 	}
 

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decorator
+
+import (
+	"sync"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+var (
+	initializers     sync.Map
+	enabledDecorator string
+	lock             sync.RWMutex
+)
+
+type InitFunc func(inner headroomassembler.HeadroomAssembler,
+	conf *config.Configuration, extraConf interface{},
+	metaReader metacache.MetaReader, metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter,
+) headroomassembler.HeadroomAssembler
+
+func RegisterInitializer(name string, initFunc InitFunc) {
+	initializers.Store(name, initFunc)
+}
+
+func GetRegisteredInitializers() map[string]InitFunc {
+	res := make(map[string]InitFunc)
+	initializers.Range(func(key, value interface{}) bool {
+		res[key.(string)] = value.(InitFunc)
+		return true
+	})
+	return res
+}
+
+func EnablePlugin(name string) {
+	lock.Lock()
+	defer lock.Unlock()
+	enabledDecorator = name
+}
+
+func GetEnabledPlugin() string {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	return enabledDecorator
+}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount.go
@@ -111,9 +111,13 @@ func (d *discountDecorator) GetHeadroom() (resource.Quantity, map[int]resource.Q
 		general.Warningf("unable to determine current discount; apply no discount instead: %s", err)
 		return d.inner.GetHeadroom()
 	}
+	if currentDiscount >= 1.0 || currentDiscount < 0 {
+		general.Warningf("discount %f apply no discount", currentDiscount)
+		return d.inner.GetHeadroom()
+	}
 
 	headroom, numaHeadrooms, err := d.inner.GetHeadroom()
-	if err != nil || currentDiscount >= 1.0 {
+	if err != nil {
 		return headroom, numaHeadrooms, err
 	}
 
@@ -140,5 +144,5 @@ func (d *discountDecorator) GetHeadroom() (resource.Quantity, map[int]resource.Q
 		)
 	}
 
-	return discountHeadroom, discountNumaHeadrooms, err
+	return discountHeadroom, discountNumaHeadrooms, nil
 }

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decorator
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/metacache"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+func NewAssemblerDiscountDecorator(inner headroomassembler.HeadroomAssembler,
+	conf *config.Configuration, extraConf interface{},
+	metaReader metacache.MetaReader, metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter,
+) headroomassembler.HeadroomAssembler {
+	discounts := map[spec.PowerAlert]float64{
+		spec.PowerAlertP1: conf.CPUHeadroomPowerDiscountP1,
+		spec.PowerAlertP2: conf.CPUHeadroomPowerDiscountP2,
+		spec.PowerAlertP3: conf.CPUHeadroomPowerDiscountP3,
+	}
+
+	return &discountDecorator{
+		inner: inner,
+		discounter: &nodeAnnotationDiscountGetter{
+			specFetcher: spec.NewFetcher(metaServer.NodeFetcher, conf.PowerAwarePluginConfiguration.AnnotationKeyPrefix),
+			conf:        conf,
+			discounts:   discounts,
+		},
+	}
+}
+
+type DiscountGetter interface {
+	GetDiscount() (float64, error)
+}
+
+type nodeAnnotationDiscountGetter struct {
+	specFetcher spec.SpecFetcher
+	conf        *config.Configuration
+
+	discounts map[spec.PowerAlert]float64
+}
+
+func getDiscountByLevel(level spec.PowerAlert, discounts map[spec.PowerAlert]float64) float64 {
+	if len(level) == 0 {
+		return 1.0
+	}
+
+	if value, ok := discounts[level]; ok {
+		return value
+	}
+
+	switch level {
+	case spec.PowerAlertS0, spec.PowerAlertP0:
+		return 0.0
+	default:
+		return 1.0
+	}
+}
+
+func (d *nodeAnnotationDiscountGetter) GetDiscount() (float64, error) {
+	powerSpec, err := d.specFetcher.GetPowerSpec(context.Background())
+	if err != nil {
+		return 1.0, errors.Wrap(err, "failed to get discount")
+	}
+
+	level := powerSpec.Alert
+	return getDiscountByLevel(level, d.discounts), nil
+}
+
+type discountDecorator struct {
+	inner      headroomassembler.HeadroomAssembler
+	discounter DiscountGetter
+}
+
+func applyDiscount(cpuQuantity resource.Quantity, discount float64) resource.Quantity {
+	milliValue := cpuQuantity.MilliValue()
+	newMilliValue := int64(float64(milliValue) * discount)
+	newQtyViaMilli := resource.NewMilliQuantity(newMilliValue, resource.DecimalSI)
+	return *newQtyViaMilli
+}
+
+func (d *discountDecorator) GetHeadroom() (resource.Quantity, map[int]resource.Quantity, error) {
+	currentDiscount, err := d.discounter.GetDiscount()
+	if err != nil {
+		general.Warningf("unable to determine current discount; apply no discount instead")
+		return d.inner.GetHeadroom()
+	}
+
+	headroom, numaHeadrooms, err := d.inner.GetHeadroom()
+	if err == nil && currentDiscount < 1.0 {
+		headroom = applyDiscount(headroom, currentDiscount)
+		for numa := range numaHeadrooms {
+			numaHeadrooms[numa] = applyDiscount(numaHeadrooms[numa], currentDiscount)
+		}
+	}
+	return headroom, numaHeadrooms, err
+}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
 	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
 
 func Test_applyDiscount(t *testing.T) {
@@ -149,6 +150,7 @@ func Test_discountDecorator_GetHeadroom(t *testing.T) {
 			d := &discountDecorator{
 				inner:      tt.fields.inner,
 				discounter: tt.fields.discounter,
+				emitter:    metrics.DummyMetrics{},
 			}
 			got, got1, err := d.GetHeadroom()
 			if (err != nil) != tt.wantErr {

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler/decorator/decorator_discount_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package decorator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/spec"
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/assembler/headroomassembler"
+)
+
+func Test_applyDiscount(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		quantity resource.Quantity
+		discount float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want resource.Quantity
+	}{
+		{
+			name: "happy path",
+			args: args{
+				quantity: resource.MustParse("1"),
+				discount: 0.32,
+			},
+			want: resource.MustParse("320m"),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := applyDiscount(tt.args.quantity, tt.args.discount); !got.Equal(tt.want) {
+				t.Errorf("applyDiscount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type mockInnerAssembler struct {
+	mock.Mock
+}
+
+func (m *mockInnerAssembler) GetHeadroom() (resource.Quantity, map[int]resource.Quantity, error) {
+	args := m.Called()
+	return args.Get(0).(resource.Quantity), args.Get(1).(map[int]resource.Quantity), args.Error(2)
+}
+
+type mockDiscounter struct {
+	mock.Mock
+}
+
+func (m *mockDiscounter) GetDiscount() (float64, error) {
+	args := m.Called()
+	return args.Get(0).(float64), args.Error(1)
+}
+
+func Test_discountDecorator_GetHeadroom(t *testing.T) {
+	t.Parallel()
+
+	innerMockOK := new(mockInnerAssembler)
+	innerMockOK.On("GetHeadroom").Return(
+		resource.MustParse("4"),
+		map[int]resource.Quantity{
+			0: resource.MustParse("1"),
+			1: resource.MustParse("3"),
+		}, nil,
+	)
+
+	discounterMockOK := new(mockDiscounter)
+	discounterMockOK.On("GetDiscount").Return(0.48, nil)
+
+	innerMockNG := new(mockInnerAssembler)
+	innerMockNG.On("GetHeadroom").Return(
+		resource.MustParse("4"),
+		map[int]resource.Quantity{
+			0: resource.MustParse("1"),
+			1: resource.MustParse("3"),
+		}, nil,
+	)
+
+	discounterMockNG := new(mockDiscounter)
+	discounterMockNG.On("GetDiscount").Return(0.0, errors.New("test"))
+
+	type fields struct {
+		inner      headroomassembler.HeadroomAssembler
+		discounter DiscountGetter
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    resource.Quantity
+		want1   map[int]resource.Quantity
+		wantErr bool
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				inner:      innerMockOK,
+				discounter: discounterMockOK,
+			},
+			want: resource.MustParse("1920m"),
+			want1: map[int]resource.Quantity{
+				0: resource.MustParse("480m"),
+				1: resource.MustParse("1440m"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative path",
+			fields: fields{
+				inner:      innerMockNG,
+				discounter: discounterMockNG,
+			},
+			want: resource.MustParse("4"),
+			want1: map[int]resource.Quantity{
+				0: resource.MustParse("1"),
+				1: resource.MustParse("3"),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := &discountDecorator{
+				inner:      tt.fields.inner,
+				discounter: tt.fields.discounter,
+			}
+			got, got1, err := d.GetHeadroom()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetHeadroom() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("GetHeadroom() got = %v, want %v", got, tt.want)
+			}
+			if !got1[0].Equal(tt.want1[0]) {
+				t.Errorf("GetHeadroom() got1[0] = %v, want[0] %v", got1[0], tt.want1[1])
+			}
+			if !got1[1].Equal(tt.want1[1]) {
+				t.Errorf("GetHeadroom() got1[1] = %v, want[1] %v", got1[1], tt.want1[1])
+			}
+
+			if tt.fields.inner != nil {
+				tt.fields.inner.(*mockInnerAssembler).AssertExpectations(t)
+			}
+			if tt.fields.discounter != nil {
+				tt.fields.discounter.(*mockDiscounter).AssertExpectations(t)
+			}
+		})
+	}
+}
+
+type mockSpecFetcher struct {
+	mock.Mock
+}
+
+func (m *mockSpecFetcher) GetPowerSpec(ctx context.Context) (*spec.PowerSpec, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*spec.PowerSpec), args.Error(1)
+}
+
+func Test_nodeAnnotationDiscountGetter_GetDiscount(t *testing.T) {
+	t.Parallel()
+
+	discounts := map[spec.PowerAlert]float64{
+		spec.PowerAlertP1: 0.20,
+		spec.PowerAlertP2: 0.40,
+		spec.PowerAlertP3: 0.60,
+	}
+
+	specFetcherMockP3 := new(mockSpecFetcher)
+	specFetcherMockP3.On("GetPowerSpec", context.Background()).Return(
+		&spec.PowerSpec{
+			Alert: "p3",
+		},
+		nil,
+	)
+
+	specFetcherMockP0 := new(mockSpecFetcher)
+	specFetcherMockP0.On("GetPowerSpec", context.Background()).Return(
+		&spec.PowerSpec{
+			Alert: "p0",
+		},
+		nil,
+	)
+
+	type fields struct {
+		specFetcher spec.SpecFetcher
+		discounts   map[spec.PowerAlert]float64
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    float64
+		wantErr bool
+	}{
+		{
+			name: "happy path of p3",
+			fields: fields{
+				specFetcher: specFetcherMockP3,
+				discounts:   discounts,
+			},
+			want:    0.60,
+			wantErr: false,
+		},
+		{
+			name: "happy path of p0",
+			fields: fields{
+				specFetcher: specFetcherMockP0,
+				discounts:   discounts,
+			},
+			want:    0.0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			d := &nodeAnnotationDiscountGetter{
+				specFetcher: tt.fields.specFetcher,
+				discounts:   tt.fields.discounts,
+			}
+			got, err := d.GetDiscount()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDiscount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetDiscount() got = %v, want %v", got, tt.want)
+			}
+
+			if tt.fields.specFetcher != nil {
+				tt.fields.specFetcher.(*mockSpecFetcher).AssertExpectations(t)
+			}
+		})
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/memory/advisor.go
@@ -85,6 +85,10 @@ type memoryResourceAdvisor struct {
 	emitter    metrics.MetricEmitter
 }
 
+func (ra *memoryResourceAdvisor) Init() error {
+	return nil
+}
+
 // NewMemoryResourceAdvisor returns a memoryResourceAdvisor instance
 func NewMemoryResourceAdvisor(conf *config.Configuration, extraConf interface{}, metaCache metacache.MetaCache,
 	metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter,

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/resource_stub.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/resource_stub.go
@@ -33,6 +33,10 @@ type ResourceAdvisorStub struct {
 	subAdvisor map[types.QoSResourceName]*SubResourceAdvisorStub
 }
 
+func (r *ResourceAdvisorStub) Init() error {
+	return nil
+}
+
 var _ ResourceAdvisor = NewResourceAdvisorStub()
 
 func NewResourceAdvisorStub() *ResourceAdvisorStub {
@@ -74,6 +78,10 @@ func (r *ResourceAdvisorStub) SetHeadroom(resourceName v1.ResourceName, quantity
 type SubResourceAdvisorStub struct {
 	sync.Mutex
 	quantity resource.Quantity
+}
+
+func (s *SubResourceAdvisorStub) Init() error {
+	return nil
 }
 
 var _ SubResourceAdvisor = NewSubResourceAdvisorStub()

--- a/pkg/agent/sysadvisor/types/cpu.go
+++ b/pkg/agent/sysadvisor/types/cpu.go
@@ -74,6 +74,10 @@ const (
 	CPUHeadroomAssemblerDedicated CPUHeadroomAssemblerName = "dedicated"
 )
 
+const (
+	CPUHeadroomAssemblerDecoratorDiscount string = "discount"
+)
+
 // ControlKnob holds tunable system entries affecting indicator metrics
 type ControlKnob map[v1alpha1.ControlKnobName]ControlKnobItem
 

--- a/pkg/config/agent/sysadvisor/poweraware/power_aware_plugin.go
+++ b/pkg/config/agent/sysadvisor/poweraware/power_aware_plugin.go
@@ -29,9 +29,10 @@ type PowerAwarePluginConfiguration struct {
 	AnnotationKeyPrefix              string
 	DVFSIndication                   string
 
-	CPUHeadroomPowerDiscountP1 float64
-	CPUHeadroomPowerDiscountP2 float64
-	CPUHeadroomPowerDiscountP3 float64
+	CPUHeadroomPowerDiscountEnabled bool
+	CPUHeadroomPowerDiscountP1      float64
+	CPUHeadroomPowerDiscountP2      float64
+	CPUHeadroomPowerDiscountP3      float64
 }
 
 // NewPowerAwarePluginConfiguration creates a default config

--- a/pkg/config/agent/sysadvisor/poweraware/power_aware_plugin.go
+++ b/pkg/config/agent/sysadvisor/poweraware/power_aware_plugin.go
@@ -28,6 +28,10 @@ type PowerAwarePluginConfiguration struct {
 	PowerCappingAdvisorSocketAbsPath string
 	AnnotationKeyPrefix              string
 	DVFSIndication                   string
+
+	CPUHeadroomPowerDiscountP1 float64
+	CPUHeadroomPowerDiscountP2 float64
+	CPUHeadroomPowerDiscountP3 float64
 }
 
 // NewPowerAwarePluginConfiguration creates a default config

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -484,3 +484,9 @@ const (
 	MetricsPodVolumeInodesFree = "free.inodes.volume.pod.container"
 	MetricsPodVolumeInodesUsed = "used.inodes.volume.pod.container"
 )
+
+// reclaimed cpu headroom metrics
+const (
+	MetricsNodeCPUHeadroomLoss = "reduced.node.cpu.headroom"
+	MetricsNumaCPUHeadroomLoss = "reduced.numa.cpu.headroom"
+)


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
This PR allows power-ware plugin to enable reclaimed cpu headroom discount when the node's power level is of p1/p2/p3.

To ensure the power-aware plugin enabling to happen prior qos-aware cpu resource advisor being called to GetHeadroom, __Init phase__ is put with cpu sub resource advisor up to qos-aware plugin.   

