### PR TITLE
refactor(irq-tuning): handle known failure of get GetNicQueue2Irq

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/consts.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/consts.go
@@ -28,7 +28,7 @@ const (
 const (
 	NewIrqTuningControllerFailed                            string = "NewIrqTuningControllerFailed"
 	InvalidDynamicConfig                                    string = "InvalidDynamicConfig"
-	SyncNicFailed                                           string = "SyncNicFailed"
+	ListHostActiveUplinkNicsFailed                          string = "ListHostActiveUplinkNicsFailed"
 	UpdateNicIrqTuningManagersFailed                        string = "UpdateNicIrqTuningManagersFailed"
 	SyncContainersFailed                                    string = "SyncContainersFailed"
 	TuneIrqAffinityForAllNicsWithBalanceFairPolicyFailed    string = "TuneIrqAffinityForAllNicsWithBalanceFairPolicyFailed"

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux.go
@@ -984,12 +984,24 @@ func (n *NicInfo) syncIrqAffinityFromKernel() error {
 func listHostActiveUplinkNics(netNSDir string) ([]*machine.NicBasicInfo, error) {
 	// names of container network namespaces (including those of SRIOV containers) are prefixed with "cni-",
 	// additionally, the NICs of SRIOV containers will be required during the periodic ListContainers process.
-	nics, err := machine.ListActiveUplinkNics(netNSDir, []string{machine.ContainerNetNSPrefix})
+	tmpNics, err := machine.ListActiveUplinkNics(netNSDir, []string{machine.ContainerNetNSPrefix})
 	if err != nil {
 		return nil, err
 	}
 
+	var nics []*machine.NicBasicInfo
+	for _, nic := range tmpNics {
+		if len(nic.Queue2Irq) == 0 {
+			general.Warningf("%s nic %s with driver %s has empty Queue2Irq", IrqTuningLogPrefix, nic, nic.Driver)
+			continue
+		}
+		nics = append(nics, nic)
+	}
+
 	if len(nics) == 0 {
+		if len(tmpNics) > 0 {
+			return nil, machine.ErrUnsupportedNicIrq2Queue
+		}
 		return nil, fmt.Errorf("no active uplink nics, it's impossible")
 	}
 
@@ -2260,6 +2272,9 @@ func (ic *IrqTuningController) syncNics() ([]*machine.NicBasicInfo, bool, error)
 
 	nics, err := listHostActiveUplinkNics(ic.agentConf.MachineInfoConfiguration.NetNSDirAbsPath)
 	if err != nil {
+		if err != machine.ErrUnsupportedNicIrq2Queue {
+			ic.emitErrMetric(irqtuner.ListHostActiveUplinkNicsFailed, irqtuner.IrqTuningFatal)
+		}
 		return nil, false, err
 	}
 	ic.LastNicSyncTime = time.Now()
@@ -5890,7 +5905,6 @@ func (ic *IrqTuningController) periodicTuning(oldConf *config.IrqTuningConfig) {
 		nics, nicsChanged, err = ic.syncNics()
 		if err != nil {
 			general.Errorf("%s failed to syncNics, err %v", IrqTuningLogPrefix, err)
-			ic.emitErrMetric(irqtuner.SyncNicFailed, irqtuner.IrqTuningFatal)
 			return
 		}
 	}

--- a/pkg/util/machine/network.go
+++ b/pkg/util/machine/network.go
@@ -45,6 +45,7 @@ const (
 	NicDriverVirtioNet = "virtio_net"
 	NicDriverI40E      = "i40e"
 	NicDriverIXGBE     = "ixgbe"
+	NicDriverGVE       = "gve"
 	NicDriverUnknown   = "unknownNicDriver"
 )
 

--- a/pkg/util/machine/network.go
+++ b/pkg/util/machine/network.go
@@ -39,15 +39,13 @@ const (
 	ContainerNetNSPrefix = "cni-"
 )
 
-type NicDriver string
-
 const (
-	NicDriverMLX       NicDriver = "mlx"
-	NicDriverBNX       NicDriver = "bnxt"
-	NicDriverVirtioNet NicDriver = "virtio_net"
-	NicDriverI40E      NicDriver = "i40e"
-	NicDriverIXGBE     NicDriver = "ixgbe"
-	NicDriverUnknown   NicDriver = "unknown"
+	NicDriverMLX       = "mlx"
+	NicDriverBNX       = "bnxt"
+	NicDriverVirtioNet = "virtio_net"
+	NicDriverI40E      = "i40e"
+	NicDriverIXGBE     = "ixgbe"
+	NicDriverUnknown   = "unknownNicDriver"
 )
 
 // ioctl constants from <linux/sockios.h>, <linux/ethtool.h>
@@ -146,7 +144,7 @@ type IfaceAddr struct {
 
 type NicBasicInfo struct {
 	InterfaceInfo
-	Driver         NicDriver // used to filter queue stats of ethtool stats, different driver has different format
+	Driver         string // used to filter queue stats of ethtool stats, different driver has different format
 	IsVirtioNetDev bool
 	VirtioNetName  string // used to filter virtio nic's irqs in /proc/interrupts
 	Irqs           []int  // store nic's all irqs including rx irqs, Irqs is used to resolve conflicts when there 2 active nics with the same name in /proc/interrupts

--- a/pkg/util/machine/network_linux.go
+++ b/pkg/util/machine/network_linux.go
@@ -94,6 +94,11 @@ var unsupportedQueue2IrqDrivers = []string{
 	"xsc",
 }
 
+const (
+	gveNicQueueFilter    = "gve-ntfy-blk"
+	gveNicQueueDelimeter = "@"
+)
+
 var ErrUnsupportedNicIrq2Queue = errors.New("unsupported nic irq to queue mapping")
 
 var netnsMutex sync.Mutex
@@ -555,6 +560,84 @@ func GetNicTxQueuesXpsConf(nic *NicBasicInfo) (map[int]string, error) {
 	return txQueuesXpsConf, nil
 }
 
+func getGVENicQueue2Irq(nicInfo *NicBasicInfo) (map[int]int, map[int]int, error) {
+	if len(nicInfo.Irqs) < nicInfo.QueueNum*2 {
+		return nil, nil, fmt.Errorf("%s total irqs count(%d) of all irqs %+v less than 2 * queueNum(%d)",
+			nicInfo, len(nicInfo.Irqs), nicInfo.Irqs, nicInfo.QueueNum)
+	}
+	nicAllIrqs := sets.NewInt(nicInfo.Irqs...)
+
+	b, err := os.ReadFile(InterruptsFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to ReadFile(%s), err %s", InterruptsFile, err)
+	}
+
+	lines := strings.Split(string(b), "\n")
+	queue2Irq := make(map[int]int)
+
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+
+		cols := strings.Fields(line)
+		if len(cols) == 0 {
+			continue
+		}
+
+		irq, err := strconv.Atoi(strings.TrimSuffix(cols[0], ":"))
+		if err != nil {
+			klog.Warningf("failed to parse irq number, err %s", err)
+			continue
+		}
+
+		if !nicAllIrqs.Has(irq) {
+			continue
+		}
+
+		queueStr := cols[len(cols)-1]
+		if !strings.Contains(queueStr, gveNicQueueFilter) {
+			continue
+		}
+
+		queueCols := strings.Split(queueStr, gveNicQueueDelimeter)
+		if len(queueCols) < 2 {
+			continue
+		}
+
+		queue, err := strconv.Atoi(strings.TrimPrefix(queueCols[0], gveNicQueueFilter))
+		if err != nil {
+			continue
+		}
+
+		queue2Irq[queue] = irq
+	}
+
+	if len(queue2Irq) < nicInfo.QueueNum*2 {
+		return nil, nil, fmt.Errorf("%s total count (%d) of tx/rx irqs %+v is not equal to 2 * queueNum(%d)",
+			nicInfo, len(queue2Irq), queue2Irq, nicInfo.QueueNum)
+	}
+
+	txQueue2Irq := make(map[int]int)
+	rxQueue2Irq := make(map[int]int)
+	firstRxQueueIndex := len(queue2Irq) / 2
+
+	for queue, irq := range queue2Irq {
+		// low half are tx queues, high half are rx queues,
+		// refer to gve_tx_idx_to_ntfy, gve_rx_idx_to_ntfy, gve_tx_add_to_block, gve_rx_add_to_block, gve_napi_poll functions
+		// from https://code.byted.org/data-system-ste/compute-virtual-ethernet-linux/tree/master/usr/src/gve-1.4.9+byted1
+		// and gve nic shrunk queues's irqs still exist in /proc/interrupts, e.g., when nic's queue number changed from 32 to 16,
+		// nic's original 32 queues's irqs still exist in /proc/interrupts
+		if queue < nicInfo.QueueNum {
+			txQueue2Irq[queue] = irq
+		} else if queue >= firstRxQueueIndex && queue < firstRxQueueIndex+nicInfo.QueueNum {
+			rxQueue2Irq[queue-firstRxQueueIndex] = irq
+		}
+	}
+
+	return rxQueue2Irq, txQueue2Irq, nil
+}
+
 func isUnsupportedNicQueue2Irq(nic *NicBasicInfo) bool {
 	if nic == nil {
 		return false
@@ -712,6 +795,10 @@ func GetNicQueue2IrqWithQueueFilter(nicInfo *NicBasicInfo, queueFilters []string
 
 // GetNicQueue2Irq get nic queue naming in /proc/interrrupts
 func GetNicQueue2Irq(nicInfo *NicBasicInfo) (map[int]int, map[int]int, error) {
+	if strings.HasPrefix(nicInfo.Driver, NicDriverGVE) {
+		return getGVENicQueue2Irq(nicInfo)
+	}
+
 	if nicInfo.IsVirtioNetDev {
 		queueFilter := fmt.Sprintf("%s-input", nicInfo.VirtioNetName)
 		queueDelimeter := "."
@@ -910,6 +997,9 @@ func GetNicQueuesCount(nicName string) (int, error) {
 		return -1, fmt.Errorf("ioctl SIOCETHTOOL failed: %v", errno)
 	}
 
+	if ec.CombinedCount == 0 {
+		return int(ec.RxCount), nil
+	}
 	return int(ec.CombinedCount), nil
 }
 

--- a/pkg/util/machine/network_linux.go
+++ b/pkg/util/machine/network_linux.go
@@ -20,6 +20,7 @@ limitations under the License.
 package machine
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -86,6 +87,14 @@ const (
 	SoftnetStatFile    = "/proc/net/softnet_stat"
 	SoftIrqsFile       = "/proc/softirqs"
 )
+
+var unsupportedQueue2IrqDrivers = []string{
+	"mlx5_core.sf",
+	"bytenic",
+	"xsc",
+}
+
+var ErrUnsupportedNicIrq2Queue = errors.New("unsupported nic irq to queue mapping")
 
 var netnsMutex sync.Mutex
 
@@ -546,6 +555,19 @@ func GetNicTxQueuesXpsConf(nic *NicBasicInfo) (map[int]string, error) {
 	return txQueuesXpsConf, nil
 }
 
+func isUnsupportedNicQueue2Irq(nic *NicBasicInfo) bool {
+	if nic == nil {
+		return false
+	}
+
+	for _, drv := range unsupportedQueue2IrqDrivers {
+		if strings.HasPrefix(nic.Driver, drv) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetNicQueue2IrqWithQueueFilter get the queue to irq map with queue filter
 // the "same" queue may match multiple irqs, e.g., nics with the same name from different netns and sriov vfs
 // queueFilters can not be empty.
@@ -761,6 +783,10 @@ func GetNicQueue2Irq(nicInfo *NicBasicInfo) (map[int]int, map[int]int, error) {
 		}
 	}
 
+	if isUnsupportedNicQueue2Irq(nicInfo) {
+		return nil, nil, ErrUnsupportedNicIrq2Queue
+	}
+
 	return nil, nil, fmt.Errorf("failed to find matched queue in %s for %d: %s", InterruptsFile, nicInfo.IfIndex, nicInfo.Name)
 }
 
@@ -826,32 +852,15 @@ func TidyUpNicIrqsAffinityCPUs(irq2CPUs map[int][]int64) (map[int]int64, error) 
 	return irq2CPU, nil
 }
 
-func getNicDriver(nicSysPath string) (NicDriver, error) {
+func getNicDriver(nicSysPath string) (string, error) {
 	linkPath := filepath.Join(nicSysPath, "device/driver")
 
 	target, err := os.Readlink(linkPath)
 	if err != nil {
-		return NicDriverUnknown, fmt.Errorf("failed to read symlink for %s: err %v", linkPath, err)
+		return "", fmt.Errorf("failed to read symlink for %s: err %v", linkPath, err)
 	}
 
-	driverName := filepath.Base(target)
-
-	var driver NicDriver
-	if strings.HasPrefix(driverName, string(NicDriverMLX)) {
-		driver = NicDriverMLX
-	} else if strings.HasPrefix(driverName, string(NicDriverBNX)) {
-		driver = NicDriverBNX
-	} else if strings.HasPrefix(driverName, string(NicDriverVirtioNet)) {
-		driver = NicDriverVirtioNet
-	} else if strings.HasPrefix(driverName, string(NicDriverI40E)) {
-		driver = NicDriverI40E
-	} else if strings.HasPrefix(driverName, string(NicDriverIXGBE)) {
-		driver = NicDriverIXGBE
-	} else {
-		driver = NicDriverUnknown
-	}
-
-	return driver, nil
+	return filepath.Base(target), nil
 }
 
 // GetNicIrqs get nic's all irqs, including rx-tx irqs, and some irqs used for control
@@ -1480,7 +1489,12 @@ func ListActiveUplinkNics(netNSDir string, ignoredNetNSNamePrefixes []string) ([
 		for _, n := range netnsNics {
 			queue2Irq, txQueue2Irq, err := GetNicQueue2Irq(n)
 			if err != nil {
-				return nil, fmt.Errorf("failed to GetNicQueue2Irq for %d: %s, err %v", n.IfIndex, n.Name, err)
+				if err != ErrUnsupportedNicIrq2Queue {
+					return nil, fmt.Errorf("failed to GetNicQueue2Irq for %d: %s, err %v", n.IfIndex, n.Name, err)
+				}
+
+				queue2Irq = make(map[int]int)
+				txQueue2Irq = make(map[int]int)
 			}
 
 			irq2Queue := make(map[int]int)
@@ -1537,9 +1551,13 @@ func GetNetDevRxPackets(nic *NicBasicInfo) (uint64, error) {
 
 func GetNicRxQueuePackets(nic *NicBasicInfo) (map[int]uint64, error) {
 	driver := nic.Driver
-	if driver != NicDriverMLX && driver != NicDriverBNX && driver != NicDriverVirtioNet &&
-		driver != NicDriverI40E && driver != NicDriverIXGBE {
-		return nil, fmt.Errorf("unknow driver: %s", driver)
+
+	if !strings.HasPrefix(driver, NicDriverMLX) &&
+		!strings.HasPrefix(driver, NicDriverBNX) &&
+		!strings.HasPrefix(driver, NicDriverVirtioNet) &&
+		!strings.HasPrefix(driver, NicDriverI40E) &&
+		!strings.HasPrefix(driver, NicDriverIXGBE) {
+		return nil, fmt.Errorf("unsupported driver: %s", driver)
 	}
 
 	nsc, err := netnsEnter(nic.NetNSInfo)
@@ -1567,7 +1585,7 @@ func GetNicRxQueuePackets(nic *NicBasicInfo) (map[int]uint64, error) {
 		var queueStr string
 		key = strings.TrimSpace(key)
 
-		if driver == NicDriverMLX {
+		if strings.HasPrefix(driver, NicDriverMLX) {
 			// mlx nic rx queue packets key:val format
 			// key: rx60_packets
 			// val: 89462756888
@@ -1580,7 +1598,7 @@ func GetNicRxQueuePackets(nic *NicBasicInfo) (map[int]uint64, error) {
 			}
 
 			queueStr = strings.TrimSuffix(strings.TrimPrefix(key, "rx"), "_packets")
-		} else if driver == NicDriverBNX {
+		} else if strings.HasPrefix(driver, NicDriverBNX) {
 			// bnxt nic rx queue packets key:val format
 			// key: [6]: rx_ucast_packets
 			// val: 8304
@@ -1594,7 +1612,7 @@ func GetNicRxQueuePackets(nic *NicBasicInfo) (map[int]uint64, error) {
 			}
 
 			queueStr = strings.TrimSuffix(strings.TrimPrefix(cols[0], "["), "]:")
-		} else if driver == NicDriverVirtioNet {
+		} else if strings.HasPrefix(driver, NicDriverVirtioNet) {
 			// virtio_net nic rx queue packets key:val format
 			// key: rx_queue_6_packets
 			// val: 51991567584
@@ -1607,7 +1625,7 @@ func GetNicRxQueuePackets(nic *NicBasicInfo) (map[int]uint64, error) {
 			}
 
 			queueStr = strings.TrimSuffix(strings.TrimPrefix(key, "rx_queue_"), "_packets")
-		} else if driver == NicDriverI40E {
+		} else if strings.HasPrefix(driver, NicDriverI40E) {
 			// i40e nic rx queue packets key:val format
 			// key: rx-39.packets
 			// val: 2769830722
@@ -1620,7 +1638,7 @@ func GetNicRxQueuePackets(nic *NicBasicInfo) (map[int]uint64, error) {
 			}
 
 			queueStr = strings.TrimSuffix(strings.TrimPrefix(key, "rx-"), ".packets")
-		} else if driver == NicDriverIXGBE {
+		} else if strings.HasPrefix(driver, NicDriverIXGBE) {
 			// ixgbe nic rx queue packets key:val format
 			// key: rx_queue_19_packets
 			// val: 3994706599

--- a/pkg/util/machine/network_linux_test.go
+++ b/pkg/util/machine/network_linux_test.go
@@ -1966,7 +1966,7 @@ func Test_getNicDriver(t *testing.T) {
 
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "failed to read symlink")
-			So(driver, ShouldEqual, NicDriverUnknown)
+			So(driver, ShouldEqual, "")
 		})
 
 		PatchConvey("Scenario 2: When the driver is of type MLX, the NicDriverMLX should be returned correctly", func() {
@@ -1975,7 +1975,7 @@ func Test_getNicDriver(t *testing.T) {
 			driver, err := getNicDriver(dummyNicSysPath)
 
 			So(err, ShouldBeNil)
-			So(driver, ShouldEqual, NicDriverMLX)
+			So(driver, ShouldEqual, "mlx5_core")
 		})
 
 		PatchConvey("Scenario 3: When the driver is BNX type, NicDriverBNX should be returned correctly", func() {
@@ -1984,7 +1984,7 @@ func Test_getNicDriver(t *testing.T) {
 			driver, err := getNicDriver(dummyNicSysPath)
 
 			So(err, ShouldBeNil)
-			So(driver, ShouldEqual, NicDriverBNX)
+			So(driver, ShouldEqual, "bnxt_en")
 		})
 
 		PatchConvey("Scenario 4: When the driver is of type VirtioNet, NicDriverVirtioNet should be returned correctly", func() {
@@ -1993,7 +1993,7 @@ func Test_getNicDriver(t *testing.T) {
 			driver, err := getNicDriver(dummyNicSysPath)
 
 			So(err, ShouldBeNil)
-			So(driver, ShouldEqual, NicDriverVirtioNet)
+			So(driver, ShouldEqual, "virtio_net")
 		})
 
 		PatchConvey("Scenario 5: When the driver is of type I40E, the NicDriverI40E should be returned correctly", func() {
@@ -2002,7 +2002,7 @@ func Test_getNicDriver(t *testing.T) {
 			driver, err := getNicDriver(dummyNicSysPath)
 
 			So(err, ShouldBeNil)
-			So(driver, ShouldEqual, NicDriverI40E)
+			So(driver, ShouldEqual, "i40e")
 		})
 
 		PatchConvey("Scenario 6: When the driver is of type IXGBE, NicDriverIXGBE should be returned correctly", func() {
@@ -2011,7 +2011,7 @@ func Test_getNicDriver(t *testing.T) {
 			driver, err := getNicDriver(dummyNicSysPath)
 
 			So(err, ShouldBeNil)
-			So(driver, ShouldEqual, NicDriverIXGBE)
+			So(driver, ShouldEqual, "ixgbe")
 		})
 
 		PatchConvey("Scenario 7: When the driver is of an unrecognized type, an unknown driver should be returned", func() {
@@ -2020,7 +2020,7 @@ func Test_getNicDriver(t *testing.T) {
 			driver, err := getNicDriver(dummyNicSysPath)
 
 			So(err, ShouldBeNil)
-			So(driver, ShouldEqual, NicDriverUnknown)
+			So(driver, ShouldEqual, "some_other_driver")
 		})
 	})
 }
@@ -3018,7 +3018,7 @@ func Test_ListInterfacesWithIPAddr(t *testing.T) {
 	})
 }
 
-func newTestNicBasicInfo(driver NicDriver) *NicBasicInfo {
+func newTestNicBasicInfo(driver string) *NicBasicInfo {
 	return &NicBasicInfo{
 		InterfaceInfo: InterfaceInfo{
 			NetNSInfo: NetNSInfo{
@@ -3040,12 +3040,12 @@ func Test_GetNicRxQueuePackets(t *testing.T) {
 		errEthtoolStats := errors.New("ethtool stats failed")
 
 		PatchConvey("When the driver type is not supported", func() {
-			nic := newTestNicBasicInfo(NicDriverUnknown)
+			nic := newTestNicBasicInfo("xxx")
 
 			result, err := GetNicRxQueuePackets(nic)
 
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, fmt.Sprintf("unknow driver: %s", NicDriverUnknown))
+			So(err, ShouldResemble, fmt.Errorf("unsupported driver: xxx"))
 			So(result, ShouldBeNil)
 		})
 
@@ -3089,7 +3089,7 @@ func Test_GetNicRxQueuePackets(t *testing.T) {
 		})
 
 		driverTestCases := []struct {
-			driver      NicDriver
+			driver      string
 			stats       map[string]uint64
 			expected    map[int]uint64
 			description string

--- a/pkg/util/machine/network_linux_test.go
+++ b/pkg/util/machine/network_linux_test.go
@@ -1495,6 +1495,97 @@ func TestGetNicTxQueuesXpsConf(t *testing.T) {
 	})
 }
 
+func Test_getGVENicQueue2Irq(t *testing.T) {
+	nicInfo := &NicBasicInfo{
+		InterfaceInfo: InterfaceInfo{
+			Name:    "eth0",
+			IfIndex: 1,
+			PCIAddr: "0000:01:00.0",
+		},
+		Irqs:     []int{100, 101, 102, 103, 104, 105, 106},
+		QueueNum: 3,
+	}
+
+	PatchConvey("Test getGVENicQueue2Irq", t, func() {
+		PatchConvey("Scenario 1: NIC total irqs count of less than 2 * queueNum", func() {
+			nicInfo.QueueNum = 4
+			rxQueue2Irq, txQueue2Irq, err := getGVENicQueue2Irq(nicInfo)
+
+			So(rxQueue2Irq, ShouldBeNil)
+			So(txQueue2Irq, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			expectedErrMsg := fmt.Sprintf("%s total irqs count(%d) of all irqs %+v less than 2 * queueNum(%d)",
+				nicInfo, len(nicInfo.Irqs), nicInfo.Irqs, nicInfo.QueueNum)
+			So(err.Error(), ShouldEqual, expectedErrMsg)
+		})
+
+		PatchConvey("Scenario 2: Failed to read the interrupts file", func() {
+			nicInfo.QueueNum = 3
+			mockErr := errors.New("read file error")
+			Mock(os.ReadFile).Return(nil, mockErr).Build()
+
+			rxQueue2Irq, txQueue2Irq, err := getGVENicQueue2Irq(nicInfo)
+
+			So(rxQueue2Irq, ShouldBeNil)
+			So(txQueue2Irq, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, fmt.Sprintf("failed to ReadFile(%s), err %s", InterruptsFile, mockErr))
+		})
+
+		PatchConvey("Scenario 3: GVE NIC queue and IRQ mapping are successfully obtained", func() {
+			nicInfo.QueueNum = 3
+			interruptsContent := `
+			           CPU0       CPU1
+			100:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk0@pci:0000:01:00.0
+			101:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk1@pci:0000:01:00.0
+			102:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk2@pci:0000:01:00.0
+			103:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk3@pci:0000:01:00.0
+			104:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk4@pci:0000:01:00.0
+			105:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk5@pci:0000:01:00.0
+			106:        10         30    IR-PCI-MSI-edge   gve-mgmnt@pci:0000:01:00.0
+			107:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk@
+			108:        100        200   IR-PCI-MSI-edge   gve-ntfy-blkkkk@pci:0000:01:00.0
+			109:        500        600   IR-PCI-MSI-edge   other-device
+			`
+			Mock(os.ReadFile).Return([]byte(interruptsContent), nil).Build()
+
+			rxQueue2Irq, txQueue2Irq, err := getGVENicQueue2Irq(nicInfo)
+
+			So(err, ShouldBeNil)
+			So(rxQueue2Irq, ShouldNotBeNil)
+			So(txQueue2Irq, ShouldNotBeNil)
+			expectedRxQueue2Irq := map[int]int{0: 103, 1: 104, 2: 105}
+			So(rxQueue2Irq, ShouldResemble, expectedRxQueue2Irq)
+			expectedTxQueue2Irq := map[int]int{0: 100, 1: 101, 2: 102}
+			So(txQueue2Irq, ShouldResemble, expectedTxQueue2Irq)
+		})
+
+		PatchConvey("Scenario 4: NIC total count of tx/rx irq is not equal to 2 * queueNum", func() {
+			nicInfo.QueueNum = 3
+			interruptsContent := `
+			           CPU0       CPU1
+			100:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk0@pci:0000:01:00.0
+			101:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk1@pci:0000:01:00.0
+			102:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk2@pci:0000:01:00.0
+			103:        100        200   IR-PCI-MSI-edge   gve-ntfy-blk3@pci:0000:01:00.0
+			104:        10         30    IR-PCI-MSI-edge   gve-mgmnt@pci:0000:01:00.0
+			105:        500        600   IR-PCI-MSI-edge   other-device
+			`
+			Mock(os.ReadFile).Return([]byte(interruptsContent), nil).Build()
+
+			rxQueue2Irq, txQueue2Irq, err := getGVENicQueue2Irq(nicInfo)
+
+			So(rxQueue2Irq, ShouldBeNil)
+			So(txQueue2Irq, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+			queue2Irq := map[int]int{0: 100, 1: 101, 2: 102, 3: 103}
+			expectedErrMsg := fmt.Sprintf("%s total count (%d) of tx/rx irqs %+v is not equal to 2 * queueNum(%d)",
+				nicInfo, len(queue2Irq), queue2Irq, nicInfo.QueueNum)
+			So(err.Error(), ShouldEqual, expectedErrMsg)
+		})
+	})
+}
+
 func Test_GetNicQueue2IrqWithQueueFilter(t *testing.T) {
 	nicInfo := &NicBasicInfo{
 		InterfaceInfo: InterfaceInfo{
@@ -1625,7 +1716,32 @@ func Test_GetNicQueue2IrqWithQueueFilter(t *testing.T) {
 
 func Test_GetNicQueue2Irq(t *testing.T) {
 	PatchConvey("Test GetNicQueue2Irq", t, func() {
-		PatchConvey("Scenario 1: Virtio network card", func() {
+		PatchConvey("Scenario 1: GVE NIC", func() {
+			nicInfo := &NicBasicInfo{
+				InterfaceInfo: InterfaceInfo{
+					IfIndex: 1,
+					Name:    "eth0",
+				},
+				QueueNum: 2,
+				Driver:   NicDriverGVE,
+			}
+
+			PatchConvey("Successfully get GVE NIC rx/tx queue2irq mapping", func() {
+				mockTxQueue2Irq := map[int]int{0: 100, 1: 101}
+				mockRxQueue2Irq := map[int]int{0: 102, 1: 103}
+				Mock(getGVENicQueue2Irq).To(func(_ *NicBasicInfo) (map[int]int, map[int]int, error) {
+					return mockRxQueue2Irq, mockTxQueue2Irq, nil
+				}).Build()
+
+				rxQueue2Irq, txQueue2Irq, err := GetNicQueue2Irq(nicInfo)
+
+				So(err, ShouldBeNil)
+				So(rxQueue2Irq, ShouldResemble, mockRxQueue2Irq)
+				So(txQueue2Irq, ShouldResemble, mockTxQueue2Irq)
+			})
+		})
+
+		PatchConvey("Scenario 2: Virtio network card", func() {
 			nicInfo := &NicBasicInfo{
 				IsVirtioNetDev: true,
 				VirtioNetName:  "virtio-net-p0",
@@ -1705,7 +1821,7 @@ func Test_GetNicQueue2Irq(t *testing.T) {
 			})
 		})
 
-		PatchConvey("Scenario 2: Non-Virtio NICs", func() {
+		PatchConvey("Scenario 3: Other NICs", func() {
 			nicInfo := &NicBasicInfo{
 				IsVirtioNetDev: false,
 				InterfaceInfo: InterfaceInfo{

--- a/pkg/util/machine/sriov_linux.go
+++ b/pkg/util/machine/sriov_linux.go
@@ -155,7 +155,7 @@ func isSriovPf(sysFsDir string, ifName string) bool {
 // detectSriovPFDriver returns the sriov supported driver name of PF.
 // We use ethtool as the standard way to get the driver name, other than reading file or link under /sys because
 // it might have different behaviors between nic vendors.
-func detectSriovPFDriver(ifName string) (NicDriver, error) {
+func detectSriovPFDriver(ifName string) (string, error) {
 	driverName, err := ethtool.DriverName(ifName)
 	if err != nil {
 		return NicDriverUnknown, fmt.Errorf("failed to get driver name, err %w", err)


### PR DESCRIPTION
handle known failure of get GetNicQueue2Irq

#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
fix nic queue<->irq mapping
