### PR TITLE
feat(gpu): start device topology registry in base plugin

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/baseplugin/base.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/base.go
@@ -107,6 +107,7 @@ func NewBasePlugin(
 
 // Run starts the asynchronous tasks of the plugin
 func (p *BasePlugin) Run(stopCh <-chan struct{}) {
+	go p.DeviceTopologyRegistry.Run(stopCh)
 	go func() {
 		select {
 		case <-p.stateInitializedCh:
@@ -117,7 +118,6 @@ func (p *BasePlugin) Run(stopCh <-chan struct{}) {
 			return
 		}
 	}()
-	go p.DeviceTopologyRegistry.Run(stopCh)
 }
 
 // GetState may return a nil state because the state is only initialized when InitState is called.

--- a/pkg/agent/qrm-plugins/gpu/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/gpu/staticpolicy/policy.go
@@ -149,6 +149,8 @@ func (p *StaticPolicy) Start() (err error) {
 		periodicalhandler.ReadyToStartHandlersByGroup(appqrm.QRMGPUPluginPeriodicalHandlerGroupName)
 	}, 5*time.Second, p.stopCh)
 
+	p.BasePlugin.Run(p.stopCh)
+
 	return nil
 }
 


### PR DESCRIPTION

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Add missing call to run device topology registry in base plugin's Run method and ensure it's started in StaticPolicy's Start method

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
