### PR TITLE
fix(gpu-reporter): bypass cache when getting pod metadata

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -40,6 +40,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	metaserverpod "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
@@ -596,10 +597,10 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 				gpuResourceList[resourceName] = *resource.NewQuantity(1, resource.DecimalSI)
 
 				// Find the pod from the metaserver to get its namespace and name
-				pod, err := p.metaServer.GetPod(p.ctx, entry.PodUID)
+				pod, err := p.metaServer.GetPod(context.WithValue(p.ctx, metaserverpod.BypassCacheKey, metaserverpod.BypassCacheTrue), entry.PodUID)
 				if err != nil {
-					general.Errorf("failed to get pod %s: %v", entry.PodUID, err)
-					return fmt.Errorf("failed to get pod %s: %w", entry.PodUID, err)
+					general.Warningf("failed to get pod %s: %v", entry.PodUID, err)
+					continue
 				}
 
 				// Generate consumer key using namespace, name and podUID

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -2224,6 +2224,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 		{
 			name: "get checkpoint succeeds",
 			p: &gpuReporterPlugin{
+				ctx:            context.TODO(),
 				gpuDeviceNames: []string{"test-resource"},
 				checkpointManager: &mockCheckpointManager{
 					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{


### PR DESCRIPTION


#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Bug fixes
#### What this PR does / why we need it:
Prevent potential stale cache issues by using BypassCacheKey when fetching pod metadata. Also improve error handling by returning nil instead of error for non-critical failures.
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
