### PR TITLE
feat(fetcher): add checkpoint support for inner reporter plugins

### DIFF
--- a/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin.go
+++ b/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin.go
@@ -77,7 +77,7 @@ type kubeletPlugin struct {
 
 // NewKubeletReporterPlugin creates a kubelet reporter plugin
 func NewKubeletReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer,
-	conf *config.Configuration, callback plugin.ListAndWatchCallback,
+	conf *config.Configuration, callback plugin.ListAndWatchCallback, cache *v1alpha1.GetReportContentResponse,
 ) (plugin.ReporterPlugin, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &kubeletPlugin{
@@ -89,6 +89,10 @@ func NewKubeletReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaser
 		cancel:      cancel,
 		cb:          callback,
 		StopControl: process.NewStopControl(time.Time{}),
+	}
+	if cache != nil {
+		// initialize with the historical cache restored from checkpoint
+		p.latestReportContentResponse.Store(cache)
 	}
 
 	var podResourcesFilter topology.PodResourcesFilter

--- a/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin_test.go
+++ b/pkg/agent/resourcemanager/fetcher/kubelet/kubeletplugin_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
@@ -300,7 +301,7 @@ func TestNewKubeletReporterPlugin(t *testing.T) {
 		klog.Infof("Callback called with name: %s, resp: %#v", name, resp)
 	}
 
-	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, callback)
+	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, callback, nil)
 	assert.NoError(t, err)
 
 	success := make(chan bool)
@@ -336,7 +337,7 @@ func TestGetTopologyPolicyReportContent(t *testing.T) {
 		klog.Infof("Callback called with name: %s, resp: %#v", name, resp)
 	}
 
-	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, callback)
+	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, callback, nil)
 	assert.NoError(t, err)
 	kubePlugin := plugin.(*kubeletPlugin)
 
@@ -360,11 +361,36 @@ func TestGetTopologyStatusContent(t *testing.T) {
 		klog.Infof("Callback called with name: %s, resp: %#v", name, resp)
 	}
 
-	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, callback)
+	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, callback, nil)
 	assert.NoError(t, err)
 	kubePlugin := plugin.(*kubeletPlugin)
 
 	kubePlugin.topologyStatusAdapter = topology.DummyAdapter{}
 	_, err = kubePlugin.getReportContent(context.TODO())
 	assert.NoError(t, err)
+}
+
+func Test_kubeletPlugin_WithCache(t *testing.T) {
+	t.Parallel()
+
+	conf := generateTestConfiguration(t, "")
+	meta := generateTestMetaServer()
+
+	// mock a cache response
+	mockCache := &v1alpha1.GetReportContentResponse{
+		Content: []*v1alpha1.ReportContent{
+			{
+				GroupVersionKind: &util.CNRGroupVersionKind,
+			},
+		},
+	}
+
+	plugin, err := NewKubeletReporterPlugin(metrics.DummyMetrics{}, meta, conf, nil, mockCache)
+	assert.NoError(t, err)
+	assert.NotNil(t, plugin)
+
+	// Verify that the cache is properly set during initialization
+	cachedResponse := plugin.GetCache()
+	assert.NotNil(t, cachedResponse)
+	assert.Equal(t, mockCache, cachedResponse)
 }

--- a/pkg/agent/resourcemanager/fetcher/manager.go
+++ b/pkg/agent/resourcemanager/fetcher/manager.go
@@ -141,7 +141,17 @@ func (m *ReporterPluginManager) registerInnerReporterPlugins(emitter metrics.Met
 			continue
 		}
 
-		curPlugin, err := initFn(emitter, metaServer, conf, callback)
+		var cache *v1alpha1.GetReportContentResponse
+		m.mutex.Lock()
+		// Try to get the cache from the stopped remote endpoint which was restored from the checkpoint.
+		// This prevents data omission during the initial reporting cycles if the agent restarts
+		// and the data hasn't fully ready yet.
+		if old, ok := m.endpoints[pluginName]; ok {
+			cache = old.GetCache()
+		}
+		m.mutex.Unlock()
+
+		curPlugin, err := initFn(emitter, metaServer, conf, callback, cache)
 		if err != nil {
 			errList = append(errList, err)
 			continue
@@ -411,15 +421,10 @@ func (m *ReporterPluginManager) getReportContent(cacheFirst bool) (map[string]*v
 }
 
 func (m *ReporterPluginManager) writeCheckpoint(reportResponses map[string]*v1alpha1.GetReportContentResponse) error {
-	remoteResponses := make(map[string]*v1alpha1.GetReportContentResponse, 0)
-	// only write remote endpoint response to checkpoint
-	for name, response := range reportResponses {
-		if m.innerEndpoints.Has(name) {
-			continue
-		}
-		remoteResponses[name] = response
-	}
-	data := checkpoint.New(remoteResponses)
+	// Write all endpoint responses to the checkpoint to persist their states.
+	// This enables both remote and inner plugins to restore their cached responses upon agent restart,
+	// preventing potential data omission during the initial reporting cycles before data is fully ready.
+	data := checkpoint.New(reportResponses)
 	err := m.checkpointManager.CreateCheckpoint(reporterManagerCheckpoint, data)
 	if err != nil {
 		_ = m.emitter.StoreInt64("reporter_plugin_checkpoint_write_failed", 1, metrics.MetricTypeNameCount)

--- a/pkg/agent/resourcemanager/fetcher/manager_test.go
+++ b/pkg/agent/resourcemanager/fetcher/manager_test.go
@@ -197,6 +197,61 @@ func TestHealthz(t *testing.T) {
 	_ = p.Stop()
 }
 
+func TestInnerPluginCheckpointing(t *testing.T) {
+	t.Parallel()
+
+	socketDir, err := tmpSocketDir()
+	require.NoError(t, err)
+	defer os.RemoveAll(socketDir)
+
+	testReporter := reporter.NewReporterManagerStub()
+	m, err := NewReporterPluginManager(testReporter, metrics.DummyMetrics{}, nil, generateTestConfiguration(socketDir))
+	require.NoError(t, err)
+
+	// Mock a response for an inner plugin
+	mockContent := []*v1alpha1.ReportContent{
+		{
+			GroupVersionKind: &testGroupVersionKind,
+			Field: []*v1alpha1.ReportField{
+				{
+					FieldType: v1alpha1.FieldType_Spec,
+					FieldName: "inner_plugin_field",
+					Value:     []byte("inner_plugin_value"),
+				},
+			},
+		},
+	}
+	mockResponse := &v1alpha1.GetReportContentResponse{Content: mockContent}
+
+	// Manually add it to the manager's endpoints to simulate a successful report
+	m.mutex.Lock()
+	m.innerEndpoints.Insert("system-reporter-plugin")
+	m.endpoints["system-reporter-plugin"] = plugin.NewStoppedRemoteEndpoint("system-reporter-plugin", mockResponse)
+	m.mutex.Unlock()
+
+	// Write checkpoint
+	err = m.writeCheckpoint(map[string]*v1alpha1.GetReportContentResponse{
+		"system-reporter-plugin": mockResponse,
+	})
+	require.NoError(t, err)
+
+	// Create a new manager to verify checkpoint reading
+	m2, err := NewReporterPluginManager(testReporter, metrics.DummyMetrics{}, nil, generateTestConfiguration(socketDir))
+	require.NoError(t, err)
+
+	// Verify that the inner plugin's endpoint was restored from the checkpoint
+	m2.mutex.Lock()
+	restoredEndpoint, ok := m2.endpoints["system-reporter-plugin"]
+	m2.mutex.Unlock()
+
+	require.True(t, ok)
+	require.NotNil(t, restoredEndpoint)
+
+	restoredCache := restoredEndpoint.GetCache()
+	require.NotNil(t, restoredCache)
+	reporterContentsEqual(t, mockContent, restoredCache.Content)
+}
+
 func setup(t *testing.T, ctx context.Context, content []*v1alpha1.ReportContent, callback plugin.ListAndWatchCallback, socketDir string, pluginSocketName string, reporter reporter.Manager) (registration.AgentPluginHandler, <-chan interface{}, skeleton.GenericPlugin) {
 	m, updateChan := setupReporterManager(t, ctx, content, socketDir, callback, reporter)
 	p := setupReporterPlugin(t, content, socketDir, pluginSocketName)

--- a/pkg/agent/resourcemanager/fetcher/plugin/plugin.go
+++ b/pkg/agent/resourcemanager/fetcher/plugin/plugin.go
@@ -33,7 +33,7 @@ const (
 	fakePluginName = "fake-reporter-plugin"
 )
 
-type InitFunc func(emitter metrics.MetricEmitter, _ *metaserver.MetaServer, conf *config.Configuration, callback ListAndWatchCallback) (ReporterPlugin, error)
+type InitFunc func(emitter metrics.MetricEmitter, _ *metaserver.MetaServer, conf *config.Configuration, callback ListAndWatchCallback, cache *v1alpha1.GetReportContentResponse) (ReporterPlugin, error)
 
 // ReporterPlugin performs report actions based on system or kubelet information.
 type ReporterPlugin interface {

--- a/pkg/agent/resourcemanager/fetcher/system/systemplugin.go
+++ b/pkg/agent/resourcemanager/fetcher/system/systemplugin.go
@@ -70,13 +70,14 @@ type systemPlugin struct {
 }
 
 func NewSystemReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer,
-	conf *config.Configuration, _ plugin.ListAndWatchCallback,
+	conf *config.Configuration, _ plugin.ListAndWatchCallback, cache *v1alpha1.GetReportContentResponse,
 ) (plugin.ReporterPlugin, error) {
 	p := &systemPlugin{
-		conf:        conf,
-		emitter:     emitter,
-		metaServer:  metaServer,
-		StopControl: process.NewStopControl(time.Time{}),
+		conf:                        conf,
+		emitter:                     emitter,
+		metaServer:                  metaServer,
+		latestReportContentResponse: cache, // initialize with the historical cache restored from checkpoint
+		StopControl:                 process.NewStopControl(time.Time{}),
 	}
 
 	return p, nil

--- a/pkg/agent/resourcemanager/fetcher/system/systemplugin_test.go
+++ b/pkg/agent/resourcemanager/fetcher/system/systemplugin_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	internalfake "github.com/kubewharf/katalyst-api/pkg/client/clientset/versioned/fake"
+	"github.com/kubewharf/katalyst-api/pkg/protocol/reporterplugin/v1alpha1"
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
 	"github.com/kubewharf/katalyst-core/pkg/client"
 	"github.com/kubewharf/katalyst-core/pkg/config"
@@ -37,6 +38,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util"
 )
 
 func generateTestConfiguration(t *testing.T) *config.Configuration {
@@ -64,10 +66,41 @@ func Test_systemPlugin_GetReportContent(t *testing.T) {
 	metricsFetcher.SetByStringIndex(consts.MetricCPUCodeName, "Intel_SkyLake")
 	metricsFetcher.SetByStringIndex(consts.MetricInfoIsVM, false)
 
-	plugin, err := NewSystemReporterPlugin(metrics.DummyMetrics{}, meta, conf, nil)
+	plugin, err := NewSystemReporterPlugin(metrics.DummyMetrics{}, meta, conf, nil, nil)
 	assert.NoError(t, err)
 
 	content, err := plugin.GetReportContent(context.Background())
 	assert.NoError(t, err)
 	assert.NotNil(t, content)
+}
+
+func Test_systemPlugin_WithCache(t *testing.T) {
+	t.Parallel()
+
+	genericClient := &client.GenericClientSet{
+		KubeClient:     fake.NewSimpleClientset(),
+		InternalClient: internalfake.NewSimpleClientset(),
+		DynamicClient:  dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+	}
+	conf := generateTestConfiguration(t)
+	meta, err := metaserver.NewMetaServer(genericClient, metrics.DummyMetrics{}, conf)
+	assert.NoError(t, err)
+
+	// mock a cache response
+	mockCache := &v1alpha1.GetReportContentResponse{
+		Content: []*v1alpha1.ReportContent{
+			{
+				GroupVersionKind: &util.CNRGroupVersionKind,
+			},
+		},
+	}
+
+	plugin, err := NewSystemReporterPlugin(metrics.DummyMetrics{}, meta, conf, nil, mockCache)
+	assert.NoError(t, err)
+	assert.NotNil(t, plugin)
+
+	// Verify that the cache is properly set during initialization
+	cachedResponse := plugin.GetCache()
+	assert.NotNil(t, cachedResponse)
+	assert.Equal(t, mockCache, cachedResponse)
 }


### PR DESCRIPTION

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Initialize inner plugins with cached responses from checkpoint to prevent data omission after restart. Modify checkpoint logic to persist both remote and inner plugin states. Add tests for cache initialization and checkpoint restoration.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
