### PR TITLE
fix(vpa-status): skip inactive pods when checking recommendation applied

### DIFF
--- a/pkg/controller/vpa/util/api.go
+++ b/pkg/controller/vpa/util/api.go
@@ -42,6 +42,8 @@ const (
 	VPAConditionReasonCalculatedIllegal = "Illegal"
 	VPAConditionReasonPodSpecUpdated    = "PodSpecUpdated"
 	VPAConditionReasonPodSpecNoUpdate   = "PodSpecNoUpdate"
+	VPAConditionReasonNoPodsMatched     = "NoPodsMatched"
+	VPAConditionReasonPodsMatched       = "PodsMatched"
 )
 
 // SetVPAConditions is used to set conditions for vpa in local vpa

--- a/pkg/controller/vpa/vpa.go
+++ b/pkg/controller/vpa/vpa.go
@@ -371,12 +371,18 @@ func (vc *VPAController) syncVPA(key string) error {
 	workloadLister, ok := vc.workloadLister[gvk]
 	if !ok {
 		klog.Errorf("[vpa] vpa %s/%s without workload lister %v", namespace, name, gvk)
+		// Set NoPodsMatched to True when the targetRef kind is unsupported
+		_ = util.UpdateVPAConditions(vc.ctx, vc.vpaUpdater, vpa, apis.NoPodsMatched, core.ConditionTrue, util.VPAConditionReasonNoPodsMatched, fmt.Sprintf("Unsupported targetRef kind: %v", gvk))
 		return nil
 	}
 
 	workloadObj, err := katalystutil.GetWorkloadForVPA(vpa, workloadLister)
 	if err != nil {
 		klog.Errorf("[vpa] vpa %s/%s get workload error: %v", namespace, name, err)
+		if errors.IsNotFound(err) {
+			// Set NoPodsMatched to True when the workload object cannot be found
+			_ = util.UpdateVPAConditions(vc.ctx, vc.vpaUpdater, vpa, apis.NoPodsMatched, core.ConditionTrue, util.VPAConditionReasonNoPodsMatched, fmt.Sprintf("TargetRef workload not found: %s %s", gvk.Kind, vpa.Spec.TargetRef.Name))
+		}
 		return err
 	}
 
@@ -408,8 +414,25 @@ func (vc *VPAController) syncVPA(key string) error {
 	if err != nil {
 		klog.Errorf("[vpa] failed to get pods by vpa %s, err %v", vpa.Name, err)
 		_ = util.UpdateVPAConditions(vc.ctx, vc.vpaUpdater, vpa, apis.RecommendationUpdated, core.ConditionFalse, util.VPAConditionReasonCalculatedIllegal, "failed to find pods")
+		if errors.IsNotFound(err) {
+			// Set NoPodsMatched to True when the workload object cannot be found during pod list retrieval
+			_ = util.UpdateVPAConditions(vc.ctx, vc.vpaUpdater, vpa, apis.NoPodsMatched, core.ConditionTrue, util.VPAConditionReasonNoPodsMatched, fmt.Sprintf("TargetRef workload not found: %s %s", gvk.Kind, vpa.Spec.TargetRef.Name))
+		}
 		return err
 	}
+
+	if len(pods) == 0 {
+		message := "No pods match this VPA object"
+		if selector, err := native.GetUnstructuredSelector(workload); err == nil && selector != nil {
+			message = fmt.Sprintf("No pods match this VPA object, label selector: %s", selector.String())
+		}
+		// Set NoPodsMatched to True when no pods match the targetRef workload
+		_ = util.UpdateVPAConditions(vc.ctx, vc.vpaUpdater, vpa, apis.NoPodsMatched, core.ConditionTrue, util.VPAConditionReasonNoPodsMatched, message)
+	} else {
+		// Set NoPodsMatched to False when there are pods matching the targetRef workload
+		_ = util.UpdateVPAConditions(vc.ctx, vc.vpaUpdater, vpa, apis.NoPodsMatched, core.ConditionFalse, util.VPAConditionReasonPodsMatched, "Pods match this VPA object")
+	}
+
 	klog.V(4).Infof("[vpa] syncing vpa %s with %d pods", name, len(pods))
 	_ = vc.metricsEmitter.StoreInt64(metricNameVAPControlVPAPodCount, int64(len(pods)), metrics.MetricTypeNameRaw, tags...)
 

--- a/pkg/controller/vpa/vpa_status.go
+++ b/pkg/controller/vpa/vpa_status.go
@@ -325,7 +325,14 @@ func (vs *vpaStatusController) syncVPA(key string) error {
 // are updated to the expected resources in their annotations
 func (vs *vpaStatusController) setRecommendationAppliedCondition(vpa *apis.KatalystVerticalPodAutoscaler, pods []*v1.Pod) error {
 	failedCount := 0
+	activePodCount := 0
 	for _, pod := range pods {
+		if !native.PodIsActive(pod) {
+			klog.V(6).Infof("[vpa-status] pod %s is not active, skip", native.GenerateUniqObjectNameKey(pod))
+			continue
+		}
+
+		activePodCount += 1
 		if !katalystutil.CheckPodSpecUpdated(pod) {
 			failedCount += 1
 		}
@@ -337,7 +344,7 @@ func (vs *vpaStatusController) setRecommendationAppliedCondition(vpa *apis.Katal
 			return err
 		}
 	} else {
-		msg := fmt.Sprintf("failed to update %d pods, total %d pods", failedCount, len(pods))
+		msg := fmt.Sprintf("failed to update %d pods, active %d pods, total %d pods", failedCount, activePodCount, len(pods))
 		err := util.SetVPAConditions(vpa, apis.RecommendationApplied, v1.ConditionFalse, util.VPAConditionReasonPodSpecNoUpdate, msg)
 		if err != nil {
 			return err

--- a/pkg/controller/vpa/vpa_status_test.go
+++ b/pkg/controller/vpa/vpa_status_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apis "github.com/kubewharf/katalyst-api/pkg/apis/autoscaling/v1alpha1"
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/controller/vpa/util"
+)
+
+func TestSetRecommendationAppliedCondition(t *testing.T) {
+	t.Parallel()
+	vs := &vpaStatusController{}
+
+	for _, tc := range []struct {
+		name            string
+		pods            []*v1.Pod
+		expectedStatus  v1.ConditionStatus
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name: "all pods updated",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+			},
+			expectedStatus:  v1.ConditionTrue,
+			expectedReason:  util.VPAConditionReasonPodSpecUpdated,
+			expectedMessage: "",
+		},
+		{
+			name: "skip inactive pods",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// This pod is not updated, but it is inactive so it should be skipped
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodSucceeded,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+			},
+			expectedStatus:  v1.ConditionTrue,
+			expectedReason:  util.VPAConditionReasonPodSpecUpdated,
+			expectedMessage: "",
+		},
+		{
+			name: "failed to update pods with inactive ones",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										// Different from annotation to make CheckPodSpecUpdated return false
+									},
+								},
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{},
+								},
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodFailed,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+						DeletionTimestamp: &metav1.Time{},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{},
+								},
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedStatus:  v1.ConditionFalse,
+			expectedReason:  util.VPAConditionReasonPodSpecNoUpdate,
+			expectedMessage: "failed to update 1 pods, active 1 pods, total 3 pods",
+		},
+		{
+			name: "all active pods failed to update",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										// Different from annotation to make CheckPodSpecUpdated return false
+									},
+								},
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationInplaceUpdateResourcesKey: `{"c1":{"requests":{"cpu":"1","memory":"1Gi"}}}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "c1",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										// Different from annotation to make CheckPodSpecUpdated return false
+									},
+								},
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+					},
+				},
+			},
+			expectedStatus:  v1.ConditionFalse,
+			expectedReason:  util.VPAConditionReasonPodSpecNoUpdate,
+			expectedMessage: "failed to update 2 pods, active 2 pods, total 2 pods",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vpa := &apis.KatalystVerticalPodAutoscaler{
+				Status: apis.KatalystVerticalPodAutoscalerStatus{},
+			}
+
+			err := vs.setRecommendationAppliedCondition(vpa, tc.pods)
+			assert.NoError(t, err)
+
+			assert.Len(t, vpa.Status.Conditions, 1)
+			assert.Equal(t, tc.expectedStatus, vpa.Status.Conditions[0].Status)
+			assert.Equal(t, tc.expectedReason, vpa.Status.Conditions[0].Reason)
+			assert.Equal(t, tc.expectedMessage, vpa.Status.Conditions[0].Message)
+			assert.Equal(t, apis.RecommendationApplied, vpa.Status.Conditions[0].Type)
+		})
+	}
+}

--- a/pkg/controller/vpa/vpa_test.go
+++ b/pkg/controller/vpa/vpa_test.go
@@ -132,6 +132,12 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 					Status: v1.ConditionTrue,
 					Reason: util.VPAConditionReasonUpdated,
 				},
+				{
+					Type:    apis.NoPodsMatched,
+					Status:  v1.ConditionFalse,
+					Reason:  util.VPAConditionReasonPodsMatched,
+					Message: "Pods match this VPA object",
+				},
 			},
 		},
 	}
@@ -186,6 +192,12 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 					Status: v1.ConditionTrue,
 					Reason: util.VPAConditionReasonUpdated,
 				},
+				{
+					Type:    apis.NoPodsMatched,
+					Status:  v1.ConditionFalse,
+					Reason:  util.VPAConditionReasonPodsMatched,
+					Message: "Pods match this VPA object",
+				},
 			},
 		},
 	}
@@ -230,11 +242,50 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 					Status: v1.ConditionTrue,
 					Reason: util.VPAConditionReasonUpdated,
 				},
+				{
+					Type:    apis.NoPodsMatched,
+					Status:  v1.ConditionFalse,
+					Reason:  util.VPAConditionReasonPodsMatched,
+					Message: "Pods match this VPA object",
+				},
 			},
 		},
 	}
 
 	newPod3 := pod1.DeepCopy()
+
+	vpa4 := vpa3.DeepCopy()
+	vpaNew4 := vpaNew3.DeepCopy()
+	vpaNew4.Status.Conditions = []apis.VerticalPodAutoscalerCondition{
+		{
+			Type:   apis.RecommendationUpdated,
+			Status: v1.ConditionTrue,
+			Reason: util.VPAConditionReasonUpdated,
+		},
+		{
+			Type:    apis.NoPodsMatched,
+			Status:  v1.ConditionTrue,
+			Reason:  util.VPAConditionReasonNoPodsMatched,
+			Message: "No pods match this VPA object, label selector: workload=sts1",
+		},
+	}
+
+	vpa5 := vpa3.DeepCopy()
+	vpa5.Spec.TargetRef.Name = "sts2"
+	vpaNew5 := vpa5.DeepCopy()
+	vpaNew5.Status.Conditions = []apis.VerticalPodAutoscalerCondition{
+		{
+			Type:   apis.RecommendationUpdated,
+			Status: v1.ConditionTrue,
+			Reason: util.VPAConditionReasonUpdated,
+		},
+		{
+			Type:    apis.NoPodsMatched,
+			Status:  v1.ConditionTrue,
+			Reason:  util.VPAConditionReasonNoPodsMatched,
+			Message: "TargetRef workload not found: StatefulSet sts2",
+		},
+	}
 
 	for _, tc := range []struct {
 		name    string
@@ -243,6 +294,7 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 		newPods []*v1.Pod
 		vpa     *apis.KatalystVerticalPodAutoscaler
 		vpaNew  *apis.KatalystVerticalPodAutoscaler
+		wantErr bool
 	}{
 		{
 			name:   "delete owner reference",
@@ -337,6 +389,61 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 				newPod3,
 			},
 		},
+		{
+			name:   "no pods matched with valid selector",
+			vpa:    vpa4,
+			vpaNew: vpaNew4,
+			object: &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "StatefulSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sts1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						apiconsts.WorkloadAnnotationVPAEnabledKey: apiconsts.WorkloadAnnotationVPAEnabled,
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"workload": "sts1",
+						},
+					},
+				},
+			},
+			pods:    []*v1.Pod{},
+			newPods: []*v1.Pod{},
+		},
+		{
+			name:    "target ref workload not found",
+			vpa:     vpa5,
+			vpaNew:  vpaNew5,
+			wantErr: true,
+			object: &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "StatefulSet",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sts1",
+					Namespace: "default",
+					Annotations: map[string]string{
+						apiconsts.WorkloadAnnotationVPAEnabledKey: apiconsts.WorkloadAnnotationVPAEnabled,
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"workload": "sts1",
+						},
+					},
+				},
+			},
+			pods:    []*v1.Pod{},
+			newPods: []*v1.Pod{},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -380,7 +487,11 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 			assert.True(t, synced)
 
 			err = vpaController.syncVPA(key)
-			assert.NoError(t, err)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 
 			for _, pod := range tc.newPods {
 				p, err := controlCtx.Client.KubeClient.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
@@ -392,6 +503,19 @@ func TestVPAControllerSyncVPA(t *testing.T) {
 				Get(context.TODO(), tc.vpaNew.Name, metav1.GetOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, tc.vpaNew.GetObjectMeta(), vpa.GetObjectMeta())
+
+			for _, expectedCond := range tc.vpaNew.Status.Conditions {
+				found := false
+				for _, actCond := range vpa.Status.Conditions {
+					if actCond.Type == expectedCond.Type {
+						found = true
+						assert.Equal(t, expectedCond.Status, actCond.Status)
+						assert.Equal(t, expectedCond.Reason, actCond.Reason)
+						assert.Equal(t, expectedCond.Message, actCond.Message)
+					}
+				}
+				assert.True(t, found, "condition %s not found", expectedCond.Type)
+			}
 		})
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Enhancements
#### What this PR does / why we need it:
Add check for active pods before counting failed updates to avoid including terminated pods in the statistics. Update error message to show active pod count separately from total count.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
