### PR TITLE
metrics(sys-advisor): power advisor - node_power_advisor_health metric

### DIFF
--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor.go
@@ -18,6 +18,7 @@ package advisor
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -46,6 +47,18 @@ type PowerAwareAdvisor interface {
 	Run(ctx context.Context)
 	// Init initializes components
 	Init() error
+	// HealthStatus returns the health status of the advisor
+	HealthStatus() map[string]string
+}
+
+// healthState groups fields that provide input to HealthStatus().
+// All fields are safe to read from the healthMonitor goroutine while
+// being written from the main advisor goroutine.
+type healthState struct {
+	enteredMainLoop  uint32
+	errorCounters    map[string]*int64
+	cappingDisabled  bool
+	evictionDisabled bool
 }
 
 type powerAwareAdvisor struct {
@@ -59,6 +72,8 @@ type powerAwareAdvisor struct {
 	// inFreqCap is flag whether node is state of power capping via CPU frequency adjustment
 	// it is checked for power capping reset when alert is gone
 	inFreqCap bool
+
+	state *healthState
 }
 
 func (p *powerAwareAdvisor) Init() error {
@@ -107,6 +122,8 @@ func (p *powerAwareAdvisor) Run(ctx context.Context) {
 	defer p.cleanup()
 	defer p.powerCapper.Reset()
 
+	atomic.StoreUint32(&p.state.enteredMainLoop, 1)
+
 	wait.Until(func() { p.run(ctx) }, intervalSpecFetch, ctx.Done())
 
 	general.Infof("pap: advisor Run exited")
@@ -125,6 +142,7 @@ func (p *powerAwareAdvisor) cleanup() {
 func (p *powerAwareAdvisor) run(ctx context.Context) {
 	powerSpec, err := p.specFetcher.GetPowerSpec(ctx)
 	if err != nil {
+		atomic.AddInt64(p.state.errorCounters[powermetric.TagHealthSpecRead], 1)
 		p.emitErrorCode(powermetric.ErrorCodePowerSpecFormat)
 		klog.Errorf("pap: getting power spec failed: %#v", err)
 		return
@@ -150,6 +168,7 @@ func (p *powerAwareAdvisor) run(ctx context.Context) {
 
 	currentWatts, err := p.powerReader.Get(ctx)
 	if err != nil {
+		atomic.AddInt64(p.state.errorCounters[powermetric.TagHealthPowerRead], 1)
 		p.emitErrorCode(powermetric.ErrorCodePowerGetCurrentUsage)
 		klog.Errorf("pap: reading power failed: %#v", err)
 		return
@@ -163,6 +182,7 @@ func (p *powerAwareAdvisor) run(ctx context.Context) {
 
 	freqCapped, err := p.reconciler.Reconcile(ctx, powerSpec, currentWatts)
 	if err != nil {
+		atomic.AddInt64(p.state.errorCounters[powermetric.TagHealthReconcile], 1)
 		p.emitErrorCode(powermetric.ErrorCodeRecoverable)
 		general.Errorf("pap: reconcile error: %v", err)
 		return
@@ -173,6 +193,46 @@ func (p *powerAwareAdvisor) run(ctx context.Context) {
 	}
 }
 
+// healthStatus returns the health status of the advisor.
+// Called from the healthMonitor goroutine.
+func (s *healthState) healthStatus() map[string]string {
+	result := make(map[string]string, 6)
+
+	result[powermetric.TagHealthRunning] = statusOK(atomic.LoadUint32(&s.enteredMainLoop) != 0, powermetric.StatusNOK)
+
+	for dim, counter := range s.errorCounters {
+		result[dim] = errorCounterStatus(counter)
+	}
+
+	result[powermetric.TagHealthCapping] = statusOK(!s.cappingDisabled, powermetric.StatusNA)
+	result[powermetric.TagHealthEviction] = statusOK(!s.evictionDisabled, powermetric.StatusNA)
+
+	return result
+}
+
+func (p *powerAwareAdvisor) HealthStatus() map[string]string {
+	return p.state.healthStatus()
+}
+
+// errorCounterStatus atomically reads and resets the error counter.
+// Swap(0) returns errors accumulated over the past 30s window, then clears
+// the counter. Errors that occur in subsequent windows will still be
+// detected — this is a continuous rolling window, not a one-time heal.
+func errorCounterStatus(counter *int64) string {
+	if atomic.SwapInt64(counter, 0) > 0 {
+		return powermetric.StatusNOK
+	}
+	return powermetric.StatusOK
+}
+
+// statusOK returns "ok" if ok is true, otherwise returns failValue.
+func statusOK(ok bool, failValue string) string {
+	if ok {
+		return powermetric.StatusOK
+	}
+	return failValue
+}
+
 func NewAdvisor(dryRun bool,
 	annotationKeyPrefix string,
 	podEvictor evictor.PodEvictor,
@@ -181,6 +241,8 @@ func NewAdvisor(dryRun bool,
 	reader reader.PowerReader,
 	capper capper.PowerCapper,
 	reconciler PowerReconciler,
+	disableCapping bool,
+	disableEviction bool,
 ) PowerAwareAdvisor {
 	return &powerAwareAdvisor{
 		emitter:     emitter,
@@ -190,5 +252,14 @@ func NewAdvisor(dryRun bool,
 		powerCapper: capper,
 		reconciler:  reconciler,
 		inFreqCap:   false,
+		state: &healthState{
+			errorCounters: map[string]*int64{
+				powermetric.TagHealthSpecRead:  new(int64),
+				powermetric.TagHealthPowerRead: new(int64),
+				powermetric.TagHealthReconcile: new(int64),
+			},
+			cappingDisabled:  disableCapping,
+			evictionDisabled: disableEviction,
+		},
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/advisor/advisor_test.go
@@ -18,6 +18,7 @@ package advisor
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -128,6 +129,17 @@ func (d *dummySpecFetcher) GetPowerSpec(ctx context.Context) (*spec.PowerSpec, e
 	}
 }
 
+// defaultHealthState returns a healthState with default errorCounters for testing.
+func defaultHealthState() *healthState {
+	return &healthState{
+		errorCounters: map[string]*int64{
+			"spec_read":  new(int64),
+			"power_read": new(int64),
+			"reconcile":  new(int64),
+		},
+	}
+}
+
 func Test_powerAwareAdvisor_run_normal(t *testing.T) {
 	t.Parallel()
 	// make sure advisor run gets power spec, gets actual power status, and takes action in order
@@ -142,6 +154,7 @@ func Test_powerAwareAdvisor_run_normal(t *testing.T) {
 		specFetcher: &depSpecFetcher,
 		powerReader: depPowerReader,
 		reconciler:  depPowerCapper,
+		state:       defaultHealthState(),
 	}
 
 	ctx := context.TODO()
@@ -172,6 +185,7 @@ func Test_powerAwareAdvisor_run_abort_on_spec_fetcher_error(t *testing.T) {
 		emitter:     &metrics.DummyMetrics{},
 		specFetcher: &depSpecFetcher,
 		powerReader: depPowerReader,
+		state:       defaultHealthState(),
 	}
 
 	ctx := context.TODO()
@@ -197,6 +211,7 @@ func Test_powerAwareAdvisor_run_return_on_None_alert(t *testing.T) {
 		specFetcher: &depSpecFetcher,
 		powerReader: depPowerReader,
 		powerCapper: depInitResetter,
+		state:       defaultHealthState(),
 	}
 
 	ctx := context.TODO()
@@ -226,6 +241,7 @@ func Test_powerAwareAdvisor_run_return_on_Pause_op(t *testing.T) {
 		specFetcher: &depSpecFetcher,
 		powerReader: depPowerReader,
 		powerCapper: depInitResetter,
+		state:       defaultHealthState(),
 	}
 
 	ctx := context.TODO()
@@ -255,6 +271,7 @@ func Test_powerAwareAdvisor_Run_does_Init_Cleanup(t *testing.T) {
 		emitter:     &metrics.DummyMetrics{},
 		powerReader: depPowerReader,
 		podEvictor:  depPodEvictor,
+		state:       defaultHealthState(),
 	}
 
 	err := advisor.Init()
@@ -267,5 +284,41 @@ func Test_powerAwareAdvisor_Run_does_Init_Cleanup(t *testing.T) {
 	}
 	if !depPodEvictor.calledInit {
 		t.Errorf("expected power evict init called called; got %v", depPodEvictor.calledInit)
+	}
+}
+
+func Test_healthState_resets_error_counters(t *testing.T) {
+	t.Parallel()
+
+	var ecSpec int64
+	atomic.AddInt64(&ecSpec, 3)
+	var ecPower int64
+	atomic.AddInt64(&ecPower, 1)
+
+	s := defaultHealthState()
+	s.errorCounters = map[string]*int64{
+		"spec_read":  &ecSpec,
+		"power_read": &ecPower,
+		"reconcile":  new(int64),
+	}
+
+	statuses := s.healthStatus()
+
+	if statuses["spec_read"] != "nok" {
+		t.Errorf("spec_read = %s, want nok", statuses["spec_read"])
+	}
+	if statuses["power_read"] != "nok" {
+		t.Errorf("power_read = %s, want nok", statuses["power_read"])
+	}
+	if statuses["reconcile"] != "ok" {
+		t.Errorf("reconcile = %s, want ok", statuses["reconcile"])
+	}
+
+	statuses2 := s.healthStatus()
+	if statuses2["spec_read"] != "ok" {
+		t.Errorf("spec_read = %s, want ok after reset", statuses2["spec_read"])
+	}
+	if statuses2["power_read"] != "ok" {
+		t.Errorf("power_read = %s, want ok after reset", statuses2["power_read"])
 	}
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/health_monitor.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/health_monitor.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package poweraware
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/advisor"
+	powermetric "github.com/kubewharf/katalyst-core/pkg/agent/sysadvisor/plugin/poweraware/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+)
+
+type healthMonitor struct {
+	advisor advisor.PowerAwareAdvisor
+	emitter metrics.MetricEmitter
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+func newHealthMonitor(advisor advisor.PowerAwareAdvisor, emitter metrics.MetricEmitter) *healthMonitor {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &healthMonitor{
+		advisor: advisor,
+		emitter: emitter,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+func (h *healthMonitor) Start() {
+	go wait.Until(func() {
+		powermetric.EmitPowerAdvisorHealth(h.emitter, h.advisor.HealthStatus())
+	}, 30*time.Second, h.ctx.Done())
+}
+
+func (h *healthMonitor) Stop() {
+	if h.cancel != nil {
+		h.cancel()
+	}
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/metric/emit_metric.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/metric/emit_metric.go
@@ -85,3 +85,9 @@ func EmitErrorCode(emitter metrics.MetricEmitter, cause ErrorCause) {
 func EmitGetAdviceCalled(emitter metrics.MetricEmitter) {
 	_ = emitter.StoreInt64(metricGetAdviceCalled, 1, metrics.MetricTypeNameCount)
 }
+
+func EmitPowerAdvisorHealth(emitter metrics.MetricEmitter, statuses map[string]string) {
+	_ = emitter.StoreInt64(metricPowerAdvisorHealth, 1, metrics.MetricTypeNameRaw,
+		metrics.ConvertMapToTags(statuses)...,
+	)
+}

--- a/pkg/agent/sysadvisor/plugin/poweraware/metric/metric_tag.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/metric/metric_tag.go
@@ -25,6 +25,7 @@ const (
 	metricPowerCappingTarget           = "node_power_cap_target"
 	metricPowerCappingCurrent          = "node_power_cap_current"
 	metricPowerError                   = "node_power_error"
+	metricPowerAdvisorHealth           = "node_power_advisor_health"
 	metricGetAdviceCalled              = "node_power_get_advice"
 
 	tagPowerAlert         = "alert"
@@ -33,4 +34,15 @@ const (
 	tagPowerActionMode    = "mode"
 	tagPowerCappingOpCode = "op"
 	tagErrorCause         = "cause"
+
+	TagHealthRunning   = "running"
+	TagHealthSpecRead  = "spec_read"
+	TagHealthPowerRead = "power_read"
+	TagHealthReconcile = "reconcile"
+	TagHealthCapping   = "capping"
+	TagHealthEviction  = "eviction"
+
+	StatusOK  = "ok"
+	StatusNOK = "nok"
+	StatusNA  = "na"
 )

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/sysadvisor/poweraware"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	metricspool "github.com/kubewharf/katalyst-core/pkg/metrics/metrics-pool"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
@@ -42,30 +43,43 @@ import (
 const metricName = "poweraware-advisor-plugin"
 
 type powerAwarePlugin struct {
-	name    string
-	dryRun  bool
-	advisor advisor.PowerAwareAdvisor
+	name          string
+	dryRun        bool
+	advisor       advisor.PowerAwareAdvisor
+	healthMonitor *healthMonitor
 }
 
-func (p powerAwarePlugin) Name() string {
+func (p *powerAwarePlugin) Name() string {
 	return p.name
 }
 
-func (p powerAwarePlugin) Init() error {
-	general.Infof("pap initialized")
+func (p *powerAwarePlugin) Init() error {
+	// must start before advisor.Init(): framework wraps Init() with 10s timeout,
+	// and abandons the plugin (no Run() call) if Init() times out or errors out.
+	p.healthMonitor.Start()
+
+	general.Infof("pap: initializing power advisor")
 
 	if err := p.advisor.Init(); err != nil {
 		klog.Errorf("pap: failed to initialize power advisor: %v", err)
 		return errors.Wrap(err, "failed to initialize power advisor")
 	}
 
+	general.Infof("pap: power advisor initialized")
+
 	return nil
 }
 
-func (p powerAwarePlugin) Run(ctx context.Context) {
-	general.Infof("pap running")
+func (p *powerAwarePlugin) Run(ctx context.Context) {
+	general.Infof("pap: running")
+
+	go func() {
+		<-ctx.Done()
+		p.healthMonitor.Stop()
+	}()
+
 	p.advisor.Run(ctx)
-	general.Infof("pap ran and finished")
+	general.Infof("pap: power advisor ran and finished")
 }
 
 func NewPowerAwarePlugin(
@@ -119,15 +133,18 @@ func NewPowerAwarePlugin(
 		powerReader,
 		powerCapper,
 		reconciler,
+		conf.DisablePowerCapping,
+		conf.DisablePowerPressureEvict,
 	)
 
-	return newPluginWithAdvisor(pluginName, conf, powerAdvisor)
+	return newPluginWithAdvisor(pluginName, conf, powerAdvisor, emitter)
 }
 
-func newPluginWithAdvisor(pluginName string, conf *config.Configuration, advisor advisor.PowerAwareAdvisor) (plugin.SysAdvisorPlugin, error) {
+func newPluginWithAdvisor(pluginName string, conf *config.Configuration, advisor advisor.PowerAwareAdvisor, emitter metrics.MetricEmitter) (plugin.SysAdvisorPlugin, error) {
 	return &powerAwarePlugin{
-		name:    pluginName,
-		dryRun:  conf.PowerAwarePluginConfiguration.DryRun,
-		advisor: advisor,
+		name:          pluginName,
+		dryRun:        conf.PowerAwarePluginConfiguration.DryRun,
+		advisor:       advisor,
+		healthMonitor: newHealthMonitor(advisor, emitter),
 	}, nil
 }

--- a/pkg/agent/sysadvisor/plugin/poweraware/power_aware_test.go
+++ b/pkg/agent/sysadvisor/plugin/poweraware/power_aware_test.go
@@ -85,6 +85,8 @@ func Test_powerAwarePlugin_Name(t *testing.T) {
 		nil,
 		nil,
 		reconciler,
+		false, // disableCapping (capper=nil, but not disabled by config)
+		true,  // disableEviction (noop evictor, treated as disabled)
 	)
 
 	p, err := newPluginWithAdvisor(expectedName,
@@ -101,6 +103,7 @@ func Test_powerAwarePlugin_Name(t *testing.T) {
 			},
 		},
 		stubAdvisor,
+		dummyEmitterPool.GetDefaultMetricsEmitter(),
 	)
 	if err != nil {
 		t.Errorf("unexpected error: %#v", err)
@@ -161,18 +164,22 @@ func Test_powerAwarePlugin_Init(t *testing.T) {
 				nil,
 				strategy,
 			)
+			stubAdvisor := advisor.NewAdvisor(false,
+				"bar",
+				evictor.NewNoopPodEvictor(),
+				dummyEmitter,
+				tt.fields.nodeFetcher,
+				reader.NewDummyPowerReader(),
+				capper.NewNoopCapper(),
+				reconciler,
+				false, // disableCapping
+				true,  // disableEviction
+			)
 			p := powerAwarePlugin{
-				name:   tt.fields.name,
-				dryRun: tt.fields.dryRun,
-				advisor: advisor.NewAdvisor(false,
-					"bar",
-					evictor.NewNoopPodEvictor(),
-					dummyEmitter,
-					tt.fields.nodeFetcher,
-					reader.NewDummyPowerReader(),
-					capper.NewNoopCapper(),
-					reconciler,
-				),
+				name:          tt.fields.name,
+				dryRun:        tt.fields.dryRun,
+				advisor:       stubAdvisor,
+				healthMonitor: newHealthMonitor(stubAdvisor, dummyEmitter),
 			}
 			if err := p.Init(); (err != nil) != tt.wantErr {
 				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
@@ -221,9 +228,10 @@ func Test_powerAwarePlugin_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := powerAwarePlugin{
-				name:    tt.fields.name,
-				dryRun:  tt.fields.dryRun,
-				advisor: tt.fields.advisor,
+				name:          tt.fields.name,
+				dryRun:        tt.fields.dryRun,
+				advisor:       tt.fields.advisor,
+				healthMonitor: newHealthMonitor(tt.fields.advisor, nil),
 			}
 			p.Run(tt.args.ctx)
 			if !testAdvisor.called {
@@ -240,44 +248,18 @@ func TestNewPowerAwarePlugin(t *testing.T) {
 			NodeFetcher: &stubNodeFetcher{},
 		},
 	}
-	type args struct {
-		pluginName string
-		conf       *config.Configuration
-		metaServer *metaserver.MetaServer
+	conf := &config.Configuration{
+		GenericConfiguration: generic.NewGenericConfiguration(),
+		AgentConfiguration:   agentconf.NewAgentConfiguration(),
 	}
-	tests := []struct {
-		name    string
-		args    args
-		wantNil bool
-		wantErr bool
-	}{
-		{
-			name: "happy path",
-			args: args{
-				pluginName: "test",
-				conf: &config.Configuration{
-					GenericConfiguration: generic.NewGenericConfiguration(),
-					AgentConfiguration:   agentconf.NewAgentConfiguration(),
-				},
-				metaServer: stubMetaServer,
-			},
-			wantErr: false,
-		},
+	conf.DisablePowerCapping = true
+	conf.DisablePowerPressureEvict = true
+
+	got, err := NewPowerAwarePlugin("test", conf, nil, &metricspool.DummyMetricsEmitterPool{}, stubMetaServer, nil)
+	if err != nil {
+		t.Errorf("NewPowerAwarePlugin() error = %v, wantErr false", err)
 	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got, err := NewPowerAwarePlugin(tt.args.pluginName,
-				tt.args.conf, nil, &metricspool.DummyMetricsEmitterPool{},
-				tt.args.metaServer, nil)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewPowerAwarePlugin() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if (got == nil) != tt.wantNil {
-				t.Errorf("NewPowerAwarePlugin() got unexpected value %v", got)
-			}
-		})
+	if got == nil {
+		t.Errorf("NewPowerAwarePlugin() returned nil")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
it adds metrics about power-advisor, emitting every 30 seconds with 6 tags:
* running: Advisor 是否已进入主循环（ enteredMainLoop ）
* spec_read: 过去 30s 内读取 spec 是否有错误
* power_read: 过去 30s 内读取功率是否有错误
* reconcile: 过去 30s 内 reconcile 是否有错误
* capping: 功率封顶是否启用（禁用时为 na ）
* eviction: 压力驱逐是否启用（禁用时为 na ）

the metrics provides comprehensive health status for power-aware advisor, serves as part of data source of 超电治理覆盖率

#### Special notes for your reviewer:
tested at test env, the metric graph is as 
<img width="1237" height="476" alt="image" src="https://github.com/user-attachments/assets/49d50ac9-1236-4c4c-815a-673db4d87aab" />

