### PR TITLE
fix(gpu): add retry mechanism for report building failures

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
@@ -25,24 +25,26 @@ import (
 )
 
 type GPUOptions struct {
-	PolicyName                 string
-	GPUDeviceNames             []string
-	GPUMemoryAllocatablePerGPU string
-	SkipGPUStateCorruption     bool
-	RDMADeviceNames            []string
-	RequiredDeviceAffinity     bool
+	PolicyName                      string
+	GPUDeviceNames                  []string
+	GPUMemoryAllocatablePerGPU      string
+	SkipGPUStateCorruption          bool
+	RDMADeviceNames                 []string
+	RequiredDeviceAffinity          bool
+	EnableKubeletCheckpointFallback bool
 
 	GPUStrategyOptions *gpustrategy.GPUStrategyOptions
 }
 
 func NewGPUOptions() *GPUOptions {
 	return &GPUOptions{
-		PolicyName:                 "static",
-		GPUDeviceNames:             []string{"nvidia.com/gpu"},
-		GPUMemoryAllocatablePerGPU: "100",
-		RDMADeviceNames:            []string{},
-		GPUStrategyOptions:         gpustrategy.NewGPUStrategyOptions(),
-		RequiredDeviceAffinity:     true,
+		PolicyName:                      "static",
+		GPUDeviceNames:                  []string{"nvidia.com/gpu"},
+		GPUMemoryAllocatablePerGPU:      "100",
+		RDMADeviceNames:                 []string{},
+		GPUStrategyOptions:              gpustrategy.NewGPUStrategyOptions(),
+		RequiredDeviceAffinity:          true,
+		EnableKubeletCheckpointFallback: true,
 	}
 }
 
@@ -59,6 +61,8 @@ func (o *GPUOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringSliceVar(&o.RDMADeviceNames, "rdma-resource-names", o.RDMADeviceNames, "The name of the RDMA resource")
 	fs.BoolVar(&o.RequiredDeviceAffinity, "gpu-required-device-affinity", o.RequiredDeviceAffinity,
 		"required device affinity, and when true it will cause pods to admit fail if unable to meet device affinity")
+	fs.BoolVar(&o.EnableKubeletCheckpointFallback, "enable-kubelet-checkpoint-fallback", o.EnableKubeletCheckpointFallback,
+		"enable fallback to kubelet device plugin checkpoint for device allocation.")
 	o.GPUStrategyOptions.AddFlags(fss)
 }
 
@@ -76,5 +80,6 @@ func (o *GPUOptions) ApplyTo(conf *qrmconfig.GPUQRMPluginConfig) error {
 		return err
 	}
 	conf.RequiredDeviceAffinity = o.RequiredDeviceAffinity
+	conf.EnableKubeletCheckpointFallback = o.EnableKubeletCheckpointFallback
 	return nil
 }

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -23,12 +23,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	cpmerrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 
 	nodev1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/plugins/registration"
@@ -110,10 +113,12 @@ type gpuReporterPlugin struct {
 	stateGetter            func() state.State
 	deviceTypeToNames      map[string]sets.String
 
-	reportNotifyCh      chan struct{}
-	reportRetryInterval time.Duration
-	lastReportContent   *v1alpha1.GetReportContentResponse
-	checkpointManager   checkpointmanager.CheckpointManager
+	reportNotifyCh                  chan struct{}
+	reportRetryInterval             time.Duration
+	lastReportContent               *v1alpha1.GetReportContentResponse
+	checkpointManager               checkpointmanager.CheckpointManager
+	kubeletDevicePluginPath         string
+	enableKubeletCheckpointFallback bool
 }
 
 var (
@@ -130,16 +135,18 @@ func newGPUReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.
 	}
 
 	reporter := &gpuReporterPlugin{
-		gpuDeviceNames:         conf.GPUDeviceNames,
-		numaSocketZoneNodeMap:  util.GenerateNumaSocketZone(metaServer.MachineInfo.Topology),
-		emitter:                emitter,
-		deviceTopologyRegistry: topologyRegistry,
-		stateGetter:            stateGetter,
-		deviceTypeToNames:      deviceTypeToNames,
-		reportNotifyCh:         make(chan struct{}, 1),
-		reportRetryInterval:    defaultReportRetryInterval,
-		metaServer:             metaServer,
-		checkpointManager:      checkpointManager,
+		gpuDeviceNames:                  conf.GPUDeviceNames,
+		numaSocketZoneNodeMap:           util.GenerateNumaSocketZone(metaServer.MachineInfo.Topology),
+		emitter:                         emitter,
+		deviceTopologyRegistry:          topologyRegistry,
+		stateGetter:                     stateGetter,
+		deviceTypeToNames:               deviceTypeToNames,
+		reportNotifyCh:                  make(chan struct{}, 1),
+		reportRetryInterval:             defaultReportRetryInterval,
+		metaServer:                      metaServer,
+		checkpointManager:               checkpointManager,
+		kubeletDevicePluginPath:         conf.KubeletDevicePluginPath,
+		enableKubeletCheckpointFallback: conf.EnableKubeletCheckpointFallback,
 	}
 	pluginWrapper, err := skeleton.NewRegistrationPluginWrapper(reporter, []string{conf.PluginRegistrationDir},
 		func(key string, value int64) {
@@ -173,6 +180,41 @@ func (p *gpuReporterPlugin) Start() (err error) {
 	}
 
 	p.ctx, p.cancel = context.WithCancel(context.Background())
+
+	if p.enableKubeletCheckpointFallback && p.kubeletDevicePluginPath != "" {
+		err = general.EnsureDirectory(p.kubeletDevicePluginPath)
+		if err != nil {
+			return fmt.Errorf("ensure kubelet device plugin path %s exists failed: %w", p.kubeletDevicePluginPath, err)
+		}
+
+		watcherCh, err := general.RegisterFileEventWatcher(
+			p.ctx.Done(),
+			general.FileWatcherInfo{
+				Path:     []string{p.kubeletDevicePluginPath},
+				Filename: native.KubeletDeviceManagerCheckpoint,
+				Op:       fsnotify.Create,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("register file watcher failed: %w", err)
+		}
+
+		go func() {
+			for {
+				select {
+				case <-watcherCh:
+					general.Infof("kubelet device plugin checkpoint changed, trigger report")
+					p.Trigger()
+				case <-p.ctx.Done():
+					general.Infof("file watcher stopped for kubelet device plugin checkpoint")
+					return
+				}
+			}
+		}()
+	} else {
+		general.Infof("kubelet device plugin checkpoint fallback is disabled or path is empty, skip watching kubelet device plugin checkpoint")
+	}
+
 	return
 }
 
@@ -453,9 +495,11 @@ func (p *gpuReporterPlugin) getZoneAllocations(machineState state.AllocationReso
 	// Add allocations from machine state
 	p.addStateAllocations(idToAllocations, machineState)
 
-	// Add allocations from kubelet device manager checkpoint
-	if err := p.addKubeletCheckpointAllocations(idToAllocations); err != nil {
-		return nil, err
+	// Add allocations from kubelet device manager checkpoint as a fallback.
+	if p.enableKubeletCheckpointFallback {
+		if err := p.addKubeletCheckpointAllocations(idToAllocations); err != nil {
+			return nil, err
+		}
 	}
 
 	// Then construct the final zone allocations from the map of device id to allocations
@@ -515,6 +559,10 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 
 	checkpointData, err := native.GetKubeletCheckpoint(p.checkpointManager)
 	if err != nil {
+		if errors.Is(err, cpmerrors.ErrCheckpointNotFound) {
+			general.Infof("kubelet checkpoint not found, skip")
+			return nil
+		}
 		return fmt.Errorf("failed to get kubelet checkpoint: %v", err)
 	}
 

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -520,7 +520,15 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 
 	podDeviceEntries, _ := checkpointData.GetDataInLatestFormat()
 
+	validDeviceNames := sets.NewString(p.gpuDeviceNames...)
+
 	for _, entry := range podDeviceEntries {
+		// Check if the reported resource is a valid GPU device name.
+		// If not in gpuDeviceNames, skip it to avoid reporting invalid devices.
+		if !validDeviceNames.Has(entry.ResourceName) {
+			continue
+		}
+
 		resourceName := v1.ResourceName(entry.ResourceName)
 
 		// Iterate through all devices per NUMA node
@@ -542,8 +550,8 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 				// Find the pod from the metaserver to get its namespace and name
 				pod, err := p.metaServer.GetPod(p.ctx, entry.PodUID)
 				if err != nil {
-					general.Errorf("failed to get pod %s/%s: %v", entry.PodUID, entry.PodUID, err)
-					return fmt.Errorf("failed to get pod %s/%s: %w", entry.PodUID, entry.PodUID, err)
+					general.Errorf("failed to get pod %s: %v", entry.PodUID, err)
+					return fmt.Errorf("failed to get pod %s: %w", entry.PodUID, err)
 				}
 
 				// Generate consumer key using namespace, name and podUID
@@ -554,8 +562,8 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 					Requests: &gpuResourceList,
 				})
 
-				general.Infof("added allocation from checkpoint: pod=%s, container=%s, device=%s, numa=%d",
-					entry.PodUID, entry.ContainerName, deviceID, numaNode)
+				general.Infof("added allocation from checkpoint: consumer=%s, container=%s, device=%s, numa=%d",
+					consumer, entry.ContainerName, deviceID, numaNode)
 			}
 		}
 	}

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
@@ -44,8 +45,9 @@ import (
 )
 
 const (
-	gpuReporterPluginName   = "gpu-reporter-plugin"
-	propertyNameGPUTopology = "gpu_topology_attribute_key"
+	gpuReporterPluginName      = "gpu-reporter-plugin"
+	propertyNameGPUTopology    = "gpu_topology_attribute_key"
+	defaultReportRetryInterval = 5 * time.Second
 )
 
 var zeroQuantity = *resource.NewQuantity(0, resource.DecimalSI)
@@ -108,9 +110,10 @@ type gpuReporterPlugin struct {
 	stateGetter            func() state.State
 	deviceTypeToNames      map[string]sets.String
 
-	reportNotifyCh    chan struct{}
-	lastReportContent *v1alpha1.GetReportContentResponse
-	checkpointManager checkpointmanager.CheckpointManager
+	reportNotifyCh      chan struct{}
+	reportRetryInterval time.Duration
+	lastReportContent   *v1alpha1.GetReportContentResponse
+	checkpointManager   checkpointmanager.CheckpointManager
 }
 
 var (
@@ -134,6 +137,7 @@ func newGPUReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.
 		stateGetter:            stateGetter,
 		deviceTypeToNames:      deviceTypeToNames,
 		reportNotifyCh:         make(chan struct{}, 1),
+		reportRetryInterval:    defaultReportRetryInterval,
 		metaServer:             metaServer,
 		checkpointManager:      checkpointManager,
 	}
@@ -597,29 +601,33 @@ func hasExistingPodAllocation(allocations util.ZoneAllocations, podUID string) b
 func (p *gpuReporterPlugin) ListAndWatchReportContent(_ *v1alpha1.Empty, server v1alpha1.ReporterPlugin_ListAndWatchReportContentServer) error {
 	isFirst := true
 	var lastSentContent *v1alpha1.GetReportContentResponse
+	var retryCh <-chan time.Time
 
 	for {
 		resp, err := p.buildReportResponse()
 		if err != nil {
-			general.Errorf("failed to build report response: %v", err)
-			return err
-		}
-
-		p.Lock()
-		p.lastReportContent = resp
-		p.Unlock()
-
-		// Send report only when it's the first time or the content has changed
-		if isFirst || !proto.Equal(lastSentContent, resp) {
-			if err := server.Send(resp); err != nil {
-				general.Errorf("failed to send report content: %v", err)
-				return err
-			}
-			general.Infof("successfully sent report content to reporter manager, content: %v", resp)
-			lastSentContent = resp
-			isFirst = false
+			general.Errorf("failed to build report response: %v, will retry in %s", err, p.reportRetryInterval)
+			// Start a retry timer to ensure the listwatch stream doesn't break due to intermittent failures (e.g. state/topology parsing error)
+			retryCh = time.After(p.reportRetryInterval)
 		} else {
-			general.Infof("report content unchanged, skip sending")
+			// Clear retry timer if build succeeds
+			retryCh = nil
+			p.Lock()
+			p.lastReportContent = resp
+			p.Unlock()
+
+			// Send report only when it's the first time or the content has changed
+			if isFirst || !proto.Equal(lastSentContent, resp) {
+				if err := server.Send(resp); err != nil {
+					general.Errorf("failed to send report content: %v", err)
+					return err
+				}
+				general.Infof("successfully sent report content to reporter manager, content: %v", resp)
+				lastSentContent = resp
+				isFirst = false
+			} else {
+				general.Infof("report content unchanged, skip sending")
+			}
 		}
 
 		select {
@@ -631,6 +639,8 @@ func (p *gpuReporterPlugin) ListAndWatchReportContent(_ *v1alpha1.Empty, server 
 			return nil
 		case <-p.reportNotifyCh:
 			general.Infof("received report notify trigger, start to rebuild and send report")
+		case <-retryCh:
+			general.Infof("retry timer fired, start to rebuild and send report")
 		}
 	}
 }

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -33,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	cpmerrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 
 	nodev1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
@@ -1839,6 +1842,7 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			testConfig.KubeletDevicePluginPath = t.TempDir()
 			testConfig.PluginRegistrationDir = "test"
 			testConfig.GPUDeviceNames = gpuDeviceNames
+			testConfig.EnableKubeletCheckpointFallback = true
 
 			resourceTypeName := v1.ResourceName("test-gpu-resource")
 			deviceIDs := make([]string, 0)
@@ -1912,6 +1916,7 @@ func TestListAndWatchReportContent(t *testing.T) {
 	testConfig := config.NewConfiguration()
 	testConfig.KubeletDevicePluginPath = t.TempDir()
 	testConfig.GPUDeviceNames = []string{"test-gpu"}
+	testConfig.EnableKubeletCheckpointFallback = true
 	deviceTypeToNames := map[string]sets.String{"test-gpu": sets.NewString("test-gpu")}
 
 	topologyRegistry := machine.NewDeviceTopologyRegistry()
@@ -2207,6 +2212,16 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 			expectedErr:   true,
 		},
 		{
+			name: "get checkpoint returns not found",
+			p: &gpuReporterPlugin{
+				checkpointManager: &mockCheckpointManager{
+					getErr: cpmerrors.ErrCheckpointNotFound,
+				},
+			},
+			expectedEmpty: true,
+			expectedErr:   false,
+		},
+		{
 			name: "get checkpoint succeeds",
 			p: &gpuReporterPlugin{
 				gpuDeviceNames: []string{"test-resource"},
@@ -2322,4 +2337,94 @@ func (m *mockCheckpointManager) RemoveCheckpoint(checkpointKey string) error {
 
 func (m *mockCheckpointManager) ListCheckpoints() ([]string, error) {
 	return nil, nil
+}
+
+func TestGpuReporterPlugin_StartAndTrigger(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := os.MkdirTemp("", "kubelet-device-plugin")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	p := &gpuReporterPlugin{
+		kubeletDevicePluginPath:         tempDir,
+		enableKubeletCheckpointFallback: true,
+		reportNotifyCh:                  make(chan struct{}, 1),
+	}
+
+	err = p.Start()
+	assert.NoError(t, err)
+
+	// test idempotency
+	err = p.Start()
+	assert.NoError(t, err)
+
+	// trigger manually
+	p.Trigger()
+	select {
+	case <-p.reportNotifyCh:
+	default:
+		t.Fatal("expected to receive notify")
+	}
+
+	// wait for fsnotify to setup completely
+	time.Sleep(100 * time.Millisecond)
+
+	// trigger via file
+	checkpointFile := filepath.Join(tempDir, native.KubeletDeviceManagerCheckpoint)
+	err = os.WriteFile(checkpointFile, []byte("test"), 0o644)
+	assert.NoError(t, err)
+
+	// wait for file event
+	select {
+	case <-p.reportNotifyCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected to receive notify from file event")
+	}
+
+	// test stop
+	err = p.Stop()
+	assert.NoError(t, err)
+
+	// test stop idempotency
+	err = p.Stop()
+	assert.NoError(t, err)
+}
+
+func TestGpuReporterPlugin_StartEmptyPath(t *testing.T) {
+	t.Parallel()
+
+	p := &gpuReporterPlugin{
+		kubeletDevicePluginPath:         "",
+		enableKubeletCheckpointFallback: true,
+		reportNotifyCh:                  make(chan struct{}, 1),
+	}
+
+	err := p.Start()
+	assert.NoError(t, err)
+
+	err = p.Stop()
+	assert.NoError(t, err)
+}
+
+func TestGpuReporterPlugin_StartDisabledFallback(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := os.MkdirTemp("", "kubelet-device-plugin-disabled")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	p := &gpuReporterPlugin{
+		kubeletDevicePluginPath:         tempDir,
+		enableKubeletCheckpointFallback: false,
+		reportNotifyCh:                  make(chan struct{}, 1),
+	}
+
+	err = p.Start()
+	assert.NoError(t, err)
+
+	// Since fallback is disabled, no watcher is registered and trigger via file shouldn't work.
+	// But Start/Stop should be successful.
+	err = p.Stop()
+	assert.NoError(t, err)
 }

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -2209,6 +2209,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 		{
 			name: "get checkpoint succeeds",
 			p: &gpuReporterPlugin{
+				gpuDeviceNames: []string{"test-resource"},
 				checkpointManager: &mockCheckpointManager{
 					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{
 						{
@@ -2243,6 +2244,27 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 			expectedID:       "test-device-1",
 			expectedLen:      1,
 			expectedConsumer: "default/test-pod/test-pod-uid",
+		},
+		{
+			name: "skip device not in gpuDeviceNames",
+			p: &gpuReporterPlugin{
+				gpuDeviceNames: []string{"test-resource-other"},
+				checkpointManager: &mockCheckpointManager{
+					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{
+						{
+							PodUID:        "test-pod-uid",
+							ContainerName: "test-container",
+							ResourceName:  "test-resource",
+							DeviceIDs: map[int64][]string{
+								0: {"test-device-1"},
+							},
+							AllocResp: []byte(""),
+						},
+					}, make(map[string][]string)),
+				},
+			},
+			expectedEmpty: true,
+			expectedErr:   false,
 		},
 	}
 

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -1949,6 +1949,7 @@ func TestListAndWatchReportContent(t *testing.T) {
 	pluginWrapper := reporterImpl.GenericPlugin.(*skeleton.PluginRegistrationWrapper)
 	reporterPlugin := pluginWrapper.GenericPlugin.(*gpuReporterPlugin)
 	reporterPlugin.checkpointManager = &mockCheckpointManager{}
+	reporterPlugin.reportRetryInterval = 10 * time.Millisecond // Set a small interval for faster tests
 
 	_ = reporterPlugin.Start()
 	defer reporterPlugin.Stop()
@@ -2012,6 +2013,79 @@ func TestListAndWatchReportContent(t *testing.T) {
 	assert.NotNil(t, unaryResp)
 
 	// Close watch
+	cancel()
+	err = <-errCh
+	assert.NoError(t, err)
+}
+
+func TestListAndWatchReportContentRetry(t *testing.T) {
+	t.Parallel()
+
+	// 1. Setup minimal environment
+	testConfig := config.NewConfiguration()
+	testConfig.KubeletDevicePluginPath = t.TempDir()
+	testConfig.GPUDeviceNames = []string{"test-gpu"}
+	deviceTypeToNames := map[string]sets.String{"test-gpu": sets.NewString("test-gpu")}
+
+	topologyRegistry := machine.NewDeviceTopologyRegistry()
+	mockProvider := machine.NewDeviceTopologyProviderStub()
+	topologyRegistry.RegisterDeviceTopologyProvider("test-gpu", mockProvider)
+
+	topology := &machine.DeviceTopology{
+		Devices: map[string]machine.DeviceInfo{
+			"gpu-0": {NumaNodes: []int{0}},
+		},
+	}
+	_ = topologyRegistry.SetDeviceTopology("test-gpu", topology)
+
+	// stateGetter returning nil triggers an error in buildReportResponse
+	stateGetter := func() state.State { return nil }
+
+	metaServer := generateTestMetaServer([]cadvisorapi.Node{
+		{
+			Id: 0,
+			Cores: []cadvisorapi.Core{
+				{SocketID: 0, Id: 0, Threads: []int{0, 4}},
+			},
+		},
+	})
+
+	reporter, err := NewGPUReporter(metrics.DummyMetrics{}, metaServer, testConfig, topologyRegistry, stateGetter, deviceTypeToNames)
+	assert.NoError(t, err)
+	reporterImpl := reporter.(*gpuReporterImpl)
+	pluginWrapper := reporterImpl.GenericPlugin.(*skeleton.PluginRegistrationWrapper)
+	reporterPlugin := pluginWrapper.GenericPlugin.(*gpuReporterPlugin)
+	reporterPlugin.checkpointManager = &mockCheckpointManager{}
+	reporterPlugin.reportRetryInterval = 50 * time.Millisecond
+
+	_ = reporterPlugin.Start()
+	defer reporterPlugin.Stop()
+
+	// 2. Setup server mock
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sendCh := make(chan *v1alpha1.GetReportContentResponse, 10)
+	mockServer := &mockReporterPluginServer{
+		ctx:    ctx,
+		sendCh: sendCh,
+	}
+
+	// 3. Start ListAndWatch
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- reporterPlugin.ListAndWatchReportContent(nil, mockServer)
+	}()
+
+	// Because stateGetter returns nil, buildReportResponse fails and a retry timer is started.
+	// Since reportRetryInterval is 50ms, we can wait a bit to ensure it doesn't send anything despite retries.
+	select {
+	case <-sendCh:
+		t.Fatal("should not send report on failure")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	// Close watch to clean up test goroutine
 	cancel()
 	err = <-errCh
 	assert.NoError(t, err)

--- a/pkg/config/agent/qrm/gpu_plugin.go
+++ b/pkg/config/agent/qrm/gpu_plugin.go
@@ -36,6 +36,8 @@ type GPUQRMPluginConfig struct {
 	// RequiredDeviceAffinity specifies whether it is required for pods to follow device affinity strictly.
 	// If true, pods will fail to admit if they are not able to satisfy device affinity constraints. Set to true by default.
 	RequiredDeviceAffinity bool
+	// EnableKubeletCheckpointFallback specifies whether to fallback to kubelet device plugin checkpoint for allocation.
+	EnableKubeletCheckpointFallback bool
 
 	*gpustrategy.GPUStrategyConfig
 }

--- a/pkg/util/native/kubelet.go
+++ b/pkg/util/native/kubelet.go
@@ -36,8 +36,8 @@ import (
 
 const (
 	defaultTimeout = time.Second * 10
-	// kubeletDeviceManagerCheckpoint is the file name of device plugin checkpoint
-	kubeletDeviceManagerCheckpoint = "kubelet_internal_checkpoint"
+	// KubeletDeviceManagerCheckpoint is the file name of device plugin checkpoint
+	KubeletDeviceManagerCheckpoint = "kubelet_internal_checkpoint"
 )
 
 // MemoryReservation specifies the memory reservation of different types for each NUMA node
@@ -217,7 +217,7 @@ func GetKubeletCheckpoint(checkpointManager checkpointmanager.CheckpointManager)
 	devEntries := make([]checkpoint.PodDevicesEntry, 0)
 	cp := checkpoint.New(devEntries, registeredDevs)
 
-	err := checkpointManager.GetCheckpoint(kubeletDeviceManagerCheckpoint, cp)
+	err := checkpointManager.GetCheckpoint(KubeletDeviceManagerCheckpoint, cp)
 	if err != nil {
 		return nil, errors.Wrap(err, "get checkpoint failed")
 	}


### PR DESCRIPTION


Add test case to verify retry behavior works as expected without sending invalid reports.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Implement retry logic in ListAndWatchReportContent to handle temporary failures when building reports. Add reportRetryInterval field to control retry frequency. This ensures the stream doesn't break on intermittent errors while maintaining timely updates.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
