### PR TITLE
feat(qrm): qrm-mb-plugin: recalibrate ccd cap

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/mb_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/mb_plugin.go
@@ -27,6 +27,8 @@ const (
 	defaultMinCCDMB = 4_000  // 4GB
 	defaultMaxCCDMB = 40_000 // 40GB
 
+	defaultCCDCapKp = 0.1
+
 	// defaultMaxIncomingRemoteMB is that each mb domain is allowed to have traffic from other domains by default;
 	// 15GB is the heuristic value based on prior experiences
 	defaultMaxIncomingRemoteMB = 15_000 // 15GB
@@ -47,6 +49,8 @@ type MBOptions struct {
 	MaxIncomingRemoteMB            int
 	MBCapLimitPercent              int
 	ActiveTrafficMBThreshold       int
+	CCDCapKp                       float64
+	CCDCapGroups                   map[string]int
 	DomainGroupAwareCapacityPCT    map[string]int
 	NoThrottleGroups               []string
 	CrossDomainGroups              []string
@@ -60,6 +64,7 @@ func NewMBOptions() *MBOptions {
 		PolicyName:               consts.MBPluginPolicyNameGeneric, // only generic policy is supported right now
 		MinCCDMB:                 defaultMinCCDMB,
 		MaxCCDMB:                 defaultMaxCCDMB,
+		CCDCapKp:                 defaultCCDCapKp,
 		MBCapLimitPercent:        defaultMBCapLimitPercent,
 		ActiveTrafficMBThreshold: defaultMinActiveMB,
 		MaxIncomingRemoteMB:      defaultMaxIncomingRemoteMB,
@@ -73,7 +78,11 @@ func (o *MBOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.IntVar(&o.MinCCDMB, "mb-ccd-min",
 		o.MinCCDMB, "min mb per ccd")
 	fs.IntVar(&o.MaxCCDMB, "mb-ccd-max",
-		o.MaxCCDMB, "max mb per ccd")
+		o.MaxCCDMB, "max mb per ccd; saturation point of mb resource control")
+	fs.Float64Var(&o.CCDCapKp, "mb-ccd-cap-kp",
+		o.CCDCapKp, "proportional gain for ccd cap governance")
+	fs.StringToIntVar(&o.CCDCapGroups, "mb-ccd-cap-groups",
+		o.CCDCapGroups, "per-group target actual mb per ccd (e.g. dedicated=20000,shared-50=24000)")
 	fs.IntVar(&o.MaxIncomingRemoteMB, "mb-remote-limit",
 		o.MaxIncomingRemoteMB, "max mb allowed from remote domains")
 	fs.IntVar(&o.MBCapLimitPercent, "mb-cap-limit-percent",
@@ -98,6 +107,8 @@ func (o *MBOptions) ApplyTo(conf *qrm.MBQRMPluginConfig) error {
 	conf.PolicyName = o.PolicyName
 	conf.MinCCDMB = o.MinCCDMB
 	conf.MaxCCDMB = o.MaxCCDMB
+	conf.CCDCapKp = o.CCDCapKp
+	conf.CCDCapGroups = o.CCDCapGroups
 	conf.MaxIncomingRemoteMB = o.MaxIncomingRemoteMB
 	conf.MBCapLimitPercent = o.MBCapLimitPercent
 	conf.ActiveTrafficMBThreshold = o.ActiveTrafficMBThreshold

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -27,6 +27,8 @@ import (
 )
 
 // pControllerAdvisor is an advisor which restricts given groups' ccd mb to specified upper bound
+// based on P-Controler (Proportional Controller) of closed-looped automation system to compare output feedback
+// against a target value and adjust inputs in predefined ratio Kp to achieve a desired state
 type pControllerAdvisor struct {
 	ccdMinMB, ccdMaxMB int
 	inner              Advisor

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -104,6 +104,7 @@ func applyGroupCCDBoundsChecks(ccdMBs plan.GroupCCDPlan, lower, upper int) {
 }
 
 func clampMB(value, min, max int) int {
+	// caller ensures min <= max
 	if min > 0 && value < min {
 		return min
 	}

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package advisor
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+// pControllerAdvisor is an advisor which restricts given groups' ccd mb to specified upper bound
+type pControllerAdvisor struct {
+	ccdMinMB, ccdMaxMB int
+	inner              Advisor
+
+	groupStates map[string]*groupPCtrlState
+}
+
+type groupPCtrlState struct {
+	pCtrl    pController
+	ccdCapMB int
+}
+
+func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error) {
+	result, err := p.inner.GetPlan(ctx, domainsMon)
+	if err != nil {
+		return nil, err
+	}
+
+	for group, state := range p.groupStates {
+		p.restrictGroupCCDCap(group, state, domainsMon, result)
+	}
+
+	return result, nil
+}
+
+func (p *pControllerAdvisor) restrictGroupCCDCap(group string, groupState *groupPCtrlState,
+	domainsMon *monitor.DomainStats, plan *plan.MBPlan,
+) {
+	maxObservedMB := p.maxObservedCCDMBForGroup(domainsMon.Outgoings, group)
+	groupState.ccdCapMB = p.getGroupCapUpdate(groupState, maxObservedMB)
+
+	ccdMBs, ok := plan.MBGroups[group]
+	if !ok {
+		// fine to have no plan for the group
+		return
+	}
+	applyGroupCCDBoundsChecks(ccdMBs, p.ccdMinMB, groupState.ccdCapMB)
+
+	if klog.V(6).Enabled() {
+		general.InfofV(6, "[mbm] [pController] group=%s maxObserved=%d target=%d cap=%d",
+			group, maxObservedMB, groupState.pCtrl.target, groupState.ccdCapMB)
+	}
+}
+
+func (p *pControllerAdvisor) getGroupCapUpdate(state *groupPCtrlState, maxObservedMB int) int {
+	if maxObservedMB == 0 {
+		return state.ccdCapMB
+	}
+
+	delta := state.pCtrl.update(maxObservedMB)
+	newCap := state.ccdCapMB + delta
+	return clampMB(newCap, p.ccdMinMB, p.ccdMaxMB)
+}
+
+func (p *pControllerAdvisor) maxObservedCCDMBForGroup(outgoings map[int]monitor.GroupMBStats, group string) int {
+	max := 0
+	for _, groupStats := range outgoings {
+		ccdStats, ok := groupStats[group]
+		if !ok {
+			continue
+		}
+		for _, mbInfo := range ccdStats {
+			if mbInfo.TotalMB > max {
+				max = mbInfo.TotalMB
+			}
+		}
+	}
+	return max
+}
+
+func applyGroupCCDBoundsChecks(ccdMBs plan.GroupCCDPlan, lower, upper int) {
+	for ccd, mb := range ccdMBs {
+		ccdMBs[ccd] = clampMB(mb, lower, upper)
+	}
+}
+
+func clampMB(value, min, max int) int {
+	if min > 0 && value < min {
+		return min
+	}
+	if max > 0 && value > max {
+		return max
+	}
+	return value
+}
+
+func NewPControllerAdvisor(Kp float64,
+	minValue, maxValue int,
+	groupTargets map[string]int,
+	inner Advisor,
+) Advisor {
+	groupStates := make(map[string]*groupPCtrlState, len(groupTargets))
+	for group, target := range groupTargets {
+		groupStates[group] = &groupPCtrlState{
+			pCtrl: pController{
+				kp:     Kp,
+				target: target,
+			},
+			ccdCapMB: maxValue,
+		}
+	}
+
+	return &pControllerAdvisor{
+		ccdMinMB:    minValue,
+		ccdMaxMB:    maxValue,
+		inner:       inner,
+		groupStates: groupStates,
+	}
+}
+
+type pController struct {
+	kp     float64
+	target int
+}
+
+func (p *pController) update(measurement int) int {
+	gap := float64(p.target - measurement)
+	return int(p.kp * gap)
+}

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
@@ -18,6 +18,7 @@ package advisor
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,13 +34,20 @@ type mockAdvisor struct {
 
 func (m *mockAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error) {
 	args := m.Called(ctx, domainsMon)
-	return args.Get(0).(*plan.MBPlan), args.Error(1)
+
+	var returnedPlan *plan.MBPlan
+	if v := args.Get(0); v != nil {
+		returnedPlan = v.(*plan.MBPlan)
+	}
+
+	return returnedPlan, args.Error(1)
 }
 
-func TestPControllerAdvisor_GetPlan_CapDown(t *testing.T) {
+func TestPControllerAdvisor_GetPlan_May_Update_CCDCap(t *testing.T) {
 	t.Parallel()
 
-	dummyStats := monitor.DomainStats{
+	// test data for case cap-down
+	dummyStatsCapDown := monitor.DomainStats{
 		Outgoings: map[int]monitor.DomainMonStat{
 			0: {
 				"dedicated": {
@@ -49,8 +57,7 @@ func TestPControllerAdvisor_GetPlan_CapDown(t *testing.T) {
 			},
 		},
 	}
-
-	dummyPlan := plan.MBPlan{
+	dummyPlanCapDown := plan.MBPlan{
 		MBGroups: map[string]plan.GroupCCDPlan{
 			"system": {
 				0: 123,
@@ -62,52 +69,12 @@ func TestPControllerAdvisor_GetPlan_CapDown(t *testing.T) {
 			},
 		},
 	}
+	mockInnerCapDown := new(mockAdvisor)
+	mockInnerCapDown.On("GetPlan", context.TODO(), &dummyStatsCapDown).Return(
+		&dummyPlanCapDown, nil)
 
-	mockInner := new(mockAdvisor)
-	mockInner.On("GetPlan", context.TODO(), &dummyStats).Return(&dummyPlan, nil)
-
-	pCtrl := pControllerAdvisor{
-		ccdMinMB: 2000,
-		ccdMaxMB: 60000,
-		inner:    mockInner,
-		groupStates: map[string]*groupPCtrlState{
-			"dedicated": {
-				pCtrl: pController{
-					kp:     0.1,
-					target: 24000,
-				},
-				ccdCapMB: 45000,
-			},
-		},
-	}
-
-	expectedPlan := &plan.MBPlan{
-		MBGroups: map[string]plan.GroupCCDPlan{
-			"system": {
-				0: 123,
-				1: 456,
-			},
-			"dedicated": {
-				0: 16000,
-				1: 45000 - 1100, // 0.1 * (35000 - 24000)
-			},
-		},
-	}
-
-	resultPlan, err := pCtrl.GetPlan(context.TODO(), &dummyStats)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
-	}
-
-	t.Logf("result plan = %v", resultPlan)
-	assert.Equal(t, expectedPlan, resultPlan)
-	assert.Equal(t, 45000-1100, pCtrl.groupStates["dedicated"].ccdCapMB, "cap should decrease: 45000 + 0.1*(24000-35000)")
-}
-
-func TestPControllerAdvisor_GetPlan_CapUp(t *testing.T) {
-	t.Parallel()
-
-	dummyStats := monitor.DomainStats{
+	// test data for case cap-up
+	dummyStatsCapUp := monitor.DomainStats{
 		Outgoings: map[int]monitor.DomainMonStat{
 			0: {
 				"dedicated": {
@@ -117,8 +84,7 @@ func TestPControllerAdvisor_GetPlan_CapUp(t *testing.T) {
 			},
 		},
 	}
-
-	dummyPlan := plan.MBPlan{
+	dummyPlanCapUp := plan.MBPlan{
 		MBGroups: map[string]plan.GroupCCDPlan{
 			"dedicated": {
 				0: 9000,
@@ -126,40 +92,172 @@ func TestPControllerAdvisor_GetPlan_CapUp(t *testing.T) {
 			},
 		},
 	}
+	mockInnerCapUp := new(mockAdvisor)
+	mockInnerCapUp.On("GetPlan", context.TODO(), &dummyStatsCapUp).Return(
+		&dummyPlanCapUp, nil)
 
-	mockInner := new(mockAdvisor)
-	mockInner.On("GetPlan", context.TODO(), &dummyStats).Return(&dummyPlan, nil)
+	// test data for negative case cap-no-data-error
+	dummyStatsCapNoData := monitor.DomainStats{}
+	mockInnerCapNoData := new(mockAdvisor)
+	mockInnerCapNoData.On("GetPlan", context.TODO(), &dummyStatsCapNoData).Return(
+		nil, fmt.Errorf("no data error"))
 
-	pCtrl := pControllerAdvisor{
-		ccdMinMB: 2000,
-		ccdMaxMB: 60000,
-		inner:    mockInner,
-		groupStates: map[string]*groupPCtrlState{
-			"dedicated": {
-				pCtrl: pController{
-					kp:     0.1,
-					target: 24000,
-				},
-				ccdCapMB: 15000,
-			},
-		},
-	}
-
-	expectedPlan := &plan.MBPlan{
+	// test data for case cap-no-usage
+	dummyStatsCapNoUsage := monitor.DomainStats{}
+	dummyPlanCapNoUsage := plan.MBPlan{
 		MBGroups: map[string]plan.GroupCCDPlan{
-			"dedicated": {
-				0: 9000,
-				1: 15500, // 15500 < new cap 15900, preserved (would have been clamped to 15000 under old cap)
+			"system": {
+				0: 123,
+				1: 456,
 			},
 		},
 	}
+	mockInnerCapNoUsage := new(mockAdvisor)
+	mockInnerCapNoUsage.On("GetPlan", context.TODO(), &dummyStatsCapNoUsage).Return(
+		&dummyPlanCapNoUsage, nil)
 
-	resultPlan, err := pCtrl.GetPlan(context.TODO(), &dummyStats)
-	if err != nil {
-		t.Errorf("unexpected error %v", err)
+	type fields struct {
+		ccdMinMB    int
+		ccdMaxMB    int
+		inner       Advisor
+		groupStates map[string]*groupPCtrlState
 	}
 
-	t.Logf("result plan = %v", resultPlan)
-	assert.Equal(t, expectedPlan, resultPlan)
-	assert.Equal(t, 15000+900, pCtrl.groupStates["dedicated"].ccdCapMB, "cap should increase: 15000 + 0.1*(24000-15000)")
+	tests := []struct {
+		name                  string
+		fields                fields
+		domainsMon            *monitor.DomainStats
+		wantErr               bool
+		wantPlan              *plan.MBPlan
+		wantDedicatedCCDCapMB int
+	}{
+		{
+			name: "mb stat higher over the target leads to lower ccd cap",
+			fields: fields{
+				ccdMinMB: 2000,
+				ccdMaxMB: 60000,
+				inner:    mockInnerCapDown,
+				groupStates: map[string]*groupPCtrlState{
+					"dedicated": {
+						pCtrl: pController{
+							kp:     0.1,
+							target: 24000,
+						},
+						ccdCapMB: 45000, // current dedicated group ccd cap
+					},
+				},
+			},
+			domainsMon: &dummyStatsCapDown,
+			wantErr:    false,
+			wantPlan: &plan.MBPlan{
+				MBGroups: map[string]plan.GroupCCDPlan{
+					"system": {
+						0: 123,
+						1: 456,
+					},
+					"dedicated": {
+						0: 16000,
+						1: 45000 - 1100, // 0.1 * (35000 - 24000)
+					},
+				},
+			},
+			wantDedicatedCCDCapMB: 45000 - 1100, // expected dedicated group ccd cap: 45000 + 0.1*(24000-35000)
+		},
+		{
+			name: "mb stat lower much under the target leads to raised ccd cap",
+			fields: fields{
+				ccdMinMB: 2000,
+				ccdMaxMB: 60000,
+				inner:    mockInnerCapUp,
+				groupStates: map[string]*groupPCtrlState{
+					"dedicated": {
+						pCtrl: pController{
+							kp:     0.1,
+							target: 24000,
+						},
+						ccdCapMB: 15000,
+					},
+				},
+			},
+			domainsMon: &dummyStatsCapUp,
+			wantErr:    false,
+			wantPlan: &plan.MBPlan{
+				MBGroups: map[string]plan.GroupCCDPlan{
+					"dedicated": {
+						0: 9000,
+						1: 15500, // 15500 < new cap 15900, preserved (would have been clamped to 15000 under old cap)
+					},
+				},
+			},
+			wantDedicatedCCDCapMB: 15000 + 900, // 15000 + (24000 - 14000) * 0.1
+		},
+		{
+			name: "error from inner passed through",
+			fields: fields{
+				ccdMinMB: 2000,
+				ccdMaxMB: 60000,
+				inner:    mockInnerCapNoData,
+				groupStates: map[string]*groupPCtrlState{
+					"dedicated": {
+						pCtrl: pController{
+							kp:     0.1,
+							target: 24000,
+						},
+						ccdCapMB: 12345,
+					},
+				},
+			},
+			domainsMon:            &dummyStatsCapNoData,
+			wantErr:               true,
+			wantPlan:              nil,
+			wantDedicatedCCDCapMB: 12345, // expecting no change
+		},
+		{
+			name: "no mb usage, no change",
+			fields: fields{
+				ccdMinMB: 2000,
+				ccdMaxMB: 60000,
+				inner:    mockInnerCapNoUsage,
+				groupStates: map[string]*groupPCtrlState{
+					"dedicated": {
+						pCtrl: pController{
+							kp:     0.1,
+							target: 24000,
+						},
+						ccdCapMB: 21312,
+					},
+				},
+			},
+			domainsMon:            &dummyStatsCapNoUsage,
+			wantErr:               false,
+			wantPlan:              &dummyPlanCapNoUsage, // expecting no change
+			wantDedicatedCCDCapMB: 21312,                // expecting no change
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pCtrl := pControllerAdvisor{
+				ccdMinMB:    tt.fields.ccdMinMB,
+				ccdMaxMB:    tt.fields.ccdMaxMB,
+				inner:       tt.fields.inner,
+				groupStates: tt.fields.groupStates,
+			}
+
+			gotPlan, err := pCtrl.GetPlan(context.TODO(), tt.domainsMon)
+
+			mock.AssertExpectationsForObjects(t, pCtrl.inner)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("pControllerAdvisor.GetPlan() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			t.Logf("result plan = %v", gotPlan)
+			assert.Equal(t, tt.wantPlan, gotPlan)
+			assert.Equal(t, tt.wantDedicatedCCDCapMB, pCtrl.groupStates["dedicated"].ccdCapMB, "new cap should be")
+		})
+	}
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package advisor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
+)
+
+type mockAdvisor struct {
+	mock.Mock
+}
+
+func (m *mockAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error) {
+	args := m.Called(ctx, domainsMon)
+	return args.Get(0).(*plan.MBPlan), args.Error(1)
+}
+
+func TestPControllerAdvisor_GetPlan_CapDown(t *testing.T) {
+	t.Parallel()
+
+	dummyStats := monitor.DomainStats{
+		Outgoings: map[int]monitor.DomainMonStat{
+			0: {
+				"dedicated": {
+					0: {TotalMB: 10000},
+					1: {TotalMB: 35000},
+				},
+			},
+		},
+	}
+
+	dummyPlan := plan.MBPlan{
+		MBGroups: map[string]plan.GroupCCDPlan{
+			"system": {
+				0: 123,
+				1: 456,
+			},
+			"dedicated": {
+				0: 16000,
+				1: 45000,
+			},
+		},
+	}
+
+	mockInner := new(mockAdvisor)
+	mockInner.On("GetPlan", context.TODO(), &dummyStats).Return(&dummyPlan, nil)
+
+	pCtrl := pControllerAdvisor{
+		ccdMinMB: 2000,
+		ccdMaxMB: 60000,
+		inner:    mockInner,
+		groupStates: map[string]*groupPCtrlState{
+			"dedicated": {
+				pCtrl: pController{
+					kp:     0.1,
+					target: 24000,
+				},
+				ccdCapMB: 45000,
+			},
+		},
+	}
+
+	expectedPlan := &plan.MBPlan{
+		MBGroups: map[string]plan.GroupCCDPlan{
+			"system": {
+				0: 123,
+				1: 456,
+			},
+			"dedicated": {
+				0: 16000,
+				1: 45000 - 1100, // 0.1 * (35000 - 24000)
+			},
+		},
+	}
+
+	resultPlan, err := pCtrl.GetPlan(context.TODO(), &dummyStats)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	t.Logf("result plan = %v", resultPlan)
+	assert.Equal(t, expectedPlan, resultPlan)
+	assert.Equal(t, 45000-1100, pCtrl.groupStates["dedicated"].ccdCapMB, "cap should decrease: 45000 + 0.1*(24000-35000)")
+}
+
+func TestPControllerAdvisor_GetPlan_CapUp(t *testing.T) {
+	t.Parallel()
+
+	dummyStats := monitor.DomainStats{
+		Outgoings: map[int]monitor.DomainMonStat{
+			0: {
+				"dedicated": {
+					0: {TotalMB: 8000},
+					1: {TotalMB: 15000},
+				},
+			},
+		},
+	}
+
+	dummyPlan := plan.MBPlan{
+		MBGroups: map[string]plan.GroupCCDPlan{
+			"dedicated": {
+				0: 9000,
+				1: 15500,
+			},
+		},
+	}
+
+	mockInner := new(mockAdvisor)
+	mockInner.On("GetPlan", context.TODO(), &dummyStats).Return(&dummyPlan, nil)
+
+	pCtrl := pControllerAdvisor{
+		ccdMinMB: 2000,
+		ccdMaxMB: 60000,
+		inner:    mockInner,
+		groupStates: map[string]*groupPCtrlState{
+			"dedicated": {
+				pCtrl: pController{
+					kp:     0.1,
+					target: 24000,
+				},
+				ccdCapMB: 15000,
+			},
+		},
+	}
+
+	expectedPlan := &plan.MBPlan{
+		MBGroups: map[string]plan.GroupCCDPlan{
+			"dedicated": {
+				0: 9000,
+				1: 15500, // 15500 < new cap 15900, preserved (would have been clamped to 15000 under old cap)
+			},
+		},
+	}
+
+	resultPlan, err := pCtrl.GetPlan(context.TODO(), &dummyStats)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	t.Logf("result plan = %v", resultPlan)
+	assert.Equal(t, expectedPlan, resultPlan)
+	assert.Equal(t, 15000+900, pCtrl.groupStates["dedicated"].ccdCapMB, "cap should increase: 15000 + 0.1*(24000-15000)")
+}

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -132,7 +132,19 @@ func (m *MBPlugin) Start() (err error) {
 		m.conf.MinCCDMB, m.conf.MaxCCDMB,
 		defaultMBDomainCapacity, m.conf.MBCapLimitPercent,
 		m.conf.CrossDomainGroups, m.conf.MBQRMPluginConfig.NoThrottleGroups,
-		groupCapacities)
+		groupCapacities,
+	)
+
+	if len(m.conf.CCDCapGroups) > 0 && m.conf.CCDCapKp > 0 {
+		m.advisor = advisor.NewPControllerAdvisor(
+			m.conf.CCDCapKp,
+			m.conf.MinCCDMB,
+			m.conf.MaxCCDMB,
+			m.conf.CCDCapGroups,
+			m.advisor,
+		)
+		general.Infof("[mbm] P-Controller advisor enabled with groups=%v, Kp=%.2f", m.conf.CCDCapGroups, m.conf.CCDCapKp)
+	}
 
 	go func() {
 		wait.Until(m.run, interval, m.chStop)

--- a/pkg/agent/qrm-plugins/mb/policy/policy.go
+++ b/pkg/agent/qrm-plugins/mb/policy/policy.go
@@ -57,6 +57,7 @@ func NewGenericPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 	general.Infof("[mbm] config: group customized capacity percentages %v", conf.DomainGroupAwareCapacityPCT)
 	general.Infof("[mbm] config: min ccd mb %d MB", conf.MinCCDMB)
 	general.Infof("[mbm] config: max ccd mb %d MB", conf.MaxCCDMB)
+	general.Infof("[mbm] config: ccd cap kp %.3f, groups %v", conf.CCDCapKp, conf.CCDCapGroups)
 	general.Infof("[mbm] config: domain alient incoming mb limit %d MB", conf.MaxIncomingRemoteMB)
 	general.Infof("[mbm] config: mb cap limit percent %d%%%%", conf.MBCapLimitPercent)
 	general.Infof("[mbm] config: mb active traffic mb threshold %d MB", conf.ActiveTrafficMBThreshold)

--- a/pkg/config/agent/qrm/mb_plugin.go
+++ b/pkg/config/agent/qrm/mb_plugin.go
@@ -26,6 +26,9 @@ type MBQRMPluginConfig struct {
 	MBCapLimitPercent        int
 	ActiveTrafficMBThreshold int
 
+	CCDCapKp     float64
+	CCDCapGroups map[string]int
+
 	// DomainQoSAwareCapacityPCT keeps qos group customized mb upper capacity percentage it allows
 	DomainGroupAwareCapacityPCT map[string]int
 	// NoThrottleGroups are qos groups that should not be throttled with their mb usage


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
Existing qrm-mb-plugin allows workloads within the range of numa to share mem bandwidth - in other words, one ccd may use large portion of mb resource as long as numa upper boundary not reached yet, in "work conserving" fashion". However, under some circumstances we may want to put certain constraint for workload to consume mb. e.g. 1.5GB per core, in order to present relatively consistent resource provisioning, or regulate over-aggressive pods.

This PR implements a feature for qrm-mb-plugin, introduces 2 parameters
* mb-ccd-cap-groups
* mb-ccd-cap-kp

e.g. ``` --mb-ccd-cap-groups=dedicated=24000 --mb-ccd-cap-kp=0.1``` states dedicated group workloads under constraints 24G per ccd (1.5G per core for ccd with 16 cores), the converging speed is 0.1

Below is what observed in test machine, the effective mb usage is 13/1.5+17=25 GB
<img width="1089" height="103" alt="image" src="https://github.com/user-attachments/assets/7cefcaec-12e2-4ddb-baf0-478296fbe812" />

