### PR TITLE
metrics(qrm): mbm throttle metrics

### DIFF
--- a/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
@@ -35,7 +35,6 @@ const (
 	nameMBMAdjustedOutgoingTarget = "mbm_outgoing_target_adjusted"
 	namePlanRaw                   = "mbm_plan_raw"
 	namePlanUpdate                = "mbm_plan_update"
-	nameMBMCCDSuppressed          = "mbm_ccd_suppressed"
 
 	suppressionTypeDomainStress = "domain_stress"
 	suppressionTypeCCDLimit     = "ccd_limit"
@@ -123,26 +122,6 @@ func emitKV(emitter metrics.MetricEmitter, k string, v int, tags map[string]stri
 		metrics.MetricTypeNameRaw,
 		metrics.ConvertMapToTags(tags)...,
 	)
-}
-
-func emitCCDSuppressionTypes(emitter metrics.MetricEmitter, domGroupCCDTypes map[int]map[string]map[int]string) {
-	for domID, groupCCDTypes := range domGroupCCDTypes {
-		for group, ccdTypes := range groupCCDTypes {
-			for ccdID, suppressionType := range ccdTypes {
-				emitCCDSuppressed(emitter, domID, group, ccdID, suppressionType)
-			}
-		}
-	}
-}
-
-func emitCCDSuppressed(emitter metrics.MetricEmitter, domID int, group string, ccdID int, suppressionType string) {
-	tags := map[string]string{
-		"domain": fmt.Sprintf("%d", domID),
-		"group":  group,
-		"ccd":    fmt.Sprintf("%d", ccdID),
-		"type":   suppressionType,
-	}
-	emitKV(emitter, nameMBMCCDSuppressed, 1, tags)
 }
 
 func emitNamedGroupTargets(emitter metrics.MetricEmitter, name string, groupedDomTargets map[string][]int) {

--- a/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
@@ -35,6 +35,10 @@ const (
 	nameMBMAdjustedOutgoingTarget = "mbm_outgoing_target_adjusted"
 	namePlanRaw                   = "mbm_plan_raw"
 	namePlanUpdate                = "mbm_plan_update"
+	nameMBMCCDSuppressed          = "mbm_ccd_suppressed"
+
+	suppressionTypeDomainStress = "domain_stress"
+	suppressionTypeCCDLimit     = "ccd_limit"
 )
 
 func (a *uniqPriorityAdvisor) emitDomIncomingStatSummaryMetrics(domLimits map[int]*resource.MBGroupIncomingStat) {
@@ -119,6 +123,16 @@ func emitKV(emitter metrics.MetricEmitter, k string, v int, tags map[string]stri
 		metrics.MetricTypeNameRaw,
 		metrics.ConvertMapToTags(tags)...,
 	)
+}
+
+func emitCCDSuppressed(emitter metrics.MetricEmitter, domID int, group string, ccdID int, suppressionType string) {
+	tags := map[string]string{
+		"domain": fmt.Sprintf("%d", domID),
+		"group":  group,
+		"ccd":    fmt.Sprintf("%d", ccdID),
+		"type":   suppressionType,
+	}
+	emitKV(emitter, nameMBMCCDSuppressed, 1, tags)
 }
 
 func emitNamedGroupTargets(emitter metrics.MetricEmitter, name string, groupedDomTargets map[string][]int) {

--- a/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
@@ -125,6 +125,16 @@ func emitKV(emitter metrics.MetricEmitter, k string, v int, tags map[string]stri
 	)
 }
 
+func emitCCDSuppressionTypes(emitter metrics.MetricEmitter, domGroupCCDTypes map[int]map[string]map[int]string) {
+	for domID, groupCCDTypes := range domGroupCCDTypes {
+		for group, ccdTypes := range groupCCDTypes {
+			for ccdID, suppressionType := range ccdTypes {
+				emitCCDSuppressed(emitter, domID, group, ccdID, suppressionType)
+			}
+		}
+	}
+}
+
 func emitCCDSuppressed(emitter metrics.MetricEmitter, domID int, group string, ccdID int, suppressionType string) {
 	tags := map[string]string{
 		"domain": fmt.Sprintf("%d", domID),

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
 
@@ -32,6 +33,7 @@ import (
 type pControllerAdvisor struct {
 	ccdMinMB, ccdMaxMB int
 	inner              Advisor
+	emitter            metrics.MetricEmitter
 
 	groupStates map[string]*groupPCtrlState
 }
@@ -50,6 +52,8 @@ func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Do
 	for group, state := range p.groupStates {
 		p.restrictGroupCCDCap(group, state, domainsMon, result)
 	}
+
+	p.detectCCDLimitSuppression(domainsMon)
 
 	return result, nil
 }
@@ -99,6 +103,31 @@ func (p *pControllerAdvisor) maxObservedCCDMBForGroup(outgoings map[int]monitor.
 	return max
 }
 
+func (p *pControllerAdvisor) detectCCDLimitSuppression(domainsMon *monitor.DomainStats) {
+	if p.emitter == nil {
+		return
+	}
+
+	for group, state := range p.groupStates {
+		target := state.pCtrl.target
+		if target <= 0 || state.ccdCapMB >= p.ccdMaxMB {
+			continue
+		}
+
+		for domID, domStats := range domainsMon.Outgoings {
+			ccdStats, ok := domStats[group]
+			if !ok {
+				continue
+			}
+			for ccd, mbInfo := range ccdStats {
+				if mbInfo.TotalMB >= target {
+					emitCCDSuppressed(p.emitter, domID, group, ccd, suppressionTypeCCDLimit)
+				}
+			}
+		}
+	}
+}
+
 func applyGroupCCDBoundsChecks(ccdMBs plan.GroupCCDPlan, lower, upper int) {
 	for ccd, mb := range ccdMBs {
 		ccdMBs[ccd] = clampMB(mb, lower, upper)
@@ -120,6 +149,7 @@ func NewPControllerAdvisor(Kp float64,
 	minValue, maxValue int,
 	groupTargets map[string]int,
 	inner Advisor,
+	emitter metrics.MetricEmitter,
 ) Advisor {
 	groupStates := make(map[string]*groupPCtrlState, len(groupTargets))
 	for group, target := range groupTargets {
@@ -136,6 +166,7 @@ func NewPControllerAdvisor(Kp float64,
 		ccdMinMB:    minValue,
 		ccdMaxMB:    maxValue,
 		inner:       inner,
+		emitter:     emitter,
 		groupStates: groupStates,
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -35,7 +35,8 @@ type pControllerAdvisor struct {
 	inner              Advisor
 	emitter            metrics.MetricEmitter
 
-	groupStates map[string]*groupPCtrlState
+	groupStates             map[string]*groupPCtrlState
+	lastCCDLimitSuppression map[int]map[string]map[int]string
 }
 
 type groupPCtrlState struct {
@@ -53,11 +54,33 @@ func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Do
 		p.restrictGroupCCDCap(group, state, domainsMon, result)
 	}
 
+	p.lastCCDLimitSuppression = p.getCCDLimitSuppression(domainsMon)
 	if p.emitter != nil {
-		emitCCDSuppressionTypes(p.emitter, p.getCCDLimitSuppression(domainsMon))
+		emitCCDSuppressionTypes(p.emitter, p.lastCCDLimitSuppression)
 	}
 
 	return result, nil
+}
+
+func (p *pControllerAdvisor) GetSuppressedCCDs() []SuppressedCCD {
+	innerSuppressed := p.inner.GetSuppressedCCDs()
+
+	var result []SuppressedCCD
+	for domID, groupCCDTypes := range p.lastCCDLimitSuppression {
+		for group, ccdTypes := range groupCCDTypes {
+			for ccdID, suppressionType := range ccdTypes {
+				result = append(result, SuppressedCCD{
+					DomID:           domID,
+					Group:           group,
+					CCDID:           ccdID,
+					SuppressionType: suppressionType,
+				})
+			}
+		}
+	}
+	result = append(result, innerSuppressed...)
+
+	return result
 }
 
 func (p *pControllerAdvisor) restrictGroupCCDCap(group string, groupState *groupPCtrlState,
@@ -74,7 +97,7 @@ func (p *pControllerAdvisor) restrictGroupCCDCap(group string, groupState *group
 	applyGroupCCDBoundsChecks(ccdMBs, p.ccdMinMB, groupState.ccdCapMB)
 
 	if klog.V(6).Enabled() {
-		general.InfofV(6, "[mbm] [pController] group=%s maxObserved=%d target=%d cap=%d",
+		general.Infof("[mbm] [pController] group=%s maxObserved=%d target=%d cap=%d",
 			group, maxObservedMB, groupState.pCtrl.target, groupState.ccdCapMB)
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -18,12 +18,12 @@ package advisor
 
 import (
 	"context"
+	"sync"
 
 	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
-	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
 
@@ -31,9 +31,10 @@ import (
 // based on P-Controler (Proportional Controller) of closed-looped automation system to compare output feedback
 // against a target value and adjust inputs in predefined ratio Kp to achieve a desired state
 type pControllerAdvisor struct {
+	mu sync.Mutex
+
 	ccdMinMB, ccdMaxMB int
 	inner              Advisor
-	emitter            metrics.MetricEmitter
 
 	groupStates             map[string]*groupPCtrlState
 	lastCCDLimitSuppression map[int]map[string]map[int]string
@@ -50,35 +51,29 @@ func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Do
 		return nil, err
 	}
 
+	p.mu.Lock()
 	for group, state := range p.groupStates {
 		p.restrictGroupCCDCap(group, state, domainsMon, result)
 	}
 
-	p.lastCCDLimitSuppression = p.getCCDLimitSuppression(domainsMon)
-	if p.emitter != nil {
-		emitCCDSuppressionTypes(p.emitter, p.lastCCDLimitSuppression)
-	}
+	suppression := computeCCDLimitSuppression(domainsMon, p.groupStates, p.ccdMaxMB)
+	p.lastCCDLimitSuppression = suppression
+	p.mu.Unlock()
 
 	return result, nil
 }
 
 func (p *pControllerAdvisor) GetSuppressedCCDs() []SuppressedCCD {
+	p.mu.Lock()
 	innerSuppressed := p.inner.GetSuppressedCCDs()
+	lastSuppression := p.lastCCDLimitSuppression
+	p.mu.Unlock()
 
-	var result []SuppressedCCD
-	for domID, groupCCDTypes := range p.lastCCDLimitSuppression {
-		for group, ccdTypes := range groupCCDTypes {
-			for ccdID, suppressionType := range ccdTypes {
-				result = append(result, SuppressedCCD{
-					DomID:           domID,
-					Group:           group,
-					CCDID:           ccdID,
-					SuppressionType: suppressionType,
-				})
-			}
-		}
-	}
-	result = append(result, innerSuppressed...)
+	result := buildSuppressedCCDs(lastSuppression, innerSuppressed,
+		len(lastSuppression)+len(innerSuppressed),
+		// len(lastSuppression) is a lower bound (top-level domain count in 3-level nested map);
+		// computing the exact count requires a full traversal which defeats the purpose of the hint
+	)
 
 	return result
 }
@@ -128,12 +123,12 @@ func (p *pControllerAdvisor) maxObservedCCDMBForGroup(outgoings map[int]monitor.
 	return max
 }
 
-func (p *pControllerAdvisor) getCCDLimitSuppression(domainsMon *monitor.DomainStats) map[int]map[string]map[int]string {
+func computeCCDLimitSuppression(domainsMon *monitor.DomainStats, groupStates map[string]*groupPCtrlState, ccdMaxMB int) map[int]map[string]map[int]string {
 	var result map[int]map[string]map[int]string
 
-	for group, state := range p.groupStates {
+	for group, state := range groupStates {
 		target := state.pCtrl.target
-		if target <= 0 || state.ccdCapMB >= p.ccdMaxMB {
+		if target <= 0 || state.ccdCapMB >= ccdMaxMB {
 			continue
 		}
 
@@ -174,7 +169,6 @@ func NewPControllerAdvisor(Kp float64,
 	minValue, maxValue int,
 	groupTargets map[string]int,
 	inner Advisor,
-	emitter metrics.MetricEmitter,
 ) Advisor {
 	groupStates := make(map[string]*groupPCtrlState, len(groupTargets))
 	for group, target := range groupTargets {
@@ -191,7 +185,6 @@ func NewPControllerAdvisor(Kp float64,
 		ccdMinMB:    minValue,
 		ccdMaxMB:    maxValue,
 		inner:       inner,
-		emitter:     emitter,
 		groupStates: groupStates,
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -31,7 +31,7 @@ import (
 // based on P-Controler (Proportional Controller) of closed-looped automation system to compare output feedback
 // against a target value and adjust inputs in predefined ratio Kp to achieve a desired state
 type pControllerAdvisor struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	ccdMinMB, ccdMaxMB int
 	inner              Advisor
@@ -64,10 +64,10 @@ func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Do
 }
 
 func (p *pControllerAdvisor) GetSuppressedCCDs() []SuppressedCCD {
-	p.mu.Lock()
+	p.mu.RLock()
 	innerSuppressed := p.inner.GetSuppressedCCDs()
 	lastSuppression := p.lastCCDLimitSuppression
-	p.mu.Unlock()
+	p.mu.RUnlock()
 
 	result := buildSuppressedCCDs(lastSuppression, innerSuppressed,
 		len(lastSuppression)+len(innerSuppressed),

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -53,7 +53,9 @@ func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Do
 		p.restrictGroupCCDCap(group, state, domainsMon, result)
 	}
 
-	p.detectCCDLimitSuppression(domainsMon)
+	if p.emitter != nil {
+		emitCCDSuppressionTypes(p.emitter, p.getCCDLimitSuppression(domainsMon))
+	}
 
 	return result, nil
 }
@@ -103,10 +105,8 @@ func (p *pControllerAdvisor) maxObservedCCDMBForGroup(outgoings map[int]monitor.
 	return max
 }
 
-func (p *pControllerAdvisor) detectCCDLimitSuppression(domainsMon *monitor.DomainStats) {
-	if p.emitter == nil {
-		return
-	}
+func (p *pControllerAdvisor) getCCDLimitSuppression(domainsMon *monitor.DomainStats) map[int]map[string]map[int]string {
+	var result map[int]map[string]map[int]string
 
 	for group, state := range p.groupStates {
 		target := state.pCtrl.target
@@ -121,11 +121,13 @@ func (p *pControllerAdvisor) detectCCDLimitSuppression(domainsMon *monitor.Domai
 			}
 			for ccd, mbInfo := range ccdStats {
 				if mbInfo.TotalMB >= target {
-					emitCCDSuppressed(p.emitter, domID, group, ccd, suppressionTypeCCDLimit)
+					addQuadruplet(&result, domID, group, ccd, suppressionTypeCCDLimit)
 				}
 			}
 		}
 	}
+
+	return result
 }
 
 func applyGroupCCDBoundsChecks(ccdMBs plan.GroupCCDPlan, lower, upper int) {

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
@@ -43,6 +43,11 @@ func (m *mockAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainSta
 	return returnedPlan, args.Error(1)
 }
 
+func (m *mockAdvisor) GetSuppressedCCDs() []SuppressedCCD {
+	args := m.Called()
+	return args.Get(0).([]SuppressedCCD)
+}
+
 func TestPControllerAdvisor_GetPlan_May_Update_CCDCap(t *testing.T) {
 	t.Parallel()
 
@@ -316,4 +321,28 @@ func Test_pControllerAdvisor_detectCCDLimitSuppression(t *testing.T) {
 			assert.Equalf(t, tt.want, p.getCCDLimitSuppression(tt.args.domainsMon), "getCCDLimitSuppression(%v)", tt.args.domainsMon)
 		})
 	}
+}
+
+func TestPControllerAdvisor_GetSuppressedCCDs(t *testing.T) {
+	t.Parallel()
+
+	innerSuppressed := []SuppressedCCD{
+		{DomID: 0, Group: "share", CCDID: 2, SuppressionType: "domain_stress"},
+	}
+
+	mockInner := new(mockAdvisor)
+	mockInner.On("GetSuppressedCCDs").Return(innerSuppressed)
+
+	pCtrl := &pControllerAdvisor{
+		inner: mockInner,
+		lastCCDLimitSuppression: map[int]map[string]map[int]string{
+			0: {"dedicated": {4: "ccd_limit"}},
+		},
+	}
+
+	got := pCtrl.GetSuppressedCCDs()
+
+	assert.Len(t, got, 2)
+	assert.Contains(t, got, innerSuppressed[0])
+	assert.Contains(t, got, SuppressedCCD{DomID: 0, Group: "dedicated", CCDID: 4, SuppressionType: "ccd_limit"})
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
@@ -318,7 +318,7 @@ func Test_pControllerAdvisor_detectCCDLimitSuppression(t *testing.T) {
 				ccdMaxMB:    tt.fields.ccdMaxMB,
 				groupStates: tt.fields.groupStates,
 			}
-			assert.Equalf(t, tt.want, p.getCCDLimitSuppression(tt.args.domainsMon), "getCCDLimitSuppression(%v)", tt.args.domainsMon)
+			assert.Equalf(t, tt.want, computeCCDLimitSuppression(tt.args.domainsMon, p.groupStates, p.ccdMaxMB), "computeCCDLimitSuppression(%v)", tt.args.domainsMon)
 		})
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor_test.go
@@ -261,3 +261,59 @@ func TestPControllerAdvisor_GetPlan_May_Update_CCDCap(t *testing.T) {
 		})
 	}
 }
+
+func Test_pControllerAdvisor_detectCCDLimitSuppression(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		ccdMaxMB    int
+		groupStates map[string]*groupPCtrlState
+	}
+	type args struct {
+		domainsMon *monitor.DomainStats
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[int]map[string]map[int]string
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				ccdMaxMB: 60000,
+				groupStates: map[string]*groupPCtrlState{
+					"dedicated": {
+						pCtrl:    pController{target: 666},
+						ccdCapMB: 333,
+					},
+				},
+			},
+			args: args{
+				domainsMon: &monitor.DomainStats{
+					Outgoings: map[int]monitor.DomainMonStat{
+						2: map[string]monitor.GroupMB{
+							"dedicated": map[int]monitor.MBInfo{
+								16: {TotalMB: 777},
+								18: {TotalMB: 500},
+							},
+						},
+					},
+				},
+			},
+			want: map[int]map[string]map[int]string{
+				2: {"dedicated": {16: "ccd_limit"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := &pControllerAdvisor{
+				ccdMaxMB:    tt.fields.ccdMaxMB,
+				groupStates: tt.fields.groupStates,
+			}
+			assert.Equalf(t, tt.want, p.getCCDLimitSuppression(tt.args.domainsMon), "getCCDLimitSuppression(%v)", tt.args.domainsMon)
+		})
+	}
+}

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
@@ -149,7 +149,7 @@ func (a *priorityAdvisor) getDomainQuotaSuppression(groupInfos *groupInfo) map[i
 }
 
 func addQuadruplet(receptacle *map[int]map[string]map[int]string,
-	domID int, group string, ccd int, suppressionTypeCCDLimit string,
+	domID int, group string, ccd int, suppressionType string,
 ) {
 	if *receptacle == nil {
 		*receptacle = make(map[int]map[string]map[int]string)
@@ -164,7 +164,7 @@ func addQuadruplet(receptacle *map[int]map[string]map[int]string,
 		result[domID][group] = make(map[int]string)
 	}
 
-	result[domID][group][ccd] = suppressionTypeCCDLimit
+	result[domID][group][ccd] = suppressionType
 }
 
 func (a *priorityAdvisor) updateSuppressedCCDs(groupInfos *groupInfo) {

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
@@ -34,6 +34,7 @@ import (
 // todo: enhance to handle multiple groups of same priority sharing ccd
 type priorityAdvisor struct {
 	uniqPriorityAdvisor *uniqPriorityAdvisor
+	lastSuppressedCCDs  []SuppressedCCD
 }
 
 // groupInfo stores the mapping of groups and their CCDs for each domain
@@ -165,7 +166,26 @@ func addQuadruplet(receptacle *map[int]map[string]map[int]string,
 }
 
 func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
-	emitCCDSuppressionTypes(a.uniqPriorityAdvisor.emitter, a.getDomainQuotaSuppression(groupInfos))
+	domGroupCCDTypes := a.getDomainQuotaSuppression(groupInfos)
+	emitCCDSuppressionTypes(a.uniqPriorityAdvisor.emitter, domGroupCCDTypes)
+
+	a.lastSuppressedCCDs = nil
+	for domID, groupCCDTypes := range domGroupCCDTypes {
+		for group, ccdTypes := range groupCCDTypes {
+			for ccdID, suppressionType := range ccdTypes {
+				a.lastSuppressedCCDs = append(a.lastSuppressedCCDs, SuppressedCCD{
+					DomID:           domID,
+					Group:           group,
+					CCDID:           ccdID,
+					SuppressionType: suppressionType,
+				})
+			}
+		}
+	}
+}
+
+func (a *priorityAdvisor) GetSuppressedCCDs() []SuppressedCCD {
+	return a.lastSuppressedCCDs
 }
 
 func New(emitter metrics.MetricEmitter, domains domain.Domains, ccdMinMB, ccdMaxMB int, defaultDomainCapacity int,

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
@@ -18,6 +18,7 @@ package advisor
 
 import (
 	"context"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -33,6 +34,7 @@ import (
 // It targets the scenarios where the groups of same priority don't share ccd.
 // todo: enhance to handle multiple groups of same priority sharing ccd
 type priorityAdvisor struct {
+	mu                  sync.Mutex
 	uniqPriorityAdvisor *uniqPriorityAdvisor
 	lastSuppressedCCDs  []SuppressedCCD
 }
@@ -61,7 +63,7 @@ func (a *priorityAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Domai
 		return nil, err
 	}
 
-	a.emitQuotaSuppressionMetrics(groupInfos)
+	a.updateSuppressedCCDs(groupInfos)
 
 	return a.splitPlan(mbPlan, groupInfos), nil
 }
@@ -165,15 +167,31 @@ func addQuadruplet(receptacle *map[int]map[string]map[int]string,
 	result[domID][group][ccd] = suppressionTypeCCDLimit
 }
 
-func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
+func (a *priorityAdvisor) updateSuppressedCCDs(groupInfos *groupInfo) {
 	domGroupCCDTypes := a.getDomainQuotaSuppression(groupInfos)
-	emitCCDSuppressionTypes(a.uniqPriorityAdvisor.emitter, domGroupCCDTypes)
+	capHint := a.getLastSuppressedCCDCap()
+	suppressed := buildSuppressedCCDs(domGroupCCDTypes, nil, capHint)
+	a.setLastSuppressedCCDs(suppressed)
+}
 
-	a.lastSuppressedCCDs = nil
+func (a *priorityAdvisor) getLastSuppressedCCDCap() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return cap(a.lastSuppressedCCDs)
+}
+
+func (a *priorityAdvisor) setLastSuppressedCCDs(v []SuppressedCCD) {
+	a.mu.Lock()
+	a.lastSuppressedCCDs = v
+	a.mu.Unlock()
+}
+
+func buildSuppressedCCDs(domGroupCCDTypes map[int]map[string]map[int]string, extra []SuppressedCCD, bufCap int) []SuppressedCCD {
+	result := make([]SuppressedCCD, 0, bufCap)
 	for domID, groupCCDTypes := range domGroupCCDTypes {
 		for group, ccdTypes := range groupCCDTypes {
 			for ccdID, suppressionType := range ccdTypes {
-				a.lastSuppressedCCDs = append(a.lastSuppressedCCDs, SuppressedCCD{
+				result = append(result, SuppressedCCD{
 					DomID:           domID,
 					Group:           group,
 					CCDID:           ccdID,
@@ -182,9 +200,13 @@ func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
 			}
 		}
 	}
+	result = append(result, extra...)
+	return result
 }
 
 func (a *priorityAdvisor) GetSuppressedCCDs() []SuppressedCCD {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return a.lastSuppressedCCDs
 }
 

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
@@ -113,15 +113,10 @@ func (a *priorityAdvisor) splitPlan(mbPlan *plan.MBPlan, groupInfos *groupInfo) 
 	return mbPlan
 }
 
-func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
-	suppressed := a.uniqPriorityAdvisor.lastQuotaSuppressedCCDs
-	if len(suppressed) == 0 {
-		return
-	}
+func (a *priorityAdvisor) getDomainQuotaSuppression(groupInfos *groupInfo) map[int]map[string]map[int]string {
+	var result map[int]map[string]map[int]string
 
-	emitter := a.uniqPriorityAdvisor.emitter
-
-	for domID, groupCCDs := range suppressed {
+	for domID, groupCCDs := range a.uniqPriorityAdvisor.lastQuotaSuppressedCCDs {
 		for groupKey, ccdIDs := range groupCCDs {
 			if isCombinedGroup(groupKey) {
 				domGroupMapping, hasMapping := groupInfos.DomainGroups[domID]
@@ -135,17 +130,42 @@ func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
 				for realGroup, ccdSet := range combinedMapping {
 					for _, ccd := range ccdIDs {
 						if ccdSet.Has(ccd) {
-							emitCCDSuppressed(emitter, domID, realGroup, ccd, suppressionTypeDomainStress)
+							addQuadruplet(&result, domID, realGroup, ccd, suppressionTypeDomainStress)
 						}
 					}
 				}
 			} else {
 				for _, ccd := range ccdIDs {
-					emitCCDSuppressed(emitter, domID, groupKey, ccd, suppressionTypeDomainStress)
+					addQuadruplet(&result, domID, groupKey, ccd, suppressionTypeDomainStress)
 				}
 			}
 		}
 	}
+
+	return result
+}
+
+func addQuadruplet(receptacle *map[int]map[string]map[int]string,
+	domID int, group string, ccd int, suppressionTypeCCDLimit string,
+) {
+	if *receptacle == nil {
+		*receptacle = make(map[int]map[string]map[int]string)
+	}
+	result := *receptacle
+
+	if _, ok := result[domID]; !ok {
+		result[domID] = make(map[string]map[int]string)
+	}
+
+	if _, ok := result[domID][group]; !ok {
+		result[domID][group] = make(map[int]string)
+	}
+
+	result[domID][group][ccd] = suppressionTypeCCDLimit
+}
+
+func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
+	emitCCDSuppressionTypes(a.uniqPriorityAdvisor.emitter, a.getDomainQuotaSuppression(groupInfos))
 }
 
 func New(emitter metrics.MetricEmitter, domains domain.Domains, ccdMinMB, ccdMaxMB int, defaultDomainCapacity int,

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
@@ -59,6 +59,9 @@ func (a *priorityAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.Domai
 	if err != nil {
 		return nil, err
 	}
+
+	a.emitQuotaSuppressionMetrics(groupInfos)
+
 	return a.splitPlan(mbPlan, groupInfos), nil
 }
 
@@ -108,6 +111,41 @@ func (a *priorityAdvisor) splitPlan(mbPlan *plan.MBPlan, groupInfos *groupInfo) 
 		delete(mbPlan.MBGroups, groupKey)
 	}
 	return mbPlan
+}
+
+func (a *priorityAdvisor) emitQuotaSuppressionMetrics(groupInfos *groupInfo) {
+	suppressed := a.uniqPriorityAdvisor.lastQuotaSuppressedCCDs
+	if len(suppressed) == 0 {
+		return
+	}
+
+	emitter := a.uniqPriorityAdvisor.emitter
+
+	for domID, groupCCDs := range suppressed {
+		for groupKey, ccdIDs := range groupCCDs {
+			if isCombinedGroup(groupKey) {
+				domGroupMapping, hasMapping := groupInfos.DomainGroups[domID]
+				if !hasMapping {
+					continue
+				}
+				combinedMapping, hasCombined := domGroupMapping[groupKey]
+				if !hasCombined {
+					continue
+				}
+				for realGroup, ccdSet := range combinedMapping {
+					for _, ccd := range ccdIDs {
+						if ccdSet.Has(ccd) {
+							emitCCDSuppressed(emitter, domID, realGroup, ccd, suppressionTypeDomainStress)
+						}
+					}
+				}
+			} else {
+				for _, ccd := range ccdIDs {
+					emitCCDSuppressed(emitter, domID, groupKey, ccd, suppressionTypeDomainStress)
+				}
+			}
+		}
+	}
 }
 
 func New(emitter metrics.MetricEmitter, domains domain.Domains, ccdMinMB, ccdMaxMB int, defaultDomainCapacity int,

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor.go
@@ -34,7 +34,7 @@ import (
 // It targets the scenarios where the groups of same priority don't share ccd.
 // todo: enhance to handle multiple groups of same priority sharing ccd
 type priorityAdvisor struct {
-	mu                  sync.Mutex
+	mu                  sync.RWMutex
 	uniqPriorityAdvisor *uniqPriorityAdvisor
 	lastSuppressedCCDs  []SuppressedCCD
 }
@@ -175,8 +175,8 @@ func (a *priorityAdvisor) updateSuppressedCCDs(groupInfos *groupInfo) {
 }
 
 func (a *priorityAdvisor) getLastSuppressedCCDCap() int {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return cap(a.lastSuppressedCCDs)
 }
 
@@ -205,8 +205,8 @@ func buildSuppressedCCDs(domGroupCCDTypes map[int]map[string]map[int]string, ext
 }
 
 func (a *priorityAdvisor) GetSuppressedCCDs() []SuppressedCCD {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return a.lastSuppressedCCDs
 }
 

--- a/pkg/agent/qrm-plugins/mb/advisor/priority_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/priority_advisor_test.go
@@ -20,6 +20,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor/priority"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
@@ -272,6 +275,61 @@ func Test_priorityGroupDecorator_splitPlan(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("splitPlan() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_priorityAdvisor_getDomainQuotaSuppression(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		uniqPriorityAdvisor *uniqPriorityAdvisor
+	}
+	type args struct {
+		groupInfos *groupInfo
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[int]map[string]map[int]string
+	}{
+		{
+			name: "happy path",
+			fields: fields{
+				uniqPriorityAdvisor: &uniqPriorityAdvisor{
+					lastQuotaSuppressedCCDs: map[int]map[string][]int{
+						1: {"combined-9000": {9, 27}},
+					},
+				},
+			},
+			args: args{
+				groupInfos: &groupInfo{
+					DomainGroups: map[int]domainGroupMapping{
+						1: map[string]combinedGroupMapping{
+							"combined-9000": map[string]ccdSet{
+								"dedicated": sets.NewInt(27),
+								"machine":   sets.NewInt(9),
+							},
+						},
+					},
+				},
+			},
+			want: map[int]map[string]map[int]string{
+				1: {
+					"dedicated": {27: "domain_stress"},
+					"machine":   {9: "domain_stress"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &priorityAdvisor{
+				uniqPriorityAdvisor: tt.fields.uniqPriorityAdvisor,
+			}
+			assert.Equalf(t, tt.want, a.getDomainQuotaSuppression(tt.args.groupInfos), "getDomainQuotaSuppression(%v)", tt.args.groupInfos)
 		})
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/types.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/types.go
@@ -23,6 +23,14 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
 )
 
+type SuppressedCCD struct {
+	DomID           int
+	Group           string
+	CCDID           int
+	SuppressionType string
+}
+
 type Advisor interface {
 	GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error)
+	GetSuppressedCCDs() []SuppressedCCD
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor.go
@@ -59,6 +59,8 @@ type uniqPriorityAdvisor struct {
 	flower        sankey.DomainFlower
 	adjusters     map[string]adjuster.Adjuster
 	ccdDistribute distributor.Distributor
+
+	lastQuotaSuppressedCCDs map[int]map[string][]int
 }
 
 func (a *uniqPriorityAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error) {
@@ -83,6 +85,8 @@ func (a *uniqPriorityAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.D
 			stringify(groupedDomIncomingTargets))
 	}
 	a.emitIncomingTargets(groupedDomIncomingTargets)
+
+	a.detectQuotaSuppression(domIncomingInfo, domIncomingQuotas, domainsMon.Outgoings)
 
 	// for each group, based on incoming targets, decide what the outgoing targets are
 	var groupedDomOutgoingTargets map[string][]int
@@ -134,6 +138,62 @@ func (a *uniqPriorityAdvisor) getNoThrottleMB() int {
 	}
 
 	return a.defaultDomainCapacity
+}
+
+func (a *uniqPriorityAdvisor) detectQuotaSuppression(
+	domIncomingInfo map[int]*resource.MBGroupIncomingStat,
+	domIncomingQuotas resource.DomQuotas,
+	outgoings map[int]monitor.GroupMBStats,
+) {
+	a.lastQuotaSuppressedCCDs = make(map[int]map[string][]int)
+
+	for domID, incomingInfo := range domIncomingInfo {
+		if incomingInfo.ResourceState != resource.ResourceStressful {
+			continue
+		}
+
+		domQuotas, ok := domIncomingQuotas[domID]
+		if !ok {
+			continue
+		}
+
+		domOutgoing, hasOutgoing := outgoings[domID]
+		if !hasOutgoing {
+			continue
+		}
+
+		for group, groupOutgoing := range domOutgoing {
+			if a.groupNeverThrottles.Has(group) {
+				continue
+			}
+
+			quota, hasQuota := domQuotas[group]
+			if !hasQuota {
+				continue
+			}
+
+			groupTotalUse := incomingInfo.GroupTotalUses[group]
+			if groupTotalUse < quota {
+				continue
+			}
+
+			var suppressedCCDs []int
+			for ccd, mbInfo := range groupOutgoing {
+				if mbInfo.TotalMB > 0 {
+					suppressedCCDs = append(suppressedCCDs, ccd)
+				}
+			}
+
+			if len(suppressedCCDs) == 0 {
+				continue
+			}
+
+			if _, ok := a.lastQuotaSuppressedCCDs[domID]; !ok {
+				a.lastQuotaSuppressedCCDs[domID] = make(map[string][]int)
+			}
+			a.lastQuotaSuppressedCCDs[domID][group] = suppressedCCDs
+		}
+	}
 }
 
 func (a *uniqPriorityAdvisor) adjust(_ context.Context,

--- a/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor.go
@@ -86,7 +86,7 @@ func (a *uniqPriorityAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.D
 	}
 	a.emitIncomingTargets(groupedDomIncomingTargets)
 
-	a.detectQuotaSuppression(domIncomingInfo, domIncomingQuotas, domainsMon.Outgoings)
+	a.detectDomainQuotaSuppression(domIncomingInfo, domIncomingQuotas, domainsMon.Outgoings)
 
 	// for each group, based on incoming targets, decide what the outgoing targets are
 	var groupedDomOutgoingTargets map[string][]int
@@ -140,7 +140,7 @@ func (a *uniqPriorityAdvisor) getNoThrottleMB() int {
 	return a.defaultDomainCapacity
 }
 
-func (a *uniqPriorityAdvisor) detectQuotaSuppression(
+func (a *uniqPriorityAdvisor) detectDomainQuotaSuppression(
 	domIncomingInfo map[int]*resource.MBGroupIncomingStat,
 	domIncomingQuotas resource.DomQuotas,
 	outgoings map[int]monitor.GroupMBStats,

--- a/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor_test.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor/adjuster"
@@ -535,6 +536,66 @@ func Test_domainAdvisor_GetPlan(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetPlan() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_uniqPriorityAdvisor_detectQuotaSuppression(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		groupNeverThrottles sets.String
+	}
+	type args struct {
+		domIncomingInfo   map[int]*resource.MBGroupIncomingStat
+		domIncomingQuotas resource.DomQuotas
+		outgoings         map[int]monitor.GroupMBStats
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[int]map[string][]int
+	}{
+		{
+			name:   "happy path",
+			fields: fields{},
+			args: args{
+				domIncomingInfo: map[int]*resource.MBGroupIncomingStat{
+					1: {
+						GroupTotalUses: map[string]int{
+							"dedicated": 19000,
+							"shared-50": 7777,
+						},
+						ResourceState: "stressful",
+					},
+				},
+				domIncomingQuotas: map[int]resource.GroupSettings{
+					1: map[string]int{
+						"dedicated": 20000,
+						"shared-50": 5000,
+					},
+				},
+				outgoings: map[int]monitor.GroupMBStats{
+					1: map[string]monitor.GroupMB{
+						"dedicated": map[int]monitor.MBInfo{8: {TotalMB: 20000}},
+						"shared-50": map[int]monitor.MBInfo{9: {TotalMB: 4500}},
+					},
+				},
+			},
+			want: map[int]map[string][]int{
+				1: {"shared-50": {9}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &uniqPriorityAdvisor{
+				groupNeverThrottles: tt.fields.groupNeverThrottles,
+			}
+			a.detectDomainQuotaSuppression(tt.args.domIncomingInfo, tt.args.domIncomingQuotas, tt.args.outgoings)
+			assert.Equal(t, tt.want, a.lastQuotaSuppressedCCDs, "domain-stress ccd")
 		})
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"golang.org/x/exp/maps"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -31,6 +32,7 @@ import (
 	"github.com/kubewharf/katalyst-api/pkg/plugins/skeleton"
 
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent"
+	cpustate "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor/priority"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/allocator"
@@ -40,15 +42,20 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/reader"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	metricspool "github.com/kubewharf/katalyst-core/pkg/metrics/metrics-pool"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
 const (
 	name       = "qrm_mb_plugin_generic_policy"
 	metricName = name
 	interval   = time.Second * 1
+
+	metricMBMLoadSuppressed = "mbm_load_suppressed"
+	defaultPSM              = "-"
 )
 
 type MBPlugin struct {
@@ -69,6 +76,8 @@ type MBPlugin struct {
 	metricFetcher metrictypes.MetricsFetcher
 	conf          *config.Configuration
 	agentCtx      *agent.GenericContext
+	machineInfo   *machine.KatalystMachineInfo
+	podFetcher    pod.PodFetcher
 }
 
 func (m *MBPlugin) Name() string {
@@ -246,7 +255,105 @@ func (m *MBPlugin) run() {
 		return
 	}
 
+	m.emitLoadSuppressionMetrics()
+
 	general.InfofV(6, "[mbm] plugin run end")
+}
+
+func (m *MBPlugin) buildCCDToPodsMap() map[int]map[string]*corev1.Pod {
+	cpuState, err := cpustate.GetReadonlyState()
+	if err != nil {
+		general.InfofV(6, "[mbm] cpu readonly state unavailable: %v", err)
+		return nil
+	}
+
+	ccdToPods := make(map[int]map[string]*corev1.Pod)
+	podIndexer := make(map[string]*corev1.Pod)
+	if klog.V(6).Enabled() {
+		general.Infof("[mbm] cpuState.GetPodEntries(): %v", cpuState.GetPodEntries())
+	}
+	for podUID, containerEntries := range cpuState.GetPodEntries() {
+		for _, allocationInfo := range containerEntries {
+			if allocationInfo == nil {
+				continue
+			}
+			cpus := allocationInfo.AllocationResult.ToSliceInt()
+			for _, cpu := range cpus {
+				ccdID := m.machineInfo.CPUDetails[cpu].L3CacheID
+				if ccdToPods[ccdID] == nil {
+					ccdToPods[ccdID] = make(map[string]*corev1.Pod)
+				}
+				if _, exists := ccdToPods[ccdID][podUID]; exists {
+					continue
+				}
+				podInfo, ok := podIndexer[podUID]
+				if !ok {
+					var err error
+					podInfo, err = m.podFetcher.GetPod(context.Background(), podUID)
+					if err != nil || podInfo == nil {
+						continue
+					}
+					podIndexer[podUID] = podInfo
+				}
+				ccdToPods[ccdID][podUID] = podInfo
+			}
+		}
+	}
+	return ccdToPods
+}
+
+func (m *MBPlugin) emitSuppressedPodsMetrics(suppressedCCDs []advisor.SuppressedCCD, ccdToPods map[int]map[string]*corev1.Pod) {
+	seen := make(map[string]struct{})
+	for _, s := range suppressedCCDs {
+		pods, ok := ccdToPods[s.CCDID]
+		if !ok {
+			continue
+		}
+		for _, p := range pods {
+			key := string(p.UID) + "/" + s.SuppressionType
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+
+			psm := p.Labels["psm"]
+			if psm == "" {
+				psm = defaultPSM
+			}
+
+			emitPodSuppressed(m.emitter, p.Namespace, p.Name, s.SuppressionType, psm)
+		}
+	}
+}
+
+func (m *MBPlugin) emitLoadSuppressionMetrics() {
+	suppressedCCDs := m.advisor.GetSuppressedCCDs()
+	if klog.V(6).Enabled() {
+		general.Infof("[mbm] suppressed ccds: %v", suppressedCCDs)
+	}
+	if len(suppressedCCDs) == 0 {
+		return
+	}
+
+	ccdToPods := m.buildCCDToPodsMap()
+	if klog.V(6).Enabled() {
+		general.Infof("[mbm] ccd to pod mappings: %v", ccdToPods)
+	}
+	if ccdToPods == nil {
+		return
+	}
+
+	m.emitSuppressedPodsMetrics(suppressedCCDs, ccdToPods)
+}
+
+func emitPodSuppressed(emitter metrics.MetricEmitter, namespace, podName, suppressionType string, psm string) {
+	tags := map[string]string{
+		"namespace": namespace,
+		"pod_name":  podName,
+		"type":      suppressionType,
+		"psm":       psm,
+	}
+	_ = emitter.StoreInt64(metricMBMLoadSuppressed, 1, metrics.MetricTypeNameRaw, metrics.ConvertMapToTags(tags)...)
 }
 
 func newMBPlugin(agentCtx *agent.GenericContext, conf *config.Configuration,
@@ -268,5 +375,7 @@ func newMBPlugin(agentCtx *agent.GenericContext, conf *config.Configuration,
 		metricFetcher: metricFetcher,
 		conf:          conf,
 		agentCtx:      agentCtx,
+		machineInfo:   agentCtx.KatalystMachineInfo,
+		podFetcher:    agentCtx.MetaServer.PodFetcher,
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -54,10 +54,11 @@ const (
 	metricName = name
 	interval   = time.Second * 1
 
-	suppressEmitInterval = time.Second * 30
+	emitInterval30s = time.Second * 30
 
 	metricMBMLoadSuppressed = "mbm_load_suppressed"
 	metricMBMCCDSuppressed  = "mbm_ccd_suppressed"
+	metricMBMHealthStatus   = "mbm_health_status"
 )
 
 type MBPlugin struct {
@@ -104,9 +105,10 @@ func (m *MBPlugin) Start() (err error) {
 	// todo: consider option not to reset resctrl FS on start to avoid hiccup between deployment updates
 	general.Infof("mbm: to reset resctrl FS on start")
 	ccds := sets.NewInt(maps.Keys(m.ccdToDomain)...)
+	m.chStop = make(chan struct{})
 	if err = m.planAllocator.Reset(context.Background(), ccds); err != nil {
 		general.Errorf("mbm: reset resctrl FS on start failed: %v", err)
-		general.Warningf("mbm: likely resctrl is not mounted; not to manage mem bandwidth")
+		go wait.Until(m.emitResctrlResetFailure, emitInterval30s, m.chStop)
 		return nil
 	}
 
@@ -115,7 +117,6 @@ func (m *MBPlugin) Start() (err error) {
 		return nil
 	}
 
-	m.chStop = make(chan struct{})
 	if !cache.WaitForCacheSync(m.chStop, m.metricFetcher.HasSynced) {
 		general.Errorf("mbm: wait for metric fetcher cache sync failed")
 		return fmt.Errorf("mbm plugin failed to wait for metric fetcher cache sync")
@@ -168,7 +169,7 @@ func (m *MBPlugin) Start() (err error) {
 		}
 	}()
 
-	go wait.Until(m.emitSuppressionMetrics, suppressEmitInterval, m.chStop)
+	go wait.Until(m.emitSuppressionMetrics, emitInterval30s, m.chStop)
 
 	return nil
 }
@@ -367,6 +368,14 @@ func (m *MBPlugin) emitSuppressionMetrics() {
 	if klog.V(6).Enabled() {
 		general.Infof("[mbm] metrics: done emitting suppression metrics")
 	}
+}
+
+func (m *MBPlugin) emitResctrlResetFailure() {
+	_ = m.emitter.StoreInt64(metricMBMHealthStatus, 1, metrics.MetricTypeNameRaw,
+		metrics.MetricTag{Key: "healthy", Val: "false"},
+		metrics.MetricTag{Key: "sub_system", Val: "resctrl"},
+		metrics.MetricTag{Key: "reason", Val: "reset_failure"},
+	)
 }
 
 func emitPodSuppressed(emitter metrics.MetricEmitter, namespace, podName, suppressionType string, labels map[string]string, podMetricLabels sets.String) {

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -265,16 +265,29 @@ func (m *MBPlugin) run() {
 func (m *MBPlugin) buildCCDToPodsMap() map[int]map[string]*corev1.Pod {
 	cpuState, err := cpustate.GetReadonlyState()
 	if err != nil {
-		general.InfofV(6, "[mbm] cpu readonly state unavailable: %v", err)
+		general.Warningf("[mbm] cpu readonly state unavailable: %v", err)
 		return nil
 	}
 
+	podEntries := cpuState.GetPodEntries()
+
+	if klog.V(6).Enabled() {
+		general.Infof("[mbm] cpuState.GetPodEntries(): %v", podEntries)
+	}
+
+	return buildCCDToPodsMapFromState(
+		podEntries,
+		m.machineInfo.CPUDetails,
+		m.podFetcher.GetPod,
+	)
+}
+
+type getPodFunc func(ctx context.Context, podUID string) (*corev1.Pod, error)
+
+func buildCCDToPodsMapFromState(podEntries cpustate.PodEntries, cpuTopology machine.CPUDetails, getPod getPodFunc) map[int]map[string]*corev1.Pod {
 	ccdToPods := make(map[int]map[string]*corev1.Pod)
 	podIndexer := make(map[string]*corev1.Pod)
-	if klog.V(6).Enabled() {
-		general.Infof("[mbm] cpuState.GetPodEntries(): %v", cpuState.GetPodEntries())
-	}
-	for podUID, containerEntries := range cpuState.GetPodEntries() {
+	for podUID, containerEntries := range podEntries {
 		if containerEntries == nil || containerEntries.IsPoolEntry() {
 			continue
 		}
@@ -284,22 +297,21 @@ func (m *MBPlugin) buildCCDToPodsMap() map[int]map[string]*corev1.Pod {
 				continue
 			}
 			cpus := allocationInfo.AllocationResult.ToSliceInt()
-			for _, cpu := range cpus {
-				ccdID := m.machineInfo.CPUDetails[cpu].L3CacheID
-				if ccdToPods[ccdID] == nil {
-					ccdToPods[ccdID] = make(map[string]*corev1.Pod)
-				}
-				if _, exists := ccdToPods[ccdID][podUID]; exists {
+
+			podInfo, ok := podIndexer[podUID]
+			if !ok {
+				var err error
+				podInfo, err = getPod(context.Background(), podUID)
+				if err != nil || podInfo == nil {
 					continue
 				}
-				podInfo, ok := podIndexer[podUID]
-				if !ok {
-					var err error
-					podInfo, err = m.podFetcher.GetPod(context.Background(), podUID)
-					if err != nil || podInfo == nil {
-						continue
-					}
-					podIndexer[podUID] = podInfo
+				podIndexer[podUID] = podInfo
+			}
+
+			for _, cpu := range cpus {
+				ccdID := cpuTopology[cpu].L3CacheID
+				if ccdToPods[ccdID] == nil {
+					ccdToPods[ccdID] = make(map[string]*corev1.Pod)
 				}
 				ccdToPods[ccdID][podUID] = podInfo
 			}

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -143,6 +143,7 @@ func (m *MBPlugin) Start() (err error) {
 			m.conf.MaxCCDMB,
 			m.conf.CCDCapGroups,
 			m.advisor,
+			m.emitter,
 		)
 		general.Infof("[mbm] P-Controller advisor enabled with groups=%v, Kp=%.2f", m.conf.CCDCapGroups, m.conf.CCDCapKp)
 	}

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -385,7 +385,7 @@ func (m *MBPlugin) emitSuppressionMetrics() {
 func (m *MBPlugin) emitResctrlResetFailure() {
 	_ = m.emitter.StoreInt64(metricMBMHealthStatus, 1, metrics.MetricTypeNameRaw,
 		metrics.MetricTag{Key: "healthy", Val: "false"},
-		metrics.MetricTag{Key: "sub_system", Val: "resctrl"},
+		metrics.MetricTag{Key: "component", Val: "resctrl"},
 		metrics.MetricTag{Key: "reason", Val: "reset_failure"},
 	)
 }

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -58,7 +58,6 @@ const (
 
 	metricMBMLoadSuppressed = "mbm_load_suppressed"
 	metricMBMCCDSuppressed  = "mbm_ccd_suppressed"
-	defaultPSM              = "-"
 )
 
 type MBPlugin struct {
@@ -275,8 +274,12 @@ func (m *MBPlugin) buildCCDToPodsMap() map[int]map[string]*corev1.Pod {
 		general.Infof("[mbm] cpuState.GetPodEntries(): %v", cpuState.GetPodEntries())
 	}
 	for podUID, containerEntries := range cpuState.GetPodEntries() {
+		if containerEntries == nil || containerEntries.IsPoolEntry() {
+			continue
+		}
+
 		for _, allocationInfo := range containerEntries {
-			if allocationInfo == nil {
+			if allocationInfo == nil || !allocationInfo.CheckMainContainer() {
 				continue
 			}
 			cpus := allocationInfo.AllocationResult.ToSliceInt()
@@ -317,6 +320,8 @@ func (m *MBPlugin) emitSuppressedCCDsMetrics(suppressedCCDs []advisor.Suppressed
 }
 
 func (m *MBPlugin) emitSuppressedPodsMetrics(suppressedCCDs []advisor.SuppressedCCD, ccdToPods map[int]map[string]*corev1.Pod) {
+	// reuse GenericEvictionConfiguration.PodMetricLabels as MB plugin does not have its own
+	podMetricLabels := m.conf.GenericEvictionConfiguration.PodMetricLabels
 	seen := make(map[string]struct{})
 	for _, s := range suppressedCCDs {
 		pods, ok := ccdToPods[s.CCDID]
@@ -330,12 +335,7 @@ func (m *MBPlugin) emitSuppressedPodsMetrics(suppressedCCDs []advisor.Suppressed
 			}
 			seen[key] = struct{}{}
 
-			psm := p.Labels["psm"]
-			if psm == "" {
-				psm = defaultPSM
-			}
-
-			emitPodSuppressed(m.emitter, p.Namespace, p.Name, s.SuppressionType, psm)
+			emitPodSuppressed(m.emitter, p.Namespace, p.Name, s.SuppressionType, p.Labels, podMetricLabels)
 		}
 	}
 }
@@ -369,14 +369,19 @@ func (m *MBPlugin) emitSuppressionMetrics() {
 	}
 }
 
-func emitPodSuppressed(emitter metrics.MetricEmitter, namespace, podName, suppressionType string, psm string) {
-	tags := map[string]string{
-		"namespace": namespace,
-		"pod_name":  podName,
-		"type":      suppressionType,
-		"psm":       psm,
+func emitPodSuppressed(emitter metrics.MetricEmitter, namespace, podName, suppressionType string, labels map[string]string, podMetricLabels sets.String) {
+	tags := []metrics.MetricTag{
+		{Key: "suppressed_namespace", Val: namespace},
+		{Key: "suppressed_pod", Val: podName},
+		{Key: "suppression_type", Val: suppressionType},
 	}
-	_ = emitter.StoreInt64(metricMBMLoadSuppressed, 1, metrics.MetricTypeNameRaw, metrics.ConvertMapToTags(tags)...)
+	for _, label := range podMetricLabels.List() {
+		value, ok := labels[label]
+		if ok {
+			tags = append(tags, metrics.MetricTag{Key: label, Val: value})
+		}
+	}
+	_ = emitter.StoreInt64(metricMBMLoadSuppressed, 1, metrics.MetricTypeNameRaw, tags...)
 }
 
 func newMBPlugin(agentCtx *agent.GenericContext, conf *config.Configuration,

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -54,7 +54,10 @@ const (
 	metricName = name
 	interval   = time.Second * 1
 
+	suppressEmitInterval = time.Second * 30
+
 	metricMBMLoadSuppressed = "mbm_load_suppressed"
+	metricMBMCCDSuppressed  = "mbm_ccd_suppressed"
 	defaultPSM              = "-"
 )
 
@@ -152,7 +155,6 @@ func (m *MBPlugin) Start() (err error) {
 			m.conf.MaxCCDMB,
 			m.conf.CCDCapGroups,
 			m.advisor,
-			m.emitter,
 		)
 		general.Infof("[mbm] P-Controller advisor enabled with groups=%v, Kp=%.2f", m.conf.CCDCapGroups, m.conf.CCDCapKp)
 	}
@@ -166,6 +168,8 @@ func (m *MBPlugin) Start() (err error) {
 			general.Errorf("mbm: reset resctrl FS on stop failed: %v", err)
 		}
 	}()
+
+	go wait.Until(m.emitSuppressionMetrics, suppressEmitInterval, m.chStop)
 
 	return nil
 }
@@ -255,8 +259,6 @@ func (m *MBPlugin) run() {
 		return
 	}
 
-	m.emitLoadSuppressionMetrics()
-
 	general.InfofV(6, "[mbm] plugin run end")
 }
 
@@ -302,6 +304,18 @@ func (m *MBPlugin) buildCCDToPodsMap() map[int]map[string]*corev1.Pod {
 	return ccdToPods
 }
 
+func (m *MBPlugin) emitSuppressedCCDsMetrics(suppressedCCDs []advisor.SuppressedCCD) {
+	for _, ccd := range suppressedCCDs {
+		tags := map[string]string{
+			"domain": fmt.Sprintf("%d", ccd.DomID),
+			"group":  ccd.Group,
+			"ccd":    fmt.Sprintf("%d", ccd.CCDID),
+			"type":   ccd.SuppressionType,
+		}
+		_ = m.emitter.StoreInt64(metricMBMCCDSuppressed, 1, metrics.MetricTypeNameRaw, metrics.ConvertMapToTags(tags)...)
+	}
+}
+
 func (m *MBPlugin) emitSuppressedPodsMetrics(suppressedCCDs []advisor.SuppressedCCD, ccdToPods map[int]map[string]*corev1.Pod) {
 	seen := make(map[string]struct{})
 	for _, s := range suppressedCCDs {
@@ -326,24 +340,33 @@ func (m *MBPlugin) emitSuppressedPodsMetrics(suppressedCCDs []advisor.Suppressed
 	}
 }
 
-func (m *MBPlugin) emitLoadSuppressionMetrics() {
+func (m *MBPlugin) emitSuppressionMetrics() {
+	if klog.V(6).Enabled() {
+		general.Infof("[mbm] metrics: start emitting suppression metrics")
+	}
+
 	suppressedCCDs := m.advisor.GetSuppressedCCDs()
 	if klog.V(6).Enabled() {
-		general.Infof("[mbm] suppressed ccds: %v", suppressedCCDs)
+		general.Infof("[mbm] metrics: suppressed ccds: %v", suppressedCCDs)
 	}
 	if len(suppressedCCDs) == 0 {
 		return
 	}
 
+	m.emitSuppressedCCDsMetrics(suppressedCCDs)
+
 	ccdToPods := m.buildCCDToPodsMap()
 	if klog.V(6).Enabled() {
-		general.Infof("[mbm] ccd to pod mappings: %v", ccdToPods)
+		general.Infof("[mbm] metrics: ccds to pod mappings: %v", ccdToPods)
 	}
 	if ccdToPods == nil {
 		return
 	}
 
 	m.emitSuppressedPodsMetrics(suppressedCCDs, ccdToPods)
+	if klog.V(6).Enabled() {
+		general.Infof("[mbm] metrics: done emitting suppression metrics")
+	}
 }
 
 func emitPodSuppressed(emitter metrics.MetricEmitter, namespace, podName, suppressionType string, psm string) {

--- a/pkg/agent/qrm-plugins/mb/policy/plugin.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin.go
@@ -105,7 +105,9 @@ func (m *MBPlugin) Start() (err error) {
 	// todo: consider option not to reset resctrl FS on start to avoid hiccup between deployment updates
 	general.Infof("mbm: to reset resctrl FS on start")
 	ccds := sets.NewInt(maps.Keys(m.ccdToDomain)...)
-	m.chStop = make(chan struct{})
+	if m.chStop == nil {
+		m.chStop = make(chan struct{})
+	}
 	if err = m.planAllocator.Reset(context.Background(), ccds); err != nil {
 		general.Errorf("mbm: reset resctrl FS on start failed: %v", err)
 		go wait.Until(m.emitResctrlResetFailure, emitInterval30s, m.chStop)

--- a/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor"
@@ -41,6 +43,11 @@ func (ma *mockAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainSt
 	return args.Get(0).(*plan.MBPlan), args.Error(1)
 }
 
+func (ma *mockAdvisor) GetSuppressedCCDs() []advisor.SuppressedCCD {
+	args := ma.Called()
+	return args.Get(0).([]advisor.SuppressedCCD)
+}
+
 type mockPlanAlloctor struct {
 	mock.Mock
 	allocator.PlanAllocator
@@ -58,6 +65,16 @@ type mockReader struct {
 func (mr *mockReader) GetMBData() (*reader.MBData, error) {
 	args := mr.Called()
 	return args.Get(0).(*reader.MBData), args.Error(1)
+}
+
+type mockMetricEmitter struct {
+	mock.Mock
+	metrics.MetricEmitter
+}
+
+func (m *mockMetricEmitter) StoreInt64(key string, val int64, emitType metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	args := m.Called(key, val, emitType, tags)
+	return args.Error(0)
 }
 
 func TestMBPlugin_run(t *testing.T) {
@@ -86,6 +103,7 @@ func TestMBPlugin_run(t *testing.T) {
 
 	mAdvisor := new(mockAdvisor)
 	mAdvisor.On("GetPlan", mock.Anything, mock.Anything).Return(dummyPlan, nil)
+	mAdvisor.On("GetSuppressedCCDs").Return([]advisor.SuppressedCCD{})
 
 	mPlanAllocator := new(mockPlanAlloctor)
 	mPlanAllocator.On("Allocate", mock.Anything, dummyPlan).Return(nil)
@@ -136,4 +154,79 @@ func TestMBPlugin_run(t *testing.T) {
 			mock.AssertExpectationsForObjects(t, tt.fields.planAllocator)
 		})
 	}
+}
+
+func TestEmitSuppressedPodsMetrics(t *testing.T) {
+	t.Parallel()
+
+	podUID1 := "uid-1"
+	podUID2 := "uid-2"
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "uid-1",
+			Namespace: "ns1",
+			Name:      "pod-a",
+			Labels:    map[string]string{"psm": "svc-a"},
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "uid-2",
+			Namespace: "ns2",
+			Name:      "pod-b",
+		},
+	}
+
+	ccdToPods := map[int]map[string]*corev1.Pod{
+		0: {podUID1: pod1},
+		1: {podUID2: pod2},
+		2: {podUID1: pod1},
+		3: {podUID2: pod2},
+	}
+
+	suppressedCCDs := []advisor.SuppressedCCD{
+		{CCDID: 0, SuppressionType: "domain_stress"},
+		{CCDID: 1, SuppressionType: "ccd_limit"},
+		{CCDID: 2, SuppressionType: "domain_stress"},
+		{CCDID: 3, SuppressionType: "ccd_limit"},
+		{CCDID: 99, SuppressionType: "domain_stress"},
+	}
+
+	emitter := new(mockMetricEmitter)
+	emitter.On("StoreInt64", "mbm_load_suppressed", int64(1), metrics.MetricTypeNameRaw,
+		mock.MatchedBy(func(tags []metrics.MetricTag) bool {
+			return tagsMatch(tags, map[string]string{
+				"namespace": "ns1",
+				"pod_name":  "pod-a",
+				"type":      "domain_stress",
+				"psm":       "svc-a",
+			})
+		})).Return(nil)
+	emitter.On("StoreInt64", "mbm_load_suppressed", int64(1), metrics.MetricTypeNameRaw,
+		mock.MatchedBy(func(tags []metrics.MetricTag) bool {
+			return tagsMatch(tags, map[string]string{
+				"namespace": "ns2",
+				"pod_name":  "pod-b",
+				"type":      "ccd_limit",
+				"psm":       "-",
+			})
+		})).Return(nil)
+
+	m := &MBPlugin{emitter: emitter}
+	m.emitSuppressedPodsMetrics(suppressedCCDs, ccdToPods)
+
+	mock.AssertExpectationsForObjects(t, emitter)
+}
+
+func tagsMatch(tags []metrics.MetricTag, expected map[string]string) bool {
+	if len(tags) != len(expected) {
+		return false
+	}
+	for _, tag := range tags {
+		if v, ok := expected[tag.Key]; !ok || v != tag.Val {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
@@ -103,7 +103,6 @@ func TestMBPlugin_run(t *testing.T) {
 
 	mAdvisor := new(mockAdvisor)
 	mAdvisor.On("GetPlan", mock.Anything, mock.Anything).Return(dummyPlan, nil)
-	mAdvisor.On("GetSuppressedCCDs").Return([]advisor.SuppressedCCD{})
 
 	mPlanAllocator := new(mockPlanAlloctor)
 	mPlanAllocator.On("Allocate", mock.Anything, dummyPlan).Return(nil)

--- a/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
@@ -31,6 +31,9 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/reader"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/eviction"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
 
@@ -196,23 +199,32 @@ func TestEmitSuppressedPodsMetrics(t *testing.T) {
 	emitter.On("StoreInt64", "mbm_load_suppressed", int64(1), metrics.MetricTypeNameRaw,
 		mock.MatchedBy(func(tags []metrics.MetricTag) bool {
 			return tagsMatch(tags, map[string]string{
-				"namespace": "ns1",
-				"pod_name":  "pod-a",
-				"type":      "domain_stress",
-				"psm":       "svc-a",
+				"suppressed_namespace": "ns1",
+				"suppressed_pod":       "pod-a",
+				"suppression_type":     "domain_stress",
+				"psm":                  "svc-a",
 			})
 		})).Return(nil)
 	emitter.On("StoreInt64", "mbm_load_suppressed", int64(1), metrics.MetricTypeNameRaw,
 		mock.MatchedBy(func(tags []metrics.MetricTag) bool {
 			return tagsMatch(tags, map[string]string{
-				"namespace": "ns2",
-				"pod_name":  "pod-b",
-				"type":      "ccd_limit",
-				"psm":       "-",
+				"suppressed_namespace": "ns2",
+				"suppressed_pod":       "pod-b",
+				"suppression_type":     "ccd_limit",
 			})
 		})).Return(nil)
 
-	m := &MBPlugin{emitter: emitter}
+	conf := &config.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			GenericAgentConfiguration: &agent.GenericAgentConfiguration{
+				GenericEvictionConfiguration: &eviction.GenericEvictionConfiguration{
+					PodMetricLabels: sets.NewString("psm"),
+				},
+			},
+		},
+	}
+
+	m := &MBPlugin{emitter: emitter, conf: conf}
 	m.emitSuppressedPodsMetrics(suppressedCCDs, ccdToPods)
 
 	mock.AssertExpectationsForObjects(t, emitter)

--- a/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
+++ b/pkg/agent/qrm-plugins/mb/policy/plugin_test.go
@@ -18,13 +18,19 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	cpustate "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/allocator"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/domain"
@@ -35,6 +41,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/config/agent"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/eviction"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
 type mockAdvisor struct {
@@ -78,6 +85,130 @@ type mockMetricEmitter struct {
 func (m *mockMetricEmitter) StoreInt64(key string, val int64, emitType metrics.MetricTypeName, tags ...metrics.MetricTag) error {
 	args := m.Called(key, val, emitType, tags)
 	return args.Error(0)
+}
+
+func TestBuildCCDToPodsMapFromState(t *testing.T) {
+	t.Parallel()
+
+	newAllocationInfo := func(cpus ...int) *cpustate.AllocationInfo {
+		return &cpustate.AllocationInfo{
+			AllocationMeta: commonstate.AllocationMeta{
+				ContainerType: pluginapi.ContainerType_MAIN.String(),
+			},
+			AllocationResult: machine.NewCPUSet(cpus...),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		cpuTopology machine.CPUDetails
+		podEntries  cpustate.PodEntries
+		getPod      getPodFunc
+		want        map[int]map[string]*corev1.Pod
+	}{
+		{
+			name: "happy path - two pods on different ccds",
+			cpuTopology: machine.CPUDetails{
+				0: {L3CacheID: 0}, 1: {L3CacheID: 0},
+				2: {L3CacheID: 1}, 3: {L3CacheID: 1},
+			},
+			podEntries: cpustate.PodEntries{
+				"uid-1": cpustate.ContainerEntries{"main": newAllocationInfo(0, 1)},
+				"uid-2": cpustate.ContainerEntries{"main": newAllocationInfo(2, 3)},
+			},
+			getPod: successPodFetcher,
+			want: map[int]map[string]*corev1.Pod{
+				0: {"uid-1": stubPod("uid-1")},
+				1: {"uid-2": stubPod("uid-2")},
+			},
+		},
+		{
+			name: "single pod spans multiple ccds",
+			cpuTopology: machine.CPUDetails{
+				0: {L3CacheID: 0},
+				2: {L3CacheID: 1},
+			},
+			podEntries: cpustate.PodEntries{
+				"uid-1": cpustate.ContainerEntries{"main": newAllocationInfo(0, 2)},
+			},
+			getPod: successPodFetcher,
+			want: map[int]map[string]*corev1.Pod{
+				0: {"uid-1": stubPod("uid-1")},
+				1: {"uid-1": stubPod("uid-1")},
+			},
+		},
+		{
+			name:        "nil pod entries",
+			cpuTopology: machine.CPUDetails{0: {L3CacheID: 0}},
+			podEntries:  nil,
+			want:        map[int]map[string]*corev1.Pod{},
+		},
+		{
+			name: "nil allocation info is skipped",
+			cpuTopology: machine.CPUDetails{
+				0: {L3CacheID: 0},
+			},
+			podEntries: cpustate.PodEntries{
+				"uid-1": cpustate.ContainerEntries{"main": nil},
+			},
+			want: map[int]map[string]*corev1.Pod{},
+		},
+		{
+			name: "getPod returns error",
+			cpuTopology: machine.CPUDetails{
+				0: {L3CacheID: 0},
+			},
+			podEntries: cpustate.PodEntries{
+				"uid-1": cpustate.ContainerEntries{"main": newAllocationInfo(0)},
+			},
+			getPod: func(_ context.Context, _ string) (*corev1.Pod, error) {
+				return nil, errors.New("fetch error")
+			},
+			want: map[int]map[string]*corev1.Pod{},
+		},
+		{
+			name: "getPod returns nil pod",
+			cpuTopology: machine.CPUDetails{
+				0: {L3CacheID: 0},
+			},
+			podEntries: cpustate.PodEntries{
+				"uid-1": cpustate.ContainerEntries{"main": newAllocationInfo(0)},
+			},
+			getPod: func(_ context.Context, _ string) (*corev1.Pod, error) {
+				return nil, nil
+			},
+			want: map[int]map[string]*corev1.Pod{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildCCDToPodsMapFromState(tt.podEntries, tt.cpuTopology, tt.getPod)
+
+			assert.Equal(t, len(tt.want), len(got))
+			for ccdID, expectedPods := range tt.want {
+				gotPods, ok := got[ccdID]
+				assert.True(t, ok, "ccd %d not found in result", ccdID)
+				assert.Equal(t, len(expectedPods), len(gotPods))
+				for podUID, expectedPod := range expectedPods {
+					gotPod, ok := gotPods[podUID]
+					assert.True(t, ok, "pod %s not found in ccd %d", podUID, ccdID)
+					assert.Equal(t, expectedPod.Name, gotPod.Name)
+				}
+			}
+		})
+	}
+}
+
+func successPodFetcher(_ context.Context, podUID string) (*corev1.Pod, error) {
+	return stubPod(podUID), nil
+}
+
+func stubPod(uid string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), Name: "pod-" + uid}}
 }
 
 func TestMBPlugin_run(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
Enhancements - metrics

#### What this PR does / why we need it:
To have metrics that indicate which are being throttled with their mem bandwidth by qrm-mb-plugin.
the metrics it emits:

2 metrics introduced:
* name: katalyst.mbm_ccd_suppressed
tags:
  * domain ID (numa id)
  * resctrl group name
  * ccd id
  * suppression type: domain_stress, ccd_limit
* name: katalyst.mbm_load_suppressed
  tags:
  * namespace
  * pod_name
  * psm
  * suppression type
