### PR TITLE
fix: escape notifier key in pod metric syncer logs

### DIFF
--- a/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/pod.go
+++ b/pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod/pod.go
@@ -183,7 +183,7 @@ func (p *MetricSyncerPod) syncChanel() {
 					MetricName:    rawMetricName,
 				}, rChan)
 
-				klog.Infof("register raw pod metric: %v for pod/container: %v/%v, key %v",
+				klog.Infof("register raw pod metric: %v for pod/container: %v/%v, key %q",
 					rawMetricName, podList[i].Name, container.Name, key)
 				keys = append(keys, key)
 			}
@@ -202,7 +202,7 @@ func (p *MetricSyncerPod) syncChanel() {
 		}
 
 		for _, key := range pChanel.keys {
-			klog.Infof("deregister, key %v", key)
+			klog.Infof("deregister, key %q", key)
 			p.metaServer.MetricsFetcher.DeRegisterNotifier(metrictypes.MetricsScopeContainer, key)
 		}
 		close(pChanel.rChan)


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
This PR fixes garbled startup logs caused by logging raw notifier keys in pod metric syncer.

In `MetricSyncerPod.syncChanel()`, the notifier key returned by `RegisterNotifier()` was logged with `%v`:

```go
klog.Infof("register raw pod metric: %v for pod/container: %v/%v, key %v",
    rawMetricName, podList[i].Name, container.Name, key)
```

However, the notifier key is not a human-readable text token. It is generated from random raw bytes and then converted into a Go string.  
Logging it with `%v` writes the raw bytes directly into stdout/stderr, which may introduce non-printable / invalid UTF-8 bytes into the container logs.

This can lead to:
- garbled log output during agent startup
- `grep` treating the log stream as binary and printing:
  - `Binary file (standard input) matches`

This PR changes the log formatting from `%v` to `%q` for both register and deregister paths, so the key is escaped before being written to logs.

#### Which issue(s) this PR fixes:
N/A

#### Special notes for your reviewer:
I reproduced this issue on a restarted `katalyst-agent` pod.

Observed symptoms:
- startup logs contain garbled characters in lines like:
  - `register raw pod metric: ... key ...`
- `kubectl logs ... | grep "headroom"` may end with:
  - `Binary file (standard input) matches`

Root cause confirmation:
- notifier keys are generated from random bytes in `MetricsNotifierManagerImpl.RegisterNotifier()`
- `%v` on a Go string writes the raw string bytes directly
- `%q` escapes non-printable bytes and avoids polluting the log stream

A minimal Go example that demonstrates the difference between `%v` and `%q`:

```go
package main

import "fmt"

func main() {
    s := string([]byte{0x61, 0x1b, 0x84, 0x62})
    fmt.Printf("%v\n", s)
    fmt.Printf("%q\n", s)
}
```

Output:
- `%v` prints raw bytes and may look garbled
- `%q` prints escaped content such as `"a\x1b\x84b"`

Validation:
```bash
go test ./pkg/agent/sysadvisor/plugin/metric-emitter/syncer/pod
```

Attached screenshots show:
- the garbled startup log
- the `Binary file (standard input) matches` symptom
- the `%v` vs `%q` behavior in a minimal Go example
![20260414-161614](https://github.com/user-attachments/assets/387ca704-c5f4-498a-9c27-561e47e31f6c)
![20260414-161625](https://github.com/user-attachments/assets/b12e87b0-dd44-42f5-baf7-751ed0f8ae01)
<img width="472" height="405" alt="Snipaste_2026-04-14_16-17-42" src="https://github.com/user-attachments/assets/08fae1a1-5f05-483c-896e-cf979f6ac05d" />
