### PR TITLE
metaserver: auto-register missing malachite cgroup paths and expire stale ones

### DIFF
--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/global"
@@ -57,6 +58,8 @@ const (
 
 	CpiFetchFreq = time.Second * 10
 	window       = time.Second * 30
+
+	dynamicCgroupPathTTL = 5 * time.Minute
 )
 
 var Exp30s = 1 / math.Exp(float64(CpiFetchFreq)/float64(window))
@@ -65,23 +68,31 @@ var Exp30s = 1 / math.Exp(float64(CpiFetchFreq)/float64(window))
 func NewMalachiteMetricsProvisioner(baseConf *global.BaseConfiguration, _ *metaserver.MetricConfiguration,
 	emitter metrics.MetricEmitter, fetcher pod.PodFetcher, metricStore *utilmetric.MetricStore, machineInfo *machine.KatalystMachineInfo,
 ) types.MetricsProvisioner {
-	return &MalachiteMetricsProvisioner{
-		malachiteClient: client.NewMalachiteClient(fetcher, emitter),
-		metricStore:     metricStore,
-		emitter:         emitter,
-		baseConf:        baseConf,
-		machineInfo:     machineInfo,
+	provisioner := &MalachiteMetricsProvisioner{
+		malachiteClient:          client.NewMalachiteClient(fetcher, emitter),
+		metricStore:              metricStore,
+		emitter:                  emitter,
+		baseConf:                 baseConf,
+		machineInfo:              machineInfo,
+		dynamicCgroupPaths:       sets.NewString(),
+		dynamicCgroupLastQueryAt: make(map[string]time.Time),
 	}
+	metricStore.SetOnCgroupMetricAccess(provisioner.TouchDynamicCgroupPath)
+	metricStore.SetOnCgroupMetricMiss(provisioner.AddDynamicCgroupPath)
+	return provisioner
 }
 
 type MalachiteMetricsProvisioner struct {
-	metricStore     *utilmetric.MetricStore
-	malachiteClient *client.MalachiteClient
-	baseConf        *global.BaseConfiguration
-	emitter         metrics.MetricEmitter
-	machineInfo     *machine.KatalystMachineInfo
-	startOnce       sync.Once
-	cpuToNumaMap    map[int]int
+	metricStore              *utilmetric.MetricStore
+	malachiteClient          *client.MalachiteClient
+	baseConf                 *global.BaseConfiguration
+	emitter                  metrics.MetricEmitter
+	machineInfo              *machine.KatalystMachineInfo
+	startOnce                sync.Once
+	cpuToNumaMap             map[int]int
+	dynamicPathsMu           sync.RWMutex
+	dynamicCgroupPaths       sets.String
+	dynamicCgroupLastQueryAt map[string]time.Time
 }
 
 func (m *MalachiteMetricsProvisioner) Run(ctx context.Context) {
@@ -190,6 +201,8 @@ func (m *MalachiteMetricsProvisioner) updateSystemStats() error {
 }
 
 func (m *MalachiteMetricsProvisioner) getCgroupPaths() []string {
+	m.cleanupExpiredDynamicCgroupPaths(time.Now())
+
 	cgroupPaths := []string{m.baseConf.ReclaimRelativeRootCgroupPath, common.CgroupFsRootPathBurstable, common.CgroupFsRootPathBestEffort}
 	for _, path := range common.GetNUMABindingReclaimRelativeRootCgroupPaths(m.baseConf.ReclaimRelativeRootCgroupPath,
 		m.machineInfo.CPUDetails.NUMANodes().ToSliceNoSortInt()) {
@@ -200,7 +213,6 @@ func (m *MalachiteMetricsProvisioner) getCgroupPaths() []string {
 	for _, path := range m.baseConf.OptionalRelativeCgroupPaths {
 		absPath := common.GetAbsCgroupPath(common.DefaultSelectedSubsys, path)
 		if !general.IsPathExists(absPath) {
-			general.Infof("cgroup path %v not existed, ignore it", path)
 			continue
 		}
 		cgroupPaths = append(cgroupPaths, path)
@@ -210,8 +222,56 @@ func (m *MalachiteMetricsProvisioner) getCgroupPaths() []string {
 		cgroupPaths = append(cgroupPaths, path)
 	}
 
+	m.dynamicPathsMu.RLock()
+	for path := range m.dynamicCgroupPaths {
+		cgroupPaths = append(cgroupPaths, path)
+	}
+	m.dynamicPathsMu.RUnlock()
+
 	dedupCgroupPaths := general.DedupStringSlice(cgroupPaths)
 	return dedupCgroupPaths
+}
+
+func (m *MalachiteMetricsProvisioner) AddDynamicCgroupPath(cgroupPath string) {
+	m.addOrTouchDynamicCgroupPath(cgroupPath, time.Now(), true)
+}
+
+func (m *MalachiteMetricsProvisioner) TouchDynamicCgroupPath(cgroupPath string) {
+	m.addOrTouchDynamicCgroupPath(cgroupPath, time.Now(), false)
+}
+
+func (m *MalachiteMetricsProvisioner) addOrTouchDynamicCgroupPath(cgroupPath string, now time.Time, addIfAbsent bool) {
+	if cgroupPath == "" {
+		return
+	}
+
+	m.dynamicPathsMu.Lock()
+	defer m.dynamicPathsMu.Unlock()
+
+	if !m.dynamicCgroupPaths.Has(cgroupPath) {
+		if !addIfAbsent {
+			return
+		}
+		m.dynamicCgroupPaths.Insert(cgroupPath)
+		general.Infof("[malachite] register cgroup path %v for on-demand metric collection", cgroupPath)
+	}
+
+	m.dynamicCgroupLastQueryAt[cgroupPath] = now
+}
+
+func (m *MalachiteMetricsProvisioner) cleanupExpiredDynamicCgroupPaths(now time.Time) {
+	m.dynamicPathsMu.Lock()
+	defer m.dynamicPathsMu.Unlock()
+
+	for cgroupPath := range m.dynamicCgroupPaths {
+		lastQueryAt, ok := m.dynamicCgroupLastQueryAt[cgroupPath]
+		if ok && now.Sub(lastQueryAt) <= dynamicCgroupPathTTL {
+			continue
+		}
+		m.dynamicCgroupPaths.Delete(cgroupPath)
+		delete(m.dynamicCgroupLastQueryAt, cgroupPath)
+		general.Infof("[malachite] remove stale dynamic cgroup path %v from on-demand metric collection", cgroupPath)
+	}
 }
 
 func (m *MalachiteMetricsProvisioner) updateCgroupData() error {

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -295,6 +295,60 @@ func Test_getCPI(t *testing.T) {
 	assert.Equal(t, float64(1), data.Value)
 }
 
+func Test_registerDynamicCgroupPathOnMetricMiss(t *testing.T) {
+	t.Parallel()
+	store := utilmetric.NewMetricStore()
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	assert.Nil(t, err)
+
+	implement := NewMalachiteMetricsProvisioner(&global.BaseConfiguration{
+		ReclaimRelativeRootCgroupPath: "test",
+		MalachiteConfiguration: &global.MalachiteConfiguration{
+			GeneralRelativeCgroupPaths:  []string{"d1"},
+			OptionalRelativeCgroupPaths: []string{"d2"},
+		},
+	}, &metaserver.MetricConfiguration{}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store,
+		&machine.KatalystMachineInfo{
+			CPUTopology: cpuTopology,
+		})
+
+	provisioner := implement.(*MalachiteMetricsProvisioner)
+	_, err = store.GetCgroupMetric("dynamic-cgroup", consts.MetricMemUsageCgroup)
+	assert.Error(t, err)
+	assert.Contains(t, provisioner.getCgroupPaths(), "dynamic-cgroup")
+
+	_, err = store.GetCgroupNumaMetric("dynamic-cgroup-numa", 0, consts.MetricsMemTotalPerNumaCgroup)
+	assert.Error(t, err)
+	assert.Contains(t, provisioner.getCgroupPaths(), "dynamic-cgroup-numa")
+}
+
+func Test_cleanupExpiredDynamicCgroupPaths(t *testing.T) {
+	t.Parallel()
+	store := utilmetric.NewMetricStore()
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	assert.Nil(t, err)
+
+	implement := NewMalachiteMetricsProvisioner(&global.BaseConfiguration{
+		ReclaimRelativeRootCgroupPath: "test",
+		MalachiteConfiguration:        &global.MalachiteConfiguration{},
+	}, &metaserver.MetricConfiguration{}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store,
+		&machine.KatalystMachineInfo{
+			CPUTopology: cpuTopology,
+		})
+
+	provisioner := implement.(*MalachiteMetricsProvisioner)
+	now := time.Now()
+	provisioner.addOrTouchDynamicCgroupPath("fresh-cgroup", now, true)
+	provisioner.addOrTouchDynamicCgroupPath("stale-cgroup", now.Add(-dynamicCgroupPathTTL-time.Second), true)
+
+	provisioner.cleanupExpiredDynamicCgroupPaths(now)
+
+	assert.True(t, provisioner.dynamicCgroupPaths.Has("fresh-cgroup"))
+	assert.False(t, provisioner.dynamicCgroupPaths.Has("stale-cgroup"))
+	_, ok := provisioner.dynamicCgroupLastQueryAt["stale-cgroup"]
+	assert.False(t, ok)
+}
+
 func Test_setContainerMbmTotalMetric(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/util/metric/store.go
+++ b/pkg/util/metric/store.go
@@ -52,6 +52,8 @@ type MetricStore struct {
 	cgroupMetricMap           map[string]map[string]MetricData                    // map[cgroupPath]map[metricName]value
 	cgroupNumaMetricMap       map[string]map[int]map[string]MetricData            // map[cgroupPath]map[numaNode]map[metricName]value
 	stringIndexedMetricMap    map[string]interface{}
+	onCgroupMetricAccess      func(cgroupPath string)
+	onCgroupMetricMiss        func(cgroupPath string)
 }
 
 func NewMetricStore() *MetricStore {
@@ -80,6 +82,36 @@ func (c *MetricStore) SetByStringIndex(metricName string, metricMap interface{})
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.stringIndexedMetricMap[metricName] = metricMap
+}
+
+func (c *MetricStore) SetOnCgroupMetricMiss(handler func(cgroupPath string)) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.onCgroupMetricMiss = handler
+}
+
+func (c *MetricStore) SetOnCgroupMetricAccess(handler func(cgroupPath string)) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.onCgroupMetricAccess = handler
+}
+
+func (c *MetricStore) notifyCgroupMetricAccess(cgroupPath string) {
+	c.mutex.RLock()
+	handler := c.onCgroupMetricAccess
+	c.mutex.RUnlock()
+	if handler != nil {
+		handler(cgroupPath)
+	}
+}
+
+func (c *MetricStore) notifyCgroupMetricMiss(cgroupPath string) {
+	c.mutex.RLock()
+	handler := c.onCgroupMetricMiss
+	c.mutex.RUnlock()
+	if handler != nil {
+		handler(cgroupPath)
+	}
 }
 
 func (c *MetricStore) SetNodeMetric(metricName string, data MetricData) {
@@ -319,14 +351,16 @@ func (c *MetricStore) SetCgroupMetric(cgroupPath, metricName string, data Metric
 }
 
 func (c *MetricStore) GetCgroupMetric(cgroupPath, metricName string) (MetricData, error) {
+	c.notifyCgroupMetricAccess(cgroupPath)
 	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
 	metrics, ok := c.cgroupMetricMap[cgroupPath]
 	if !ok {
+		c.mutex.RUnlock()
+		c.notifyCgroupMetricMiss(cgroupPath)
 		return MetricData{}, fmt.Errorf("[MetricStore] load cgroup for %v failed", cgroupPath)
 	}
 	data, ok := metrics[metricName]
+	c.mutex.RUnlock()
 	if !ok {
 		return MetricData{}, fmt.Errorf("[MetricStore] load value for %v failed", metricName)
 	}
@@ -351,17 +385,21 @@ func (c *MetricStore) SetCgroupNumaMetric(cgroupPath string, numaNode int, metri
 }
 
 func (c *MetricStore) GetCgroupNumaMetric(cgroupPath string, numaNode int, metricName string) (MetricData, error) {
+	c.notifyCgroupMetricAccess(cgroupPath)
 	c.mutex.RLock()
-	defer c.mutex.RUnlock()
 	numaMetrics, ok := c.cgroupNumaMetricMap[cgroupPath]
 	if !ok {
+		c.mutex.RUnlock()
+		c.notifyCgroupMetricMiss(cgroupPath)
 		return MetricData{}, fmt.Errorf("[MetricStore] load value for %v failed", cgroupPath)
 	}
 	metrics, ok := numaMetrics[numaNode]
 	if !ok {
+		c.mutex.RUnlock()
 		return MetricData{}, fmt.Errorf("[MetricStore] load value for %v failed", numaNode)
 	}
 	metric, ok := metrics[metricName]
+	c.mutex.RUnlock()
 	if !ok {
 		return MetricData{}, fmt.Errorf("[MetricStore] load value for %v failed", metricName)
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features
#### What this PR does / why we need it:
    
    When a cgroup metric query misses in MetricStore, register the queried
    cgroup path into MalachiteMetricsProvisioner so malachite can start
    collecting metrics for it in later sampling rounds.
    
    Also track the last query time for dynamically added cgroup paths and
    remove entries that have not been queried for more than 5 minutes, so
    the dynamic collection set does not grow without bound.
    
    Changes included:
    - add cgroup access/miss callbacks in MetricStore
    - auto-register missing cgroup paths into malachite dynamic collection
    - refresh last query timestamp on cgroup metric access
    - clean up stale dynamic cgroup paths with a 5-minute TTL
    - add tests for dynamic registration and TTL-based cleanup
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
