### PR TITLE
feat(memory): add memory socket binding for dedicated and shared cores pods

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/memory_plugin.go
@@ -41,6 +41,7 @@ type MemoryOptions struct {
 	OOMPriorityPinnedMapAbsPath                   string
 	EnableNonBindingShareCoresMemoryResourceCheck bool
 	EnableNUMAAllocationReactor                   bool
+	EnableMemorySocketBinding                     bool
 	NUMABindResultResourceAllocationAnnotationKey string
 
 	SockMemOptions
@@ -125,6 +126,7 @@ func NewMemoryOptions() *MemoryOptions {
 		EnableOOMPriority:                             false,
 		EnableNonBindingShareCoresMemoryResourceCheck: true,
 		EnableNUMAAllocationReactor:                   false,
+		EnableMemorySocketBinding:                     false,
 		NUMABindResultResourceAllocationAnnotationKey: consts.QRMResourceAnnotationKeyNUMABindResult,
 		SockMemOptions: SockMemOptions{
 			EnableSettingSockMem: false,
@@ -185,6 +187,8 @@ func (o *MemoryOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.EnableNonBindingShareCoresMemoryResourceCheck, "enable the topology check for non-binding shares cores pods")
 	fs.BoolVar(&o.EnableNUMAAllocationReactor, "enable-numa-allocation-reactor",
 		o.EnableNUMAAllocationReactor, "enable numa allocation reactor for numa binding pods to patch pod numa binding result annotation")
+	fs.BoolVar(&o.EnableMemorySocketBinding, "enable-memory-socket-binding",
+		o.EnableMemorySocketBinding, "enable memory socket binding for dedicated_cores and shared_cores pods")
 	fs.StringVar(&o.NUMABindResultResourceAllocationAnnotationKey, "numa-bind-result-resource-allocation-annotation-key",
 		o.NUMABindResultResourceAllocationAnnotationKey, "the key of numa bind result resource allocation annotation")
 	fs.StringVar(&o.OOMPriorityPinnedMapAbsPath, "oom-priority-pinned-bpf-map-path",
@@ -248,6 +252,7 @@ func (o *MemoryOptions) ApplyTo(conf *qrmconfig.MemoryQRMPluginConfig) error {
 	conf.EnableOOMPriority = o.EnableOOMPriority
 	conf.EnableNonBindingShareCoresMemoryResourceCheck = o.EnableNonBindingShareCoresMemoryResourceCheck
 	conf.EnableNUMAAllocationReactor = o.EnableNUMAAllocationReactor
+	conf.EnableMemorySocketBinding = o.EnableMemorySocketBinding
 	conf.NUMABindResultResourceAllocationAnnotationKey = o.NUMABindResultResourceAllocationAnnotationKey
 	conf.OOMPriorityPinnedMapAbsPath = o.OOMPriorityPinnedMapAbsPath
 	conf.EnableSettingSockMem = o.EnableSettingSockMem

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -162,6 +162,7 @@ type DynamicPolicy struct {
 	enableReclaimNUMABinding                      bool
 	enableSNBHighNumaPreference                   bool
 	enableNonBindingShareCoresMemoryResourceCheck bool
+	enableMemorySocketBinding                     bool
 
 	numaAllocationReactor                         reactor.AllocationReactor
 	numaBindResultResourceAllocationAnnotationKey string
@@ -236,6 +237,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		enableSNBHighNumaPreference: conf.EnableSNBHighNumaPreference,
 		resctrlHinter:               newResctrlHinter(&conf.ResctrlConfig, wrappedEmitter),
 		enableNonBindingShareCoresMemoryResourceCheck: conf.EnableNonBindingShareCoresMemoryResourceCheck,
+		enableMemorySocketBinding:                     conf.EnableMemorySocketBinding,
 		numaBindResultResourceAllocationAnnotationKey: conf.NUMABindResultResourceAllocationAnnotationKey,
 	}
 

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
@@ -136,7 +136,7 @@ func (p *DynamicPolicy) numaBindingAllocationHandler(ctx context.Context,
 				"memoryReq(bytes)", podAggregatedRequest,
 				"currentResult(bytes)", allocationInfo.AggregatedQuantity)
 
-			resp, packErr := packAllocationResponse(allocationInfo, req, nil)
+			resp, packErr := p.packAllocationResponse(allocationInfo, req, nil)
 			if packErr != nil {
 				general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 					req.PodNamespace, req.PodName, req.ContainerName, packErr)
@@ -240,7 +240,7 @@ func (p *DynamicPolicy) numaBindingAllocationHandler(ctx context.Context,
 		return nil, fmt.Errorf("adjustAllocationEntries failed with error: %v", err)
 	}
 
-	resp, err := packAllocationResponse(allocationInfo, req, nil)
+	resp, err := p.packAllocationResponse(allocationInfo, req, nil)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -287,7 +287,7 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 				"containerName", req.ContainerName,
 				"memoryReq(bytes)", allocationInfo.AggregatedQuantity,
 				"currentResult(bytes)", allocationInfo.AggregatedQuantity)
-			return packAllocationResponse(allocationInfo, req, nil)
+			return p.packAllocationResponse(allocationInfo, req, nil)
 		}
 
 		general.InfoS("not meet requirement, clear record and re-allocate",
@@ -354,7 +354,7 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 		return nil, fmt.Errorf("adjustAllocationEntries failed with error: %v", err)
 	}
 
-	resp, err := packAllocationResponse(allocationInfo, req, p.getReclaimedResourceAllocationAnnotations(allocationInfo))
+	resp, err := p.packAllocationResponse(allocationInfo, req, p.getReclaimedResourceAllocationAnnotations(allocationInfo))
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -430,7 +430,7 @@ func (p *DynamicPolicy) numaBindingAllocationSidecarHandler(_ context.Context,
 	}
 	p.state.SetMachineState(resourcesState, persistCheckpoint)
 
-	resp, err := packAllocationResponse(allocationInfo, req, nil)
+	resp, err := p.packAllocationResponse(allocationInfo, req, nil)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -480,7 +480,7 @@ func (p *DynamicPolicy) allocateNUMAsWithoutNUMABindingPods(_ context.Context,
 		return nil, fmt.Errorf("calculate resourceState by updated pod entries failed with error: %v", err)
 	}
 
-	resp, err := packAllocationResponse(allocationInfo, req, nil)
+	resp, err := p.packAllocationResponse(allocationInfo, req, nil)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -521,7 +521,7 @@ func (p *DynamicPolicy) allocateTargetNUMAs(req *pluginapi.ResourceRequest,
 		return nil, fmt.Errorf("calculate machineState by updated pod entries failed with error: %v", err)
 	}
 
-	resp, err := packAllocationResponse(allocationInfo, req, nil)
+	resp, err := p.packAllocationResponse(allocationInfo, req, nil)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -721,11 +721,30 @@ func calculateMemoryInNumaNodes(req *pluginapi.ResourceRequest,
 }
 
 // packAllocationResponse fills pluginapi.ResourceAllocationResponse with information from AllocationInfo and pluginapi.ResourceRequest
-func packAllocationResponse(allocationInfo *state.AllocationInfo, req *pluginapi.ResourceRequest, resourceAllocationAnnotations map[string]string) (*pluginapi.ResourceAllocationResponse, error) {
+func (p *DynamicPolicy) packAllocationResponse(allocationInfo *state.AllocationInfo, req *pluginapi.ResourceRequest, resourceAllocationAnnotations map[string]string) (*pluginapi.ResourceAllocationResponse, error) {
 	if allocationInfo == nil {
 		return nil, fmt.Errorf("packAllocationResponse got nil allocationInfo")
 	} else if req == nil {
 		return nil, fmt.Errorf("packAllocationResponse got nil request")
+	}
+
+	allocationResult := allocationInfo.NumaAllocationResult.String()
+
+	// if enableMemorySocketBinding is true, we will expand the memory allocation result to the whole socket
+	// for dedicated_cores and shared_cores pods
+	if p.enableMemorySocketBinding &&
+		(allocationInfo.CheckDedicated() || allocationInfo.CheckShared()) {
+		allocatedNUMAs := allocationInfo.NumaAllocationResult.ToSliceInt()
+		socketIDs := p.topology.CPUDetails.SocketsInNUMANodes(allocatedNUMAs...).ToSliceInt()
+		socketNUMAs := p.topology.CPUDetails.NUMANodesInSockets(socketIDs...)
+		allocationResult = socketNUMAs.String()
+
+		general.InfoS("memory socket binding enabled, expand allocation result",
+			"podNamespace", req.PodNamespace,
+			"podName", req.PodName,
+			"containerName", req.ContainerName,
+			"originalAllocation", allocationInfo.NumaAllocationResult.String(),
+			"expandedAllocation", allocationResult)
 	}
 
 	return &pluginapi.ResourceAllocationResponse{
@@ -746,7 +765,7 @@ func packAllocationResponse(allocationInfo *state.AllocationInfo, req *pluginapi
 					IsScalarResource:  true,
 					Annotations:       resourceAllocationAnnotations,
 					AllocatedQuantity: float64(allocationInfo.AggregatedQuantity),
-					AllocationResult:  allocationInfo.NumaAllocationResult.String(),
+					AllocationResult:  allocationResult,
 					ResourceHints: &pluginapi.ListOfTopologyHints{
 						Hints: []*pluginapi.TopologyHint{
 							req.Hint,

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
@@ -732,8 +732,10 @@ func (p *DynamicPolicy) packAllocationResponse(allocationInfo *state.AllocationI
 
 	// if enableMemorySocketBinding is true, we will expand the memory allocation result to the whole socket
 	// for dedicated_cores and shared_cores pods
+	// but if the pod is numa_exclusive, we should not expand it
 	if p.enableMemorySocketBinding &&
-		(allocationInfo.CheckDedicated() || allocationInfo.CheckShared()) {
+		(allocationInfo.CheckDedicated() || allocationInfo.CheckShared()) &&
+		!allocationInfo.CheckNumaExclusive() {
 		allocatedNUMAs := allocationInfo.NumaAllocationResult.ToSliceInt()
 		socketIDs := p.topology.CPUDetails.SocketsInNUMANodes(allocatedNUMAs...).ToSliceInt()
 		socketNUMAs := p.topology.CPUDetails.NUMANodesInSockets(socketIDs...)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers_test.go
@@ -29,6 +29,7 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
 	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/state"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
@@ -818,4 +819,79 @@ func TestCalculateMemoryAllocation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPackAllocationResponseWithSocketBinding(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	// Create a topology with 2 sockets, 2 NUMA nodes per socket (total 4 NUMA nodes)
+	// Socket 0: NUMA 0, 1
+	// Socket 1: NUMA 2, 3
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	as.Nil(err)
+	machineInfo := &info.MachineInfo{
+		Topology: []info.Node{
+			{Memory: 100 * 1024 * 1024 * 1024, Id: 0},
+			{Memory: 100 * 1024 * 1024 * 1024, Id: 1},
+			{Memory: 100 * 1024 * 1024 * 1024, Id: 2},
+			{Memory: 100 * 1024 * 1024 * 1024, Id: 3},
+		},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestPackAllocationResponseWithSocketBinding")
+	as.Nil(err)
+	defer os.RemoveAll(tmpDir)
+
+	policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, tmpDir)
+	as.Nil(err)
+
+	// Case 1: Feature disabled
+	policy.enableMemorySocketBinding = false
+	req := &pluginapi.ResourceRequest{
+		PodUid:        "pod-1",
+		ContainerName: "container-1",
+		PodNamespace:  "default",
+		PodName:       "pod-1",
+	}
+	allocationInfo := &state.AllocationInfo{
+		AllocationMeta: commonstate.AllocationMeta{
+			QoSLevel: apiconsts.PodAnnotationQoSLevelSharedCores,
+		},
+		NumaAllocationResult: machine.NewCPUSet(0), // Allocate NUMA 0
+		AggregatedQuantity:   1024,
+	}
+
+	resp, err := policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	as.Equal("0", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
+
+	// Case 2: Feature enabled, Shared Cores
+	policy.enableMemorySocketBinding = true
+	allocationInfo.QoSLevel = apiconsts.PodAnnotationQoSLevelSharedCores
+
+	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	// Expect NUMA 0 -> Socket 0 -> NUMA 0, 1
+	as.Equal("0-1", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
+
+	// Case 3: Feature enabled, Dedicated Cores
+	allocationInfo.QoSLevel = apiconsts.PodAnnotationQoSLevelDedicatedCores
+	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	as.Equal("0-1", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
+
+	// Case 4: Feature enabled, Reclaimed Cores (Should not bind to socket)
+	allocationInfo.QoSLevel = apiconsts.PodAnnotationQoSLevelReclaimedCores
+	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	as.Equal("0", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
+
+	// Case 5: Feature enabled, Socket 1 allocation
+	allocationInfo.QoSLevel = apiconsts.PodAnnotationQoSLevelSharedCores
+	allocationInfo.NumaAllocationResult = machine.NewCPUSet(2) // NUMA 2 -> Socket 1 -> NUMA 2, 3
+	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	as.Equal("2-3", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
 }

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers_test.go
@@ -894,4 +894,26 @@ func TestPackAllocationResponseWithSocketBinding(t *testing.T) {
 	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
 	as.Nil(err)
 	as.Equal("2-3", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
+
+	// Case 6: Feature enabled, Dedicated Cores with NUMA Exclusive
+	// Should NOT expand to socket
+	allocationInfo.QoSLevel = apiconsts.PodAnnotationQoSLevelDedicatedCores
+	allocationInfo.NumaAllocationResult = machine.NewCPUSet(0) // Reset to NUMA 0
+	allocationInfo.Annotations = map[string]string{
+		apiconsts.PodAnnotationMemoryEnhancementNumaExclusive: apiconsts.PodAnnotationMemoryEnhancementNumaExclusiveEnable,
+	}
+	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	as.Equal("0", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
+
+	// Case 7: Feature enabled, Shared Cores with NUMA Exclusive
+	// Should NOT expand to socket
+	allocationInfo.QoSLevel = apiconsts.PodAnnotationQoSLevelSharedCores
+	allocationInfo.NumaAllocationResult = machine.NewCPUSet(0)
+	allocationInfo.Annotations = map[string]string{
+		apiconsts.PodAnnotationMemoryEnhancementNumaExclusive: apiconsts.PodAnnotationMemoryEnhancementNumaExclusiveEnable,
+	}
+	resp, err = policy.packAllocationResponse(allocationInfo, req, nil)
+	as.Nil(err)
+	as.Equal("0", resp.AllocationResult.ResourceAllocation[string(v1.ResourceMemory)].AllocationResult)
 }

--- a/pkg/config/agent/qrm/memory_plugin.go
+++ b/pkg/config/agent/qrm/memory_plugin.go
@@ -47,6 +47,8 @@ type MemoryQRMPluginConfig struct {
 	EnableNonBindingShareCoresMemoryResourceCheck bool
 	// EnableNUMAAllocationReactor: enable the numa allocation reactor for actual numa binding pods
 	EnableNUMAAllocationReactor bool
+	// EnableMemorySocketBinding: enable memory socket binding for dedicated_cores and shared_cores pods
+	EnableMemorySocketBinding bool
 	// NUMABindResultResourceAllocationAnnotationKey: the annotation key for numa bind result resource allocation
 	// it will be used to set cgroup path for numa bind result resource allocation
 	NUMABindResultResourceAllocationAnnotationKey string


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Enable memory socket binding to expand memory allocation to the whole socket when enabled for dedicated_cores and shared_cores pods.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
