### PR TITLE
feat(gpu): bin-packing of devices considered over different priority levels

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/deviceaffinity/bind.go
+++ b/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/deviceaffinity/bind.go
@@ -242,20 +242,23 @@ func (s *DeviceAffinityStrategy) allocateCandidateDevices(
 		return allocatedDevices, nil
 	}
 
+	// Pre-calculate groupInfos for all priority levels
+	groupInfosByPriority := make([][]groupInfo, len(affinityGroupsByPriority))
+	for p, affinityGroups := range affinityGroupsByPriority {
+		groupInfosByPriority[p] = s.prepareGroupInfos(affinityGroups, candidateDevicesSet, allocatedDevices)
+	}
+
 	// Process affinity groups from highest to lowest priority
 	for priority, affinityGroups := range affinityGroupsByPriority {
 		if len(affinityGroups) == 0 {
 			continue
 		}
 
-		// Prepare group information for evaluation
-		groupInfos := s.prepareGroupInfos(affinityGroups, candidateDevicesSet, allocatedDevices)
+		// Sort groups by allocation suitability
+		groupInfos := s.sortGroupsByPriority(groupInfosByPriority, priority, remainingDevicesToAllocate)
 		if len(groupInfos) == 0 {
 			continue
 		}
-
-		// Sort groups by allocation suitability
-		s.sortGroupsByPriority(groupInfos, remainingDevicesToAllocate)
 
 		// Try to allocate from the best matching groups
 		if result, fullyAllocated := s.tryAllocateFromGroups(
@@ -323,9 +326,15 @@ func (s *DeviceAffinityStrategy) prepareGroupInfos(
 // 2. Total unallocated devices (smaller is better to minimize fragmentation)
 // 3. Already allocated devices (larger is better to maintain consistency)
 func (s *DeviceAffinityStrategy) sortGroupsByPriority(
-	groupInfos []groupInfo,
+	groupInfosByPriority [][]groupInfo,
+	currentPriority int,
 	remainingDevicesToAllocate int,
-) {
+) []groupInfo {
+	groupInfos := groupInfosByPriority[currentPriority]
+	if len(groupInfos) == 0 {
+		return groupInfos
+	}
+
 	sort.Slice(groupInfos, func(i, j int) bool {
 		// Calculate absolute difference from needed devices
 		diffI := abs(groupInfos[i].candidates.Len() - remainingDevicesToAllocate)
@@ -341,6 +350,22 @@ func (s *DeviceAffinityStrategy) sortGroupsByPriority(
 			return groupInfos[i].unallocated.Len() < groupInfos[j].unallocated.Len()
 		}
 
+		// Check lower priority levels (larger groups) for fewer unallocated devices
+		for p := currentPriority + 1; p < len(groupInfosByPriority); p++ {
+			var unallocI, unallocJ int
+			for _, g := range groupInfosByPriority[p] {
+				if g.group.unallocatedDevices.HasAll(groupInfos[i].unallocated.UnsortedList()...) {
+					unallocI = g.unallocated.Len()
+				}
+				if g.group.unallocatedDevices.HasAll(groupInfos[j].unallocated.UnsortedList()...) {
+					unallocJ = g.unallocated.Len()
+				}
+			}
+			if unallocI != unallocJ {
+				return unallocI < unallocJ
+			}
+		}
+
 		// Prefer groups with more already allocated devices for consistency
 		if groupInfos[i].allocated.Len() != groupInfos[j].allocated.Len() {
 			return groupInfos[i].allocated.Len() > groupInfos[j].allocated.Len()
@@ -348,6 +373,8 @@ func (s *DeviceAffinityStrategy) sortGroupsByPriority(
 
 		return groupInfos[i].group.id < groupInfos[j].group.id
 	})
+
+	return groupInfos
 }
 
 // tryAllocateFromGroups attempts to allocate devices from the prioritized groups.

--- a/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/deviceaffinity/bind_test.go
+++ b/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/deviceaffinity/bind_test.go
@@ -1327,6 +1327,78 @@ func TestBind_NumberOfDevicesAllocated(t *testing.T) {
 				Success:          true,
 			},
 		},
+		{
+			name: "bin-packing checks lower priority levels to resolve ties at current priority",
+			ctx: &allocate.AllocationContext{
+				ResourceReq: &pluginapi.ResourceRequest{
+					PodUid:        "pod-1",
+					ContainerName: "container-1",
+				},
+				DeviceReq: &pluginapi.DeviceRequest{
+					DeviceName:      "gpu",
+					ReusableDevices: nil,
+					DeviceRequest:   2,
+				},
+				DeviceTopology: &machine.DeviceTopology{
+					PriorityDimensions: []string{"0", "1"},
+					Devices: map[string]machine.DeviceInfo{
+						"gpu-1": {Dimensions: dims(dimLevel(0, "g12"), dimLevel(1, "g1234"))},
+						"gpu-2": {Dimensions: dims(dimLevel(0, "g12"), dimLevel(1, "g1234"))},
+						"gpu-3": {Dimensions: dims(dimLevel(0, "g34"), dimLevel(1, "g1234"))},
+						"gpu-4": {Dimensions: dims(dimLevel(0, "g34"), dimLevel(1, "g1234"))},
+						"gpu-5": {Dimensions: dims(dimLevel(0, "g56"), dimLevel(1, "g5678"))},
+						"gpu-6": {Dimensions: dims(dimLevel(0, "g56"), dimLevel(1, "g5678"))},
+						"gpu-7": {Dimensions: dims(dimLevel(0, "g78"), dimLevel(1, "g5678"))},
+						"gpu-8": {Dimensions: dims(dimLevel(0, "g78"), dimLevel(1, "g5678"))},
+					},
+				},
+			},
+			sortedDevices: []string{"gpu-3", "gpu-4", "gpu-6", "gpu-7", "gpu-8"},
+			expectedResult: &allocate.AllocationResult{
+				AllocatedDevices: []string{"gpu-3", "gpu-4"},
+				Success:          true,
+			},
+		},
+		{
+			name: "bin-packing checks multiple lower priority levels to resolve ties",
+			ctx: &allocate.AllocationContext{
+				ResourceReq: &pluginapi.ResourceRequest{
+					PodUid:        "pod-1",
+					ContainerName: "container-1",
+				},
+				DeviceReq: &pluginapi.DeviceRequest{
+					DeviceName:      "gpu",
+					ReusableDevices: nil,
+					DeviceRequest:   2,
+				},
+				DeviceTopology: &machine.DeviceTopology{
+					PriorityDimensions: []string{"0", "1", "2"},
+					Devices: map[string]machine.DeviceInfo{
+						"gpu-1":  {Dimensions: dims(dimLevel(0, "g12"), dimLevel(1, "g1234"), dimLevel(2, "g1-8"))},
+						"gpu-2":  {Dimensions: dims(dimLevel(0, "g12"), dimLevel(1, "g1234"), dimLevel(2, "g1-8"))},
+						"gpu-3":  {Dimensions: dims(dimLevel(0, "g34"), dimLevel(1, "g1234"), dimLevel(2, "g1-8"))},
+						"gpu-4":  {Dimensions: dims(dimLevel(0, "g34"), dimLevel(1, "g1234"), dimLevel(2, "g1-8"))},
+						"gpu-5":  {Dimensions: dims(dimLevel(0, "g56"), dimLevel(1, "g5678"), dimLevel(2, "g1-8"))},
+						"gpu-6":  {Dimensions: dims(dimLevel(0, "g56"), dimLevel(1, "g5678"), dimLevel(2, "g1-8"))},
+						"gpu-7":  {Dimensions: dims(dimLevel(0, "g78"), dimLevel(1, "g5678"), dimLevel(2, "g1-8"))},
+						"gpu-8":  {Dimensions: dims(dimLevel(0, "g78"), dimLevel(1, "g5678"), dimLevel(2, "g1-8"))},
+						"gpu-9":  {Dimensions: dims(dimLevel(0, "g910"), dimLevel(1, "g9-12"), dimLevel(2, "g9-16"))},
+						"gpu-10": {Dimensions: dims(dimLevel(0, "g910"), dimLevel(1, "g9-12"), dimLevel(2, "g9-16"))},
+						"gpu-11": {Dimensions: dims(dimLevel(0, "g1112"), dimLevel(1, "g9-12"), dimLevel(2, "g9-16"))},
+						"gpu-12": {Dimensions: dims(dimLevel(0, "g1112"), dimLevel(1, "g9-12"), dimLevel(2, "g9-16"))},
+						"gpu-13": {Dimensions: dims(dimLevel(0, "g1314"), dimLevel(1, "g13-16"), dimLevel(2, "g9-16"))},
+						"gpu-14": {Dimensions: dims(dimLevel(0, "g1314"), dimLevel(1, "g13-16"), dimLevel(2, "g9-16"))},
+						"gpu-15": {Dimensions: dims(dimLevel(0, "g1516"), dimLevel(1, "g13-16"), dimLevel(2, "g9-16"))},
+						"gpu-16": {Dimensions: dims(dimLevel(0, "g1516"), dimLevel(1, "g13-16"), dimLevel(2, "g9-16"))},
+					},
+				},
+			},
+			sortedDevices: []string{"gpu-3", "gpu-4", "gpu-11", "gpu-12", "gpu-16"},
+			expectedResult: &allocate.AllocationResult{
+				AllocatedDevices: []string{"gpu-3", "gpu-4"},
+				Success:          true,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Currently, bin-packing of devices is only considered within the same priority. We should consider bin-packing across different priority levels. 

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
