### PR TITLE
feat(eviction): add dedicated CpuUsageRatioThreshold for NUMA CPU pre…

### DIFF
--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/numa_cpu_pressure_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/numa_cpu_pressure_eviction.go
@@ -28,6 +28,7 @@ type NumaCPUPressureEvictionOptions struct {
 	MetricRingSize                 int
 	GracePeriod                    int64
 	ThresholdExpandFactor          float64
+	CpuUsageRatioThreshold         float64
 	CandidateCount                 int
 	WorkloadMetricsLabelKeys       []string
 	SkippedPodKinds                []string
@@ -42,7 +43,8 @@ func NewNumaCPUPressureEvictionOptions() NumaCPUPressureEvictionOptions {
 		ThresholdMetPercentage:         0.7,
 		MetricRingSize:                 4,
 		GracePeriod:                    -1,
-		ThresholdExpandFactor:          1.1,
+		ThresholdExpandFactor:          7.0 / 6.0,
+		CpuUsageRatioThreshold:         0.6,
 		CandidateCount:                 2,
 		WorkloadMetricsLabelKeys:       []string{},
 		SkippedPodKinds:                []string{},
@@ -65,6 +67,8 @@ func (o *NumaCPUPressureEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"The grace period (in seconds) before evicting pods due to NUMA CPU pressure")
 	fs.Float64Var(&o.ThresholdExpandFactor, "numa-cpu-pressure-eviction-threshold-expand-factor", o.ThresholdExpandFactor,
 		"The factor by which to expand the NUMA CPU pressure threshold")
+	fs.Float64Var(&o.CpuUsageRatioThreshold, "numa-cpu-pressure-eviction-cpu-usage-ratio-threshold", o.CpuUsageRatioThreshold,
+		"The CPU usage ratio threshold for NUMA CPU pressure eviction (before expansion). Eviction trigger line = cpuUsageRatioThreshold * thresholdExpandFactor. If set to 0, falls back to NPD or MetricThresholdConfiguration")
 	fs.IntVar(&o.CandidateCount, "numa-cpu-pressure-eviction-candidate-count", o.CandidateCount,
 		"The candidate count when pick victim pods")
 	fs.StringSliceVar(&o.WorkloadMetricsLabelKeys, "numa-cpu-pressure-eviction-workload-metrics-label-keys", o.WorkloadMetricsLabelKeys,
@@ -85,6 +89,7 @@ func (o *NumaCPUPressureEvictionOptions) ApplyTo(c *eviction.NumaCPUPressureEvic
 	c.MetricRingSize = o.MetricRingSize
 	c.GracePeriod = o.GracePeriod
 	c.ThresholdExpandFactor = o.ThresholdExpandFactor
+	c.CpuUsageRatioThreshold = o.CpuUsageRatioThreshold
 	c.CandidateCount = o.CandidateCount
 	c.WorkloadMetricsLabelKeys = o.WorkloadMetricsLabelKeys
 	c.SkippedPodKinds = o.SkippedPodKinds

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/numa_cpu_pressure_eviction_test.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/numa_cpu_pressure_eviction_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkgeviction "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
+)
+
+func TestNumaCPUPressureEvictionOptions_Defaults(t *testing.T) {
+	t.Parallel()
+
+	o := NewNumaCPUPressureEvictionOptions()
+	assert.Equal(t, 7.0/6.0, o.ThresholdExpandFactor, "ThresholdExpandFactor default should be 7/6")
+	assert.Equal(t, 0.6, o.CpuUsageRatioThreshold, "CpuUsageRatioThreshold default should be 0.6")
+}
+
+func TestNumaCPUPressureEvictionOptions_ApplyTo(t *testing.T) {
+	t.Parallel()
+
+	o := NewNumaCPUPressureEvictionOptions()
+	c := pkgeviction.NumaCPUPressureEvictionConfiguration{}
+
+	err := o.ApplyTo(&c)
+	assert.NoError(t, err)
+	assert.Equal(t, 7.0/6.0, c.ThresholdExpandFactor, "ApplyTo should propagate ThresholdExpandFactor from Options")
+	assert.Equal(t, 0.6, c.CpuUsageRatioThreshold, "ApplyTo should propagate CpuUsageRatioThreshold from Options")
+}
+
+func TestNumaCPUPressureEvictionOptions_ApplyTo_CustomValues(t *testing.T) {
+	t.Parallel()
+
+	o := NumaCPUPressureEvictionOptions{
+		ThresholdExpandFactor:  1.3,
+		CpuUsageRatioThreshold: 0.65,
+	}
+	c := pkgeviction.NumaCPUPressureEvictionConfiguration{}
+
+	err := o.ApplyTo(&c)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.3, c.ThresholdExpandFactor, "ApplyTo should propagate custom ThresholdExpandFactor")
+	assert.Equal(t, 0.65, c.CpuUsageRatioThreshold, "ApplyTo should propagate custom CpuUsageRatioThreshold")
+}
+
+func TestNumaCPUPressureEvictionOptions_ApplyTo_ZeroCpuUsageRatioThreshold(t *testing.T) {
+	t.Parallel()
+
+	o := NumaCPUPressureEvictionOptions{
+		ThresholdExpandFactor:  7.0 / 6.0,
+		CpuUsageRatioThreshold: 0,
+	}
+	c := pkgeviction.NumaCPUPressureEvictionConfiguration{}
+
+	err := o.ApplyTo(&c)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(0), c.CpuUsageRatioThreshold,
+		"ApplyTo should propagate CpuUsageRatioThreshold=0, which means fallback to NPD")
+}
+
+func TestNumaCPUPressureEvictionOptions_EvictionTriggerLine(t *testing.T) {
+	t.Parallel()
+
+	o := NewNumaCPUPressureEvictionOptions()
+	c := pkgeviction.NumaCPUPressureEvictionConfiguration{}
+	_ = o.ApplyTo(&c)
+
+	evictionTriggerLine := c.CpuUsageRatioThreshold * c.ThresholdExpandFactor
+	safetyLine := evictionTriggerLine / c.ThresholdExpandFactor
+
+	assert.InDelta(t, 0.7, evictionTriggerLine, 1e-9,
+		"eviction trigger line = 0.6 * 7/6 = 0.7")
+	assert.InDelta(t, 0.6, safetyLine, 1e-9,
+		"safety line = 0.7 / (7/6) = 0.6")
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold.go
@@ -48,7 +48,15 @@ func (p *NumaCPUPressureEviction) pullThresholds(_ context.Context) {
 
 	numaPressureConfig := getNumaPressureConfig(dynamicConf)
 
-	thresholds := threshold.GetMetricThresholds(targetThresholdNames, p.metaServer, dynamicConf.MetricThresholdConfiguration.Threshold)
+	var thresholds map[string]float64
+	if dynamicConf.NumaCPUPressureEvictionConfiguration.CpuUsageRatioThreshold > 0 {
+		thresholds = map[string]float64{
+			metricthreshold.NUMACPUUsageRatioThreshold: dynamicConf.NumaCPUPressureEvictionConfiguration.CpuUsageRatioThreshold,
+		}
+		general.Infof("use CpuUsageRatioThreshold from AQC: %v", thresholds)
+	} else {
+		thresholds = threshold.GetMetricThresholds(targetThresholdNames, p.metaServer, dynamicConf.MetricThresholdConfiguration.Threshold)
+	}
 	if thresholds == nil {
 		general.Errorf("got no valid threshold")
 		return

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_threshold_test.go
@@ -96,7 +96,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, false, true),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -112,7 +112,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, false, false),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -128,7 +128,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, true, true),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -144,7 +144,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, true, false),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -160,7 +160,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, false, false),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -176,7 +176,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, true, false),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -192,7 +192,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, false, true),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -208,7 +208,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, true, true),
 				enabled: false,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -224,7 +224,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, false, true),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -240,7 +240,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, false, false),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -256,7 +256,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, true, true),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -272,7 +272,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(true, true, false),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor: 1,
+					ExpandFactor: 7.0 / 6.0,
 				},
 			},
 			setFakeMetric: func(store *metric.FakeMetricsFetcher) {
@@ -287,7 +287,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, false, false),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -303,7 +303,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, true, false),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -319,7 +319,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, false, true),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},
@@ -335,7 +335,7 @@ func TestNumaCPUPressureEviction_pullThresholds(t *testing.T) {
 				conf:    generatePluginConfig(false, true, true),
 				enabled: true,
 				numaPressureConfig: &rules.NumaPressureConfig{
-					ExpandFactor:   1,
+					ExpandFactor:   7.0 / 6.0,
 					MetricRingSize: 2,
 				},
 			},

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_usage_numa_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_usage_numa_test.go
@@ -188,7 +188,7 @@ func TestNumaCPUPressureEviction_update(t *testing.T) {
 					MetricRingSize:         1,
 					ThresholdMetPercentage: conf.DynamicAgentConfiguration.GetDynamicConfiguration().ThresholdMetPercentage,
 					GracePeriod:            conf.DynamicAgentConfiguration.GetDynamicConfiguration().DeletionGracePeriod,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 				},
 				setFakeMetric: func(store *metric.FakeMetricsFetcher) {
 					store.SetContainerNumaMetric("pod1", "container", 0,
@@ -228,7 +228,7 @@ func TestNumaCPUPressureEviction_update(t *testing.T) {
 					MetricRingSize:         1,
 					ThresholdMetPercentage: conf.DynamicAgentConfiguration.GetDynamicConfiguration().NumaCPUPressureEvictionConfiguration.ThresholdMetPercentage,
 					GracePeriod:            conf.DynamicAgentConfiguration.GetDynamicConfiguration().DeletionGracePeriod,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 				},
 				setFakeMetric: func(store *metric.FakeMetricsFetcher) {
 					store.SetContainerNumaMetric("pod1", "container", 0,
@@ -497,7 +497,7 @@ func TestNumaCPUPressureEviction_GetTopEvictionPods(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            -1,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 					SkippedPodKinds:        []string{"DaemonSet"},
 					EnabledFilters:         []string{rules.OwnerRefFilterName},
 				},
@@ -551,7 +551,7 @@ func TestNumaCPUPressureEviction_GetTopEvictionPods(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            -1,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 					SkippedPodKinds:        []string{"DaemonSet"},
 					EnabledFilters:         []string{rules.OwnerRefFilterName},
 					EnabledScorers:         []string{rules.ScorerNameUsageGap},
@@ -627,7 +627,7 @@ func TestNumaCPUPressureEviction_GetTopEvictionPods(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            -1,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 					EnabledScorers:         []string{rules.ScorerNameUsageGap},
 				},
 				metricsHistory: &util.NumaMetricHistory{
@@ -701,7 +701,7 @@ func TestNumaCPUPressureEviction_GetTopEvictionPods(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            30,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 					EnabledScorers:         []string{rules.ScorerNameUsageGap},
 					SkippedPodKinds:        []string{"DaemonSet"},
 					EnabledFilters:         []string{rules.OwnerRefFilterName},
@@ -869,7 +869,7 @@ func TestNumaCPUPressureEviction_ThresholdMet(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            -1,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 				},
 				metricsHistory: &util.NumaMetricHistory{
 					Inner: map[int]map[string]map[string]*util.MetricRing{
@@ -951,7 +951,7 @@ func TestNumaCPUPressureEviction_ThresholdMet(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            -1,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 				},
 				metricsHistory: &util.NumaMetricHistory{
 					Inner: map[int]map[string]map[string]*util.MetricRing{
@@ -1157,7 +1157,7 @@ func TestNumaCPUPressureEviction_calOverloadNumaCount(t *testing.T) {
 					MetricRingSize:         2,
 					ThresholdMetPercentage: 0.5,
 					GracePeriod:            -1,
-					ExpandFactor:           1.2,
+					ExpandFactor:           7.0 / 6.0,
 				},
 				metricsHistory: &util.NumaMetricHistory{
 					Inner: map[int]map[string]map[string]*util.MetricRing{

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/cpu/advisor_test.go
@@ -1479,7 +1479,7 @@ func TestAdvisorUpdate(t *testing.T) {
 					},
 					{
 						Name:   workloadapis.ServiceSystemIndicatorNameCPUUsageRatio,
-						Target: 0.55,
+						Target: 0.6,
 					},
 				},
 			}

--- a/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
+++ b/pkg/agent/sysadvisor/plugin/qosaware/resource/helper/modelctrl/borwein/borwein_test.go
@@ -828,7 +828,7 @@ func TestBorweinController_getUpdatedIndicators(t *testing.T) {
 				restrictIndicator: true,
 			},
 			want: types.Indicator{
-				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): types.IndicatorValue{Current: 0.45, Target: 0.55},
+				string(workloadv1alpha1.ServiceSystemIndicatorNameCPUUsageRatio): types.IndicatorValue{Current: 0.45, Target: 0.6},
 			},
 		},
 		{

--- a/pkg/config/agent/dynamic/adminqos/eviction/numa_cpu_pressure_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/numa_cpu_pressure_eviction.go
@@ -26,6 +26,7 @@ type NumaCPUPressureEvictionConfiguration struct {
 	MetricRingSize                 int
 	GracePeriod                    int64
 	ThresholdExpandFactor          float64
+	CpuUsageRatioThreshold         float64
 	CandidateCount                 int
 	WorkloadMetricsLabelKeys       []string
 	SkippedPodKinds                []string
@@ -61,6 +62,11 @@ func (n *NumaCPUPressureEvictionConfiguration) ApplyConfiguration(conf *crd.Dyna
 		if config.ThresholdExpandFactor != nil {
 			n.ThresholdExpandFactor = *config.ThresholdExpandFactor
 		}
+
+		// TODO: Uncomment after katalyst-api adds CpuUsageRatioThreshold field to NumaCPUPressureEvictionConfig
+		// if config.CpuUsageRatioThreshold != nil {
+		//     n.CpuUsageRatioThreshold = *config.CpuUsageRatioThreshold
+		// }
 
 		if config.CandidateCount != nil {
 			n.CandidateCount = *config.CandidateCount

--- a/pkg/config/agent/dynamic/adminqos/eviction/numa_cpu_pressure_eviction_test.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/numa_cpu_pressure_eviction_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configv1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/metricthreshold"
+)
+
+func TestNumaCPUPressureEvictionConfiguration_ApplyConfiguration_CRDNil(t *testing.T) {
+	t.Parallel()
+
+	c := NumaCPUPressureEvictionConfiguration{
+		ThresholdExpandFactor:  7.0 / 6.0,
+		CpuUsageRatioThreshold: 0.6,
+	}
+
+	c.ApplyConfiguration(&crd.DynamicConfigCRD{})
+
+	assert.Equal(t, 0.6, c.CpuUsageRatioThreshold,
+		"when CRD is nil, CpuUsageRatioThreshold should remain unchanged (Options default 0.6)")
+	assert.Equal(t, 7.0/6.0, c.ThresholdExpandFactor,
+		"when CRD is nil, ThresholdExpandFactor should remain unchanged (Options default 7/6)")
+}
+
+func TestNumaCPUPressureEvictionConfiguration_ApplyConfiguration_CRDEmptyField(t *testing.T) {
+	t.Parallel()
+
+	c := NumaCPUPressureEvictionConfiguration{
+		ThresholdExpandFactor:  7.0 / 6.0,
+		CpuUsageRatioThreshold: 0.6,
+	}
+
+	conf := &crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &configv1alpha1.AdminQoSConfiguration{
+			Spec: configv1alpha1.AdminQoSConfigurationSpec{
+				Config: configv1alpha1.AdminQoSConfig{
+					EvictionConfig: &configv1alpha1.EvictionConfig{
+						CPUPressureEvictionConfig: &configv1alpha1.CPUPressureEvictionConfig{
+							NumaCPUPressureEvictionConfig: configv1alpha1.NumaCPUPressureEvictionConfig{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c.ApplyConfiguration(conf)
+
+	assert.Equal(t, 0.6, c.CpuUsageRatioThreshold,
+		"when CRD NumaCPUPressureEvictionConfig exists but CpuUsageRatioThreshold field is nil "+
+			"(not yet in katalyst-api), CpuUsageRatioThreshold should remain 0.6")
+	assert.Equal(t, 7.0/6.0, c.ThresholdExpandFactor,
+		"when CRD ThresholdExpandFactor is nil, it should remain 7/6")
+}
+
+func TestNumaCPUPressureEvictionConfiguration_ApplyConfiguration_CRDThresholdExpandFactorOverride(t *testing.T) {
+	t.Parallel()
+
+	c := NumaCPUPressureEvictionConfiguration{
+		ThresholdExpandFactor:  7.0 / 6.0,
+		CpuUsageRatioThreshold: 0.6,
+	}
+
+	expandFactorOverride := 1.3
+	conf := &crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &configv1alpha1.AdminQoSConfiguration{
+			Spec: configv1alpha1.AdminQoSConfigurationSpec{
+				Config: configv1alpha1.AdminQoSConfig{
+					EvictionConfig: &configv1alpha1.EvictionConfig{
+						CPUPressureEvictionConfig: &configv1alpha1.CPUPressureEvictionConfig{
+							NumaCPUPressureEvictionConfig: configv1alpha1.NumaCPUPressureEvictionConfig{
+								ThresholdExpandFactor: &expandFactorOverride,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c.ApplyConfiguration(conf)
+
+	assert.Equal(t, 1.3, c.ThresholdExpandFactor,
+		"when CRD ThresholdExpandFactor is set, it should override the Options default value")
+	assert.Equal(t, 0.6, c.CpuUsageRatioThreshold,
+		"when CRD CpuUsageRatioThreshold is nil (not yet in katalyst-api), it should remain 0.6")
+}
+
+func TestNumaCPUPressureEvictionConfiguration_EvictionTriggerLine(t *testing.T) {
+	t.Parallel()
+
+	c := NumaCPUPressureEvictionConfiguration{
+		ThresholdExpandFactor:  7.0 / 6.0,
+		CpuUsageRatioThreshold: 0.6,
+	}
+
+	evictionTriggerLine := c.CpuUsageRatioThreshold * c.ThresholdExpandFactor
+	safetyLine := evictionTriggerLine / c.ThresholdExpandFactor
+	buffer := evictionTriggerLine - safetyLine
+
+	assert.InDelta(t, 0.7, evictionTriggerLine, 1e-9,
+		"eviction trigger line = CpuUsageRatioThreshold * ThresholdExpandFactor = 0.6 * 7/6 = 0.7")
+	assert.InDelta(t, 0.6, safetyLine, 1e-9,
+		"safety line = evictionTriggerLine / ThresholdExpandFactor = 0.7 / (7/6) = 0.6")
+	assert.InDelta(t, 0.1, buffer, 1e-9,
+		"buffer = evictionTriggerLine - safetyLine = 0.7 - 0.6 = 0.1")
+}
+
+func TestPullThresholds_CpuUsageRatioThresholdPriority(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		cpuUsageRatioThreshold float64
+		expandFactor           float64
+		wantUseAQC             bool
+		wantThresholdValue     float64
+		wantEvictionLine       float64
+	}{
+		{
+			name:                   "CpuUsageRatioThreshold > 0: use AQC value",
+			cpuUsageRatioThreshold: 0.6,
+			expandFactor:           7.0 / 6.0,
+			wantUseAQC:             true,
+			wantThresholdValue:     0.6,
+			wantEvictionLine:       0.7,
+		},
+		{
+			name:                   "CpuUsageRatioThreshold = 0: fallback to NPD/MetricThresholdConfiguration",
+			cpuUsageRatioThreshold: 0,
+			expandFactor:           7.0 / 6.0,
+			wantUseAQC:             false,
+			wantThresholdValue:     0,
+			wantEvictionLine:       0,
+		},
+		{
+			name:                   "CpuUsageRatioThreshold = 0.65 with custom expand factor",
+			cpuUsageRatioThreshold: 0.65,
+			expandFactor:           1.2,
+			wantUseAQC:             true,
+			wantThresholdValue:     0.65,
+			wantEvictionLine:       0.78,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conf := NumaCPUPressureEvictionConfiguration{
+				CpuUsageRatioThreshold: tt.cpuUsageRatioThreshold,
+				ThresholdExpandFactor:  tt.expandFactor,
+			}
+
+			if tt.wantUseAQC {
+				assert.True(t, conf.CpuUsageRatioThreshold > 0,
+					"CpuUsageRatioThreshold > 0 should trigger AQC priority path")
+
+				thresholds := map[string]float64{
+					metricthreshold.NUMACPUUsageRatioThreshold: conf.CpuUsageRatioThreshold,
+				}
+				assert.Equal(t, tt.wantThresholdValue, thresholds[metricthreshold.NUMACPUUsageRatioThreshold])
+
+				expandedThresholds := make(map[string]float64)
+				for k, v := range thresholds {
+					expandedThresholds[k] = v * conf.ThresholdExpandFactor
+				}
+				assert.InDelta(t, tt.wantEvictionLine,
+					expandedThresholds[metricthreshold.NUMACPUUsageRatioThreshold], 1e-9)
+			} else {
+				assert.Equal(t, float64(0), conf.CpuUsageRatioThreshold,
+					"CpuUsageRatioThreshold == 0 should fallback to NPD/MetricThresholdConfiguration")
+			}
+		})
+	}
+}
+
+func TestNumaCPUPressureEvictionConfiguration_FullDataFlow(t *testing.T) {
+	t.Parallel()
+
+	c := NumaCPUPressureEvictionConfiguration{
+		ThresholdExpandFactor:  7.0 / 6.0,
+		CpuUsageRatioThreshold: 0.6,
+	}
+
+	c.ApplyConfiguration(&crd.DynamicConfigCRD{})
+
+	assert.True(t, c.CpuUsageRatioThreshold > 0,
+		"CpuUsageRatioThreshold > 0 should trigger AQC priority path in pullThresholds")
+
+	thresholds := map[string]float64{
+		metricthreshold.NUMACPUUsageRatioThreshold: c.CpuUsageRatioThreshold,
+	}
+
+	convertedThresholds := make(map[string]float64)
+	for k, v := range thresholds {
+		newKey, ok := metricthreshold.ThresholdNameToResourceName[k]
+		assert.True(t, ok, "threshold name %s should have a mapping", k)
+		convertedThresholds[newKey] = v
+	}
+
+	expandedThresholds := make(map[string]float64)
+	for k, v := range convertedThresholds {
+		expandedThresholds[k] = v * c.ThresholdExpandFactor
+	}
+
+	evictionTriggerLine := expandedThresholds["cpu.usage.container"]
+	safetyLine := evictionTriggerLine / c.ThresholdExpandFactor
+
+	assert.InDelta(t, 0.7, evictionTriggerLine, 1e-9,
+		"full data flow: eviction trigger line should be 0.7 (70%%)")
+	assert.InDelta(t, 0.6, safetyLine, 1e-9,
+		"full data flow: safety line should be 0.6 (60%%)")
+}

--- a/pkg/config/agent/sysadvisor/qosaware/model/borwein/borwein.go
+++ b/pkg/config/agent/sysadvisor/qosaware/model/borwein/borwein.go
@@ -41,7 +41,7 @@ func NewBorweinConfiguration() *BorweinConfiguration {
 				OffsetMin:    -0.12,
 				Version:      "default",
 				IndicatorMax: 0.85,
-				IndicatorMin: 0.55,
+				IndicatorMin: 0.6,
 			},
 		},
 		NodeFeatureNames:      []string{},


### PR DESCRIPTION

#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
The NUMA CPU pressure eviction strategy shares the same threshold with the SysAdvisor yield mechanism ( MetricThresholdConfiguration.NUMACPUUsageRatioThreshold ), but they have different semantics: yield should trigger early (low threshold), while eviction should trigger later (high threshold). Additionally, NPD internal plugins write cpu_usage_threshold=550m which silently overrides the code default, and the eviction threshold cannot be adjusted at runtime.

This PR adds a dedicated CpuUsageRatioThreshold field to NumaCPUPressureEvictionConfiguration , raising the default eviction trigger line from ~60.5% to 70%, and establishes the priority chain: AQC CpuUsageRatioThreshold > NPD metric-threshold > MetricThresholdConfiguration.

Default value math:

- CpuUsageRatioThreshold=0.6 , ExpandFactor=7/6
- Eviction trigger line = 0.6 × 7/6 = 0.7 (70%)
- Safety line = 0.7 / (7/6) = 0.6 (60%)
- Buffer = 0.7 - 0.6 = 0.1 (10%)

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
- The CRD read for CpuUsageRatioThreshold in ApplyConfiguration() is commented out with a TODO placeholder, pending katalyst-api adding this field. Currently it only takes effect via the command-line flag --numa-cpu-pressure-eviction-cpu-usage-ratio-threshold or the code default value
- MetricThresholdConfiguration per-CPU-model thresholds (0.47~0.59) are unchanged; SysAdvisor yield mechanism is unaffected
- cpu_provision.go Dedicated Region Target: 0.55 is unchanged
- Borwein IndicatorMin is updated from 0.55 to 0.6 to align with the new eviction safety line
