### PR TITLE
refactor: qrm allocation hooks

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -85,6 +85,8 @@ const (
 
 var AccompanyResourceRegistry = accompanyresource.NewRegistry()
 
+type AllocationHook func(oldAllocationInfo, newAllocationInfo *state.AllocationInfo) error
+
 // DynamicPolicy is the policy that's used by default;
 // it will consider the dynamic running information to calculate
 // and adjust resource requirements and configurations
@@ -111,6 +113,7 @@ type DynamicPolicy struct {
 	residualHitMap     map[string]int64
 	allocationHandlers map[string]util.AllocationHandler
 	hintHandlers       map[string]util.HintHandler
+	allocationHooks    []AllocationHook
 
 	cpuPressureEviction       agent.Component
 	cpuPressureEvictionCancel context.CancelFunc
@@ -562,6 +565,7 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 			if allocationInfo == nil {
 				continue
 			}
+			originAllocationInfo := allocationInfo
 			allocationInfo = allocationInfo.Clone()
 
 			// sync allocation info from main container to sidecar
@@ -569,7 +573,11 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 				if p.applySidecarAllocationInfoFromMainContainer(allocationInfo, mainContainerAllocationInfo) {
 					general.Infof("pod: %s/%s, container: %s sync allocation info from main container",
 						allocationInfo.PodNamespace, allocationInfo.PodName, containerName)
-					p.state.SetAllocationInfo(podUID, containerName, allocationInfo, true)
+					if err := p.updateAllocationInfo(podUID, containerName, originAllocationInfo, allocationInfo, true); err != nil {
+						general.Errorf("updateAllocationInfo failed for pod: %s/%s, container: %s: %v",
+							allocationInfo.PodNamespace, allocationInfo.PodName, containerName, err)
+						continue
+					}
 					needUpdateMachineState = true
 				}
 			}
@@ -593,11 +601,18 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 				}
 
 				allocationInfo.InitTimestamp = time.Now().Format(util.QRMTimeFormat)
-				p.state.SetAllocationInfo(podUID, containerName, allocationInfo, true)
+				if err := p.updateAllocationInfo(podUID, containerName, originAllocationInfo, allocationInfo, true); err != nil {
+					general.Errorf("updateAllocationInfo failed for pod: %s/%s, container: %s: %v",
+						allocationInfo.PodNamespace, allocationInfo.PodName, containerName, err)
+				}
 			} else if allocationInfo.RampUp && time.Now().After(initTs.Add(p.transitionPeriod)) {
 				general.Infof("pod: %s/%s, container: %s ramp up finished", allocationInfo.PodNamespace, allocationInfo.PodName, allocationInfo.ContainerName)
 				allocationInfo.RampUp = false
-				p.state.SetAllocationInfo(podUID, containerName, allocationInfo, true)
+				if err := p.updateAllocationInfo(podUID, containerName, originAllocationInfo, allocationInfo, true); err != nil {
+					general.Errorf("updateAllocationInfo failed for pod: %s/%s, container: %s: %v",
+						allocationInfo.PodNamespace, allocationInfo.PodName, containerName, err)
+					continue
+				}
 
 				if allocationInfo.CheckShared() {
 					allocationInfosJustFinishRampUp = append(allocationInfosJustFinishRampUp, allocationInfo)
@@ -1429,4 +1444,63 @@ func (p *DynamicPolicy) applySidecarAllocationInfoFromMainContainer(sidecarAlloc
 	}
 
 	return changed
+}
+
+// RegisterAllocationHook registers a hook that is called before allocation info is updated.
+// It is concurrency-safe.
+func (p *DynamicPolicy) RegisterAllocationHook(hook AllocationHook) {
+	p.Lock()
+	defer p.Unlock()
+	p.allocationHooks = append(p.allocationHooks, hook)
+}
+
+// invokeAllocationHooks executes all registered hooks. It is called without re-acquiring the lock.
+func (p *DynamicPolicy) invokeAllocationHooks(oldAllocationInfo, newAllocationInfo *state.AllocationInfo) error {
+	for _, hook := range p.allocationHooks {
+		if err := hook(oldAllocationInfo, newAllocationInfo); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// invokeAllocationHooksForPodEntries triggers allocation hooks for non-pool containers before committing to state.
+func (p *DynamicPolicy) invokeAllocationHooksForPodEntries(curEntries, newEntries state.PodEntries) error {
+	if len(p.allocationHooks) == 0 {
+		return nil
+	}
+
+	for podUID, containerEntries := range newEntries {
+		if containerEntries.IsPoolEntry() {
+			continue
+		}
+		for containerName, newAllocationInfo := range containerEntries {
+			var oldAllocationInfo *state.AllocationInfo
+			// retrieve old allocation info from curEntries directly to avoid the overhead
+			// of GetAllocationInfo which involves Clone() operations.
+			if curContainerEntries, ok := curEntries[podUID]; ok {
+				oldAllocationInfo = curContainerEntries[containerName]
+			}
+			if err := p.invokeAllocationHooks(oldAllocationInfo, newAllocationInfo); err != nil {
+				return fmt.Errorf("invokeAllocationHooks failed for pod: %s, container: %s: %v", podUID, containerName, err)
+			}
+		}
+	}
+	return nil
+}
+
+// updateAllocationInfo wraps state.SetAllocationInfo with hook execution.
+// If no hooks are registered, it avoids the overhead of retrieving the old allocation info.
+func (p *DynamicPolicy) updateAllocationInfo(podUID, containerName string, oldAllocationInfo, allocationInfo *state.AllocationInfo, persist bool) error {
+	if len(p.allocationHooks) > 0 {
+		if oldAllocationInfo == nil {
+			oldAllocationInfo = p.state.GetAllocationInfo(podUID, containerName)
+		}
+		if err := p.invokeAllocationHooks(oldAllocationInfo, allocationInfo); err != nil {
+			return err
+		}
+	}
+
+	p.state.SetAllocationInfo(podUID, containerName, allocationInfo, persist)
+	return nil
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -85,6 +85,9 @@ const (
 
 var AccompanyResourceRegistry = accompanyresource.NewRegistry()
 
+// AllocationHook is a hook function which can be registered and called when allocationInfo changes.
+// It is designed to intercept state updates and perform actions like injecting or updating annotations
+// (e.g., NUMA topology information) based on the differences between old and new allocation info.
 type AllocationHook func(oldAllocationInfo, newAllocationInfo *state.AllocationInfo) error
 
 // DynamicPolicy is the policy that's used by default;
@@ -243,6 +246,8 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		reservedReclaimedCPUsSize:       general.Max(reservedReclaimedCPUsSize, agentCtx.KatalystMachineInfo.NumNUMANodes),
 	}
 
+	policyImplement.RegisterAllocationHook(policyImplement.topologyAllocationHook)
+
 	// initialize hint optimizer
 	err = policyImplement.initHintOptimizers()
 	if err != nil {
@@ -315,6 +320,31 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 	}
 
 	return true, &agent.PluginWrapper{GenericPlugin: pluginWrapper}, nil
+}
+
+// topologyAllocationHook is an AllocationHook that intercepts allocation info changes and updates topology annotations.
+// It generates and merges topology-aware CPU allocation annotations into the allocationInfo when there are physical
+// CPU allocation changes, quantity changes, or NUMA-aware topology assignments changes.
+func (p *DynamicPolicy) topologyAllocationHook(oldInfo, newInfo *state.AllocationInfo) error {
+	if newInfo == nil || !newInfo.CheckMainContainer() || !newInfo.CheckNUMABinding() {
+		return nil
+	}
+
+	if len(newInfo.TopologyAwareAssignments) == 0 {
+		return nil
+	}
+
+	if !cpuutil.IsTopologyAllocationChanged(oldInfo, newInfo) {
+		return nil
+	}
+
+	annotations, err := cpuutil.GetCPUTopologyAllocationsAnnotations(newInfo, p.topologyAllocationAnnotationKey)
+	if err != nil {
+		return err
+	}
+
+	newInfo.Annotations = general.MergeAnnotations(newInfo.Annotations, annotations)
+	return nil
 }
 
 func (p *DynamicPolicy) Name() string {
@@ -663,6 +693,7 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 						IsScalarResource:  true,
 						AllocatedQuantity: float64(allocationInfo.AllocationResult.Size()),
 						AllocationResult:  allocationInfo.AllocationResult.String(),
+						Annotations:       general.DeepCopyMap(allocationInfo.Annotations),
 					},
 				},
 			}
@@ -1015,17 +1046,8 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 			"originalAllocationResult", allocationInfo.OriginalAllocationResult.String(),
 			"currentResult", allocationInfo.AllocationResult.String())
 
-		// Add topologyAllocationAnnotations for numa binding containers
-		var topologyAllocationAnnotations map[string]string
-		if allocationInfo.CheckNUMABinding() {
-			topologyAllocationAnnotations, err = cpuutil.GetCPUTopologyAllocationsAnnotations(allocationInfo, p.topologyAllocationAnnotationKey, req)
-			if err != nil {
-				return nil, fmt.Errorf("GetCPUTopologyAllocationsAnnotations failed with error: %v", err)
-			}
-		}
-
 		resp, err = cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs,
-			false, true, req, topologyAllocationAnnotations)
+			false, true, req, allocationInfo.Annotations)
 		if err != nil {
 			general.Errorf("pod: %s/%s, container: %s PackResourceAllocationResponseByAllocationInfo failed with error: %v",
 				req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -1429,9 +1451,9 @@ func (p *DynamicPolicy) applySidecarAllocationInfoFromMainContainer(sidecarAlloc
 		changed = true
 	}
 
-	// Copy missing annotations from main container
+	// Copy annotations from main container
 	for key, value := range mainAllocationInfo.Annotations {
-		if _, ok := sidecarAllocationInfo.Annotations[key]; !ok {
+		if sidecarAllocationInfo.Annotations[key] != value {
 			sidecarAllocationInfo.Annotations[key] = value
 			changed = true
 		}
@@ -1454,7 +1476,9 @@ func (p *DynamicPolicy) RegisterAllocationHook(hook AllocationHook) {
 	p.allocationHooks = append(p.allocationHooks, hook)
 }
 
-// invokeAllocationHooks executes all registered hooks. It is called without re-acquiring the lock.
+// invokeAllocationHooks triggers all registered allocation hooks.
+// Note: This method must be called with the lock held by the caller if concurrency protection is needed.
+// We avoid internal locking here to prevent potential deadlocks when called from methods that already hold the lock.
 func (p *DynamicPolicy) invokeAllocationHooks(oldAllocationInfo, newAllocationInfo *state.AllocationInfo) error {
 	for _, hook := range p.allocationHooks {
 		if err := hook(oldAllocationInfo, newAllocationInfo); err != nil {
@@ -1465,6 +1489,8 @@ func (p *DynamicPolicy) invokeAllocationHooks(oldAllocationInfo, newAllocationIn
 }
 
 // invokeAllocationHooksForPodEntries triggers allocation hooks for non-pool containers before committing to state.
+// Note: This method must be called with the lock held by the caller to ensure state consistency
+// and avoid deadlocks due to nested locking.
 func (p *DynamicPolicy) invokeAllocationHooksForPodEntries(curEntries, newEntries state.PodEntries) error {
 	if len(p.allocationHooks) == 0 {
 		return nil

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_advisor_handler.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_advisor_handler.go
@@ -1544,6 +1544,11 @@ func (p *DynamicPolicy) applyBlocks(blockCPUSet advisorapi.BlockCPUSet, resp *ad
 		}
 	}
 
+	// trigger allocation hooks for non-pool containers before committing to state.
+	if err := p.invokeAllocationHooksForPodEntries(curEntries, newEntries); err != nil {
+		return err
+	}
+
 	// use pod entries generated above to generate machine state info, and store in local state
 	newMachineState, err := generateMachineStateFromPodEntries(p.machineInfo.CPUTopology, newEntries, p.state.GetMachineState())
 	if err != nil {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -133,7 +133,9 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 					req.PodNamespace, req.PodName, req.ContainerName)
 				allocationInfo.RampUp = true
 			} else {
-				p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+				if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, originAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+					return nil, err
+				}
 				_, err = p.doAndCheckPutAllocationInfo(allocationInfo, false, persistCheckpoint)
 				if err != nil {
 					return nil, err
@@ -162,7 +164,9 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 				req.PodNamespace, req.PodName, req.ContainerName, allocationInfo.RequestQuantity, reqFloat64)
 			allocationInfo.RequestQuantity = reqFloat64
 
-			p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+			if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, originAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+				return nil, err
+			}
 			_, err := p.doAndCheckPutAllocationInfoPodResizingAware(originAllocationInfo, allocationInfo, false, true, persistCheckpoint)
 			if err != nil {
 				general.Errorf("pod: %s/%s, container: %s doAndCheckPutAllocationInfoPodResizingAware failed: %q",
@@ -185,7 +189,9 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 		// update pod entries directly.
 		// if one of subsequent steps is failed,
 		// we will delete current allocationInfo from podEntries in defer function of allocation function.
-		p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, originAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, err
+		}
 		podEntries := p.state.GetPodEntries()
 
 		updatedMachineState, err := generateMachineStateFromPodEntries(p.machineInfo.CPUTopology, podEntries, p.state.GetMachineState())
@@ -236,6 +242,7 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 	}
 
 	allocationInfo := p.state.GetAllocationInfo(req.PodUid, req.ContainerName)
+	originAllocationInfo := allocationInfo.Clone()
 	if util.PodInplaceUpdateResizing(req) {
 		if allocationInfo == nil {
 			return nil, fmt.Errorf("pod request to cpu inplace update resize, but origin allocationInfo is nil")
@@ -255,7 +262,9 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 		general.Infof("pod: %s/%s, container: %s request to cpu inplace update resize allocation, request: %.2f->%.2f",
 			req.PodNamespace, req.PodName, req.ContainerName, allocationInfo.RequestQuantity, reqFloat64)
 		allocationInfo.RequestQuantity = reqFloat64
-		p.state.SetAllocationInfo(req.PodUid, req.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(req.PodUid, req.ContainerName, originAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, err
+		}
 	} else {
 		err = updateAllocationInfoByReq(req, allocationInfo)
 		if err != nil {
@@ -298,7 +307,9 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 
 		// update pod entries directly.
 		// if one of subsequent steps is failed, we will delete current allocationInfo from podEntries in defer function of allocation function.
-		p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, originAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, err
+		}
 
 		// update reclaim non-actual numa_binding reclaim cores allocations if it needs to transfer a non-RNB numa to RNB numa
 		podEntries := p.state.GetPodEntries()
@@ -487,7 +498,9 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingAllocationHandler(ctx conte
 
 	// update pod entries directly.
 	// if one of subsequent steps is failed, we will delete current allocationInfo from podEntries in defer function of allocation function.
-	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+	if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, nil, allocationInfo, persistCheckpoint); err != nil {
+		return nil, err
+	}
 	podEntries := p.state.GetPodEntries()
 
 	updatedMachineState, err := generateMachineStateFromPodEntries(p.machineInfo.CPUTopology, podEntries, p.state.GetMachineState())
@@ -561,7 +574,9 @@ func (p *DynamicPolicy) allocationSidecarHandler(_ context.Context,
 
 	// update pod entries directly.
 	// if one of subsequent steps is failed, we will delete current allocationInfo from podEntries in defer function of allocation function.
-	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+	if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, nil, allocationInfo, persistCheckpoint); err != nil {
+		return nil, err
+	}
 	podEntries = p.state.GetPodEntries()
 
 	updatedMachineState, err := generateMachineStateFromPodEntries(p.machineInfo.CPUTopology, podEntries, p.state.GetMachineState())
@@ -806,7 +821,9 @@ func (p *DynamicPolicy) allocateSharedNumaBindingCPUs(req *pluginapi.ResourceReq
 
 		general.Infof("pod: %s/%s, container: %s request to cpu inplace update resize allocation (%.02f->%.02f)",
 			req.PodNamespace, req.PodName, req.ContainerName, originAllocationInfo.RequestQuantity, allocationInfo.RequestQuantity)
-		p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, originAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, err
+		}
 		checkedAllocationInfo, err := p.doAndCheckPutAllocationInfoPodResizingAware(originAllocationInfo, allocationInfo, false, true, persistCheckpoint)
 		if err != nil {
 			general.Errorf("pod: %s/%s, container: %s request to cpu inplace update resize allocation, but doAndCheckPutAllocationInfoPodResizingAware failed: %q",
@@ -816,7 +833,9 @@ func (p *DynamicPolicy) allocateSharedNumaBindingCPUs(req *pluginapi.ResourceReq
 		}
 		return checkedAllocationInfo, nil
 	} else {
-		p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, nil, allocationInfo, persistCheckpoint); err != nil {
+			return nil, err
+		}
 		checkedAllocationInfo, err := p.doAndCheckPutAllocationInfo(allocationInfo, true, persistCheckpoint)
 		if err != nil {
 			return nil, fmt.Errorf("doAndCheckPutAllocationInfo failed with error: %v", err)
@@ -1521,6 +1540,11 @@ func (p *DynamicPolicy) applyPoolsAndIsolatedInfo(poolsCPUSet map[string]machine
 		}
 	}
 
+	// trigger allocation hooks for non-pool containers before committing to state.
+	if err := p.invokeAllocationHooksForPodEntries(curEntries, newPodEntries); err != nil {
+		return err
+	}
+
 	// use pod entries generated above to generate machine state info, and store in local state
 	machineState, err = generateMachineStateFromPodEntries(p.machineInfo.CPUTopology, newPodEntries, machineState)
 	if err != nil {
@@ -2170,7 +2194,9 @@ func (p *DynamicPolicy) systemCoresAllocationHandler(ctx context.Context, req *p
 	allocationInfo.TopologyAwareAssignments = topologyAwareAssignments
 	allocationInfo.OriginalTopologyAwareAssignments = machine.DeepcopyCPUAssignment(topologyAwareAssignments)
 
-	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+	if err := p.updateAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, nil, allocationInfo, persistCheckpoint); err != nil {
+		return nil, err
+	}
 	podEntries := p.state.GetPodEntries()
 
 	updatedMachineState, err := generateMachineStateFromPodEntries(p.machineInfo.CPUTopology, podEntries, p.state.GetMachineState())

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -203,7 +203,7 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 		p.state.SetMachineState(updatedMachineState, persistCheckpoint)
 	}
 
-	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req)
+	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, allocationInfo.Annotations)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -334,17 +334,7 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 		p.state.SetMachineState(updatedMachineState, persistCheckpoint)
 	}
 
-	// Get topology allocation for numa binding reclaimed cores
-	var topologyAllocationAnnotations map[string]string
-	if allocationInfo.CheckReclaimedActualNUMABinding() {
-		var err error
-		topologyAllocationAnnotations, err = cpuutil.GetCPUTopologyAllocationsAnnotations(allocationInfo, p.conf.TopologyAllocationAnnotationKey, req)
-		if err != nil {
-			return nil, fmt.Errorf("GetCPUTopologyAllocationsAnnotations failed with error: %v", err)
-		}
-	}
-
-	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, topologyAllocationAnnotations)
+	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, allocationInfo.Annotations)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -518,13 +508,8 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingAllocationHandler(ctx conte
 		return nil, fmt.Errorf("adjustAllocationEntries failed with error: %v", err)
 	}
 
-	topologyAllocationAnnotations, err := cpuutil.GetCPUTopologyAllocationsAnnotations(allocationInfo, p.conf.TopologyAllocationAnnotationKey, req)
-	if err != nil {
-		return nil, fmt.Errorf("GetCPUTopologyAllocationsAnnotations failed with error: %v", err)
-	}
-
 	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU),
-		util.OCIPropertyNameCPUSetCPUs, false, true, req, topologyAllocationAnnotations)
+		util.OCIPropertyNameCPUSetCPUs, false, true, req, allocationInfo.Annotations)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s PackResourceAllocationResponseByAllocationInfo failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -587,7 +572,7 @@ func (p *DynamicPolicy) allocationSidecarHandler(_ context.Context,
 	}
 	p.state.SetMachineState(updatedMachineState, persistCheckpoint)
 
-	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req)
+	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, allocationInfo.Annotations)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -622,13 +607,8 @@ func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.
 
 	// there is no need to call SetPodEntries and SetMachineState,
 	// since they are already done in doAndCheckPutAllocationInfo of allocateSharedNumaBindingCPUs
-	topologyAllocationAnnotations, err := cpuutil.GetCPUTopologyAllocationsAnnotations(allocationInfo, p.conf.TopologyAllocationAnnotationKey, req)
-	if err != nil {
-		return nil, fmt.Errorf("GetCPUTopologyAllocationsAnnotations failed with error: %v", err)
-	}
-
 	resp, err := cpuutil.PackAllocationResponse(allocationInfo,
-		string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, topologyAllocationAnnotations)
+		string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, allocationInfo.Annotations)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s PackResourceAllocationResponseByAllocationInfo failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -2207,7 +2187,7 @@ func (p *DynamicPolicy) systemCoresAllocationHandler(ctx context.Context, req *p
 	}
 	p.state.SetMachineState(updatedMachineState, persistCheckpoint)
 
-	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req)
+	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req, allocationInfo.Annotations)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s PackResourceAllocationResponseByAllocationInfo failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -1674,6 +1675,42 @@ func TestGetTopologyHints(t *testing.T) {
 		numaNumberAnnotationKey  string
 		numaIDsAnnotationKey     string
 	}{
+		{
+			name: "req for system_cores container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:         string(uuid.NewUUID()),
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   string(v1.ResourceCPU),
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 2,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+			},
+			expectedResp: &pluginapi.ResourceHintsResponse{
+				PodNamespace:   testName,
+				PodName:        testName,
+				ContainerName:  testName,
+				ContainerType:  pluginapi.ContainerType_MAIN,
+				ContainerIndex: 0,
+				ResourceName:   string(v1.ResourceCPU),
+				ResourceHints: map[string]*pluginapi.ListOfTopologyHints{
+					string(v1.ResourceCPU): nil,
+				},
+				Labels: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+			},
+			cpuTopology: cpuTopology,
+		},
 		{
 			name: "req for container of debug pod",
 			req: &pluginapi.ResourceRequest{
@@ -8290,6 +8327,557 @@ func TestNewDynamicPolicy(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("NewDynamicPolicy() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestDynamicPolicy_AllocationHooks(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		req          *pluginapi.ResourceRequest
+		hook         AllocationHook
+		expectErr    bool
+		errContains  string
+		preRun       func(policy *DynamicPolicy)
+		verifyResult func(t *testing.T, policy *DynamicPolicy)
+	}{
+		{
+			name: "hook modifies allocation",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "modify-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "modify-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "modify-pod" {
+					if newAlloc.Annotations == nil {
+						newAlloc.Annotations = make(map[string]string)
+					}
+					newAlloc.Annotations["hook-modified"] = "true"
+				}
+				return nil
+			},
+			expectErr: false,
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo("modify-pod-uid", "c1")
+				require.NotNil(t, allocInfo)
+				require.Equal(t, "true", allocInfo.Annotations["hook-modified"])
+			},
+		},
+		{
+			name: "hook modifies allocation for reclaimed_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "modify-reclaimed-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "modify-reclaimed-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "modify-reclaimed-pod" {
+					if newAlloc.Annotations == nil {
+						newAlloc.Annotations = make(map[string]string)
+					}
+					newAlloc.Annotations["hook-modified-reclaimed"] = "true"
+				}
+				return nil
+			},
+			expectErr: false,
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo("modify-reclaimed-pod-uid", "c1")
+				require.NotNil(t, allocInfo)
+				require.Equal(t, "true", allocInfo.Annotations["hook-modified-reclaimed"])
+			},
+		},
+		{
+			name: "hook modifies allocation for dedicated_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "modify-dedicated-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "modify-dedicated-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+					consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding": "true", "numa_exclusive": "true"}`,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 2,
+				},
+				Hint: &pluginapi.TopologyHint{
+					Nodes:     []uint64{0},
+					Preferred: true,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "modify-dedicated-pod" {
+					if newAlloc.Annotations == nil {
+						newAlloc.Annotations = make(map[string]string)
+					}
+					newAlloc.Annotations["hook-modified-dedicated"] = "true"
+				}
+				return nil
+			},
+			expectErr: false,
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo("modify-dedicated-pod-uid", "c1")
+				require.NotNil(t, allocInfo)
+				require.Equal(t, "true", allocInfo.Annotations["hook-modified-dedicated"])
+			},
+		},
+		{
+			name: "hook modifies allocation for system_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "modify-system-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "modify-system-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "modify-system-pod" {
+					if newAlloc.Annotations == nil {
+						newAlloc.Annotations = make(map[string]string)
+					}
+					newAlloc.Annotations["hook-modified-system"] = "true"
+				}
+				return nil
+			},
+			expectErr: false,
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo("modify-system-pod-uid", "c1")
+				require.NotNil(t, allocInfo)
+				require.Equal(t, "true", allocInfo.Annotations["hook-modified-system"])
+			},
+		},
+		{
+			name: "hook modifies allocation for sidecar container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "modify-sidecar-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "modify-sidecar-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_SIDECAR,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "modify-sidecar-pod" {
+					if newAlloc.Annotations == nil {
+						newAlloc.Annotations = make(map[string]string)
+					}
+					newAlloc.Annotations["hook-modified-sidecar"] = "true"
+				}
+				return nil
+			},
+			preRun: func(policy *DynamicPolicy) {
+				policy.state.SetAllocationInfo("modify-sidecar-pod-uid", "main-c", &state.AllocationInfo{
+					AllocationMeta: commonstate.AllocationMeta{
+						PodUid:        "modify-sidecar-pod-uid",
+						PodNamespace:  "default",
+						PodName:       "modify-sidecar-pod",
+						ContainerName: "main-c",
+						ContainerType: pluginapi.ContainerType_MAIN.String(),
+					},
+					AllocationResult: machine.NewCPUSet(0, 1),
+				}, false)
+			},
+			expectErr: false,
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo("modify-sidecar-pod-uid", "c1")
+				require.NotNil(t, allocInfo)
+				require.Equal(t, "true", allocInfo.Annotations["hook-modified-sidecar"])
+			},
+		},
+		{
+			name: "hook returns error for shared_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "error-pod" {
+					return fmt.Errorf("hook injected error")
+				}
+				return nil
+			},
+			expectErr:   true,
+			errContains: "hook injected error",
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo("error-pod-uid", "c1")
+				require.Nil(t, allocInfo)
+			},
+		},
+		{
+			name: "hook returns error for reclaimed_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-reclaimed-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-reclaimed-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "error-reclaimed-pod" {
+					return fmt.Errorf("hook injected error for reclaimed")
+				}
+				return nil
+			},
+			expectErr:   true,
+			errContains: "hook injected error for reclaimed",
+		},
+		{
+			name: "hook returns error for dedicated_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-dedicated-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-dedicated-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+					consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding": "true", "numa_exclusive": "true"}`,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 2,
+				},
+				Hint: &pluginapi.TopologyHint{
+					Nodes:     []uint64{0},
+					Preferred: true,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "error-dedicated-pod" {
+					return fmt.Errorf("hook injected error for dedicated")
+				}
+				return nil
+			},
+			expectErr:   true,
+			errContains: "hook injected error for dedicated",
+		},
+		{
+			name: "hook returns error for system_cores",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-system-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-system-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "error-system-pod" {
+					return fmt.Errorf("hook injected error for system")
+				}
+				return nil
+			},
+			expectErr:   true,
+			errContains: "hook injected error for system",
+		},
+		{
+			name: "hook returns error for sidecar container",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-sidecar-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-sidecar-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_SIDECAR,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 1,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "error-sidecar-pod" {
+					return fmt.Errorf("hook injected error for sidecar")
+				}
+				return nil
+			},
+			preRun: func(policy *DynamicPolicy) {
+				policy.state.SetAllocationInfo("error-sidecar-pod-uid", "main-c", &state.AllocationInfo{
+					AllocationMeta: commonstate.AllocationMeta{
+						PodUid:        "error-sidecar-pod-uid",
+						PodNamespace:  "default",
+						PodName:       "error-sidecar-pod",
+						ContainerName: "main-c",
+						ContainerType: pluginapi.ContainerType_MAIN.String(),
+					},
+					AllocationResult: machine.NewCPUSet(0, 1),
+				}, false)
+			},
+			expectErr:   true,
+			errContains: "hook injected error for sidecar",
+		},
+		{
+			name: "hook returns error for shared_cores with NUMA binding",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-shared-numa-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-shared-numa-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelSharedCores,
+					consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding": "true"}`,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 2,
+				},
+				Hint: &pluginapi.TopologyHint{
+					Nodes:     []uint64{0},
+					Preferred: true,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "error-shared-numa-pod" {
+					return fmt.Errorf("hook injected error for shared numa")
+				}
+				return nil
+			},
+			expectErr:   true,
+			errContains: "hook injected error for shared numa",
+		},
+		{
+			name: "hook returns error for dedicated_cores without numa_binding",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-dedicated-no-numa-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-dedicated-no-numa-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceCPU),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceCPU): 2,
+				},
+			},
+			hook: func(oldAlloc, newAlloc *state.AllocationInfo) error {
+				return nil
+			},
+			expectErr:   true,
+			errContains: "not support dedicated_cores without NUMA binding",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			topology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+			require.NoError(t, err)
+
+			policy, err := getTestDynamicPolicyWithInitialization(topology, tmpDir)
+			require.NoError(t, err)
+			defer func() {
+				_ = policy.Stop()
+			}()
+
+			if tc.preRun != nil {
+				tc.preRun(policy)
+			}
+
+			policy.RegisterAllocationHook(tc.hook)
+
+			resp, err := policy.Allocate(context.TODO(), tc.req)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+				require.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+			}
+
+			if tc.verifyResult != nil {
+				tc.verifyResult(t, policy)
+			}
+		})
+	}
+}
+
+func TestDynamicPolicy_InvokeAllocationHooksForPodEntries(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		setupHook    func(policy *DynamicPolicy)
+		verifyResult func(t *testing.T, err error, newEntries state.PodEntries)
+	}{
+		{
+			name:      "success without hooks",
+			setupHook: func(policy *DynamicPolicy) {},
+			verifyResult: func(t *testing.T, err error, newEntries state.PodEntries) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "success with hooks modifying allocation info",
+			setupHook: func(policy *DynamicPolicy) {
+				modifyHook := func(oldAlloc, newAlloc *state.AllocationInfo) error {
+					if oldAlloc != nil {
+						newAlloc.Annotations["hook-saw-old"] = oldAlloc.Annotations["old"]
+					} else {
+						newAlloc.Annotations["hook-saw-old"] = "false"
+					}
+					return nil
+				}
+				policy.RegisterAllocationHook(modifyHook)
+			},
+			verifyResult: func(t *testing.T, err error, newEntries state.PodEntries) {
+				require.NoError(t, err)
+				assert.Equal(t, "true", newEntries["pod-1"]["container-1"].Annotations["hook-saw-old"])
+				assert.Equal(t, "false", newEntries["pod-2"]["container-2"].Annotations["hook-saw-old"])
+			},
+		},
+		{
+			name: "hook returns error",
+			setupHook: func(policy *DynamicPolicy) {
+				errorHook := func(oldAlloc, newAlloc *state.AllocationInfo) error {
+					if newAlloc.PodUid == "pod-2" {
+						return fmt.Errorf("injected error for pod-2")
+					}
+					return nil
+				}
+				policy.RegisterAllocationHook(errorHook)
+			},
+			verifyResult: func(t *testing.T, err error, newEntries state.PodEntries) {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invokeAllocationHooks failed for pod: pod-2")
+				assert.Contains(t, err.Error(), "injected error for pod-2")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			topology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+			require.NoError(t, err)
+
+			policy, err := getTestDynamicPolicyWithInitialization(topology, tmpDir)
+			require.NoError(t, err)
+			defer func() {
+				_ = policy.Stop()
+			}()
+
+			curEntries := state.PodEntries{
+				"pod-1": state.ContainerEntries{
+					"container-1": &state.AllocationInfo{
+						AllocationMeta: commonstate.AllocationMeta{
+							PodUid:        "pod-1",
+							ContainerName: "container-1",
+							Annotations:   map[string]string{"old": "true"},
+						},
+					},
+				},
+				"pool-1": state.ContainerEntries{
+					"": &state.AllocationInfo{
+						AllocationMeta: commonstate.AllocationMeta{
+							PodUid:        "pool-1",
+							ContainerName: "",
+						},
+					},
+				},
+			}
+
+			newEntries := state.PodEntries{
+				"pod-1": state.ContainerEntries{
+					"container-1": &state.AllocationInfo{
+						AllocationMeta: commonstate.AllocationMeta{
+							PodUid:        "pod-1",
+							ContainerName: "container-1",
+							Annotations:   map[string]string{"new": "true"},
+						},
+					},
+				},
+				"pod-2": state.ContainerEntries{
+					"container-2": &state.AllocationInfo{
+						AllocationMeta: commonstate.AllocationMeta{
+							PodUid:        "pod-2",
+							ContainerName: "container-2",
+							Annotations:   map[string]string{"new": "true"},
+						},
+					},
+				},
+				"pool-1": state.ContainerEntries{
+					"": &state.AllocationInfo{
+						AllocationMeta: commonstate.AllocationMeta{
+							PodUid:        "pool-1",
+							ContainerName: "",
+						},
+					},
+				},
+			}
+
+			tc.setupHook(policy)
+			err = policy.invokeAllocationHooksForPodEntries(curEntries, newEntries)
+			tc.verifyResult(t, err, newEntries)
 		})
 	}
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
@@ -72,7 +72,6 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/spd"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	metricspool "github.com/kubewharf/katalyst-core/pkg/metrics/metrics-pool"
-	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
 	cgroupcm "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
 	cgroupcmutils "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
@@ -168,7 +167,14 @@ func getTestDynamicPolicyWithoutInitialization(
 		numaNumberAnnotationKey:   consts.PodAnnotationCPUEnhancementNumaNumber,
 		numaIDsAnnotationKey:      consts.PodAnnotationCPUEnhancementNumaIDs,
 		resourcePackageManager:    resourcepackage.NewCachedResourcePackageManager(resourcepackage.NewResourcePackageManager(&npd.DummyNPDFetcher{NPD: &nodev1alpha1.NodeProfileDescriptor{}})),
+
+		topologyAllocationAnnotationKey: coreconsts.QRMPodAnnotationTopologyAllocationKey,
 	}
+
+	// Important: We must register the topologyAllocationHook and set the annotation keys
+	// to ensure that the test environment correctly generates NUMA topology annotations
+	// in the allocation response, matching the production behavior.
+	policyImplement.RegisterAllocationHook(policyImplement.topologyAllocationHook)
 
 	// register allocation behaviors for pods with different QoS level
 	policyImplement.allocationHandlers = map[string]util.AllocationHandler{
@@ -441,6 +447,9 @@ func TestAllocate(t *testing.T) {
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+							},
 						},
 					},
 				},
@@ -496,6 +505,9 @@ func TestAllocate(t *testing.T) {
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
+							},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
 							},
 						},
 					},
@@ -561,7 +573,10 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"1,8-9"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive: consts.PodAnnotationMemoryEnhancementNumaExclusiveEnable,
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"1,8-9"}}}}`,
 							},
 						},
 					},
@@ -629,7 +644,11 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"1,9"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"1,9"}}}}`,
 							},
 						},
 					},
@@ -697,7 +716,10 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"1,8-9"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive: consts.PodAnnotationMemoryEnhancementNumaExclusiveEnable,
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"1,8-9"}}}}`,
 							},
 						},
 					},
@@ -768,6 +790,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"1,9"}}}}`,
 							},
 						},
@@ -835,6 +860,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelSharedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"2"}}}}`,
 							},
 						},
@@ -903,6 +931,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelSharedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"300m"}}}}`,
 							},
 						},
@@ -999,6 +1030,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelSharedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"1"}}}}`,
 							},
 						},
@@ -1057,6 +1091,10 @@ func TestAllocate(t *testing.T) {
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
+							Annotations: map[string]string{
+								"cpuset_pool":                   "reserve",
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
+							},
 						},
 					},
 				},
@@ -1113,6 +1151,9 @@ func TestAllocate(t *testing.T) {
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
+							},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSystemCores,
 							},
 						},
 					},
@@ -1179,6 +1220,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"300m"}}}}`,
 							},
 						},
@@ -1249,6 +1293,10 @@ func TestAllocate(t *testing.T) {
 									},
 								},
 							},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+							},
 						},
 					},
 				},
@@ -1317,7 +1365,11 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"2":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"4,12"}},"3":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"6,14"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                              consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:             consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNuma: consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNumaEnable,
+								consts.PodAnnotationCPUEnhancementNumaNumber:                 "2",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:             `{"Numa":{"2":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"4,12"}},"3":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"6,14"}}}}`,
 							},
 						},
 					},
@@ -1388,6 +1440,10 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "2",
+								"full_pcpus_pairing":                             "true",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"2":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"4,12"}}}}`,
 							},
 						},
@@ -1488,7 +1544,12 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"2":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"4-5,12"}},"3":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"6-7,14"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                              consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:             consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNuma: consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNumaEnable,
+								consts.PodAnnotationCPUEnhancementFullPCPUsPairing:           consts.PodAnnotationCPUEnhancementFullPCPUsPairingEnable,
+								consts.PodAnnotationCPUEnhancementNumaNumber:                 "2",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:             `{"Numa":{"2":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"4-5,12"}},"3":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"6-7,14"}}}}`,
 							},
 						},
 					},
@@ -1561,6 +1622,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationCPUEnhancementNumaNumber:     "2",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"2":{"allocated":{"cpu":"4"},"attributes":{"CpusetCpus":"4-5,12-13"}},"3":{"allocated":{"cpu":"2"},"attributes":{"CpusetCpus":"6,14"}}}}`,
 							},
 						},
@@ -5712,6 +5776,9 @@ func TestGetResourcesAllocation(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+		},
 	}, resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	// test after ramping up
@@ -5736,6 +5803,9 @@ func TestGetResourcesAllocation(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
 		AllocationResult:  machine.NewCPUSet(1, 3, 4, 5, 6, 7, 8, 9, 10, 11).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+		},
 	}, resp2.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	// test for reclaimed_cores
@@ -5773,6 +5843,9 @@ func TestGetResourcesAllocation(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 4,
 		AllocationResult:  machine.NewCPUSet(12, 13, 14, 15).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+		},
 	}, resp2.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	req = &pluginapi.ResourceRequest{
@@ -5836,6 +5909,9 @@ func TestGetResourcesAllocation(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 14,
 		AllocationResult:  machine.NewCPUSet(1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+		},
 	}, resp3.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	reclaimEntry := dynamicPolicy.state.GetAllocationInfo(commonstate.PoolNameReclaim, "")
@@ -7453,28 +7529,35 @@ func TestCheckCPUSet(t *testing.T) {
 }
 
 func TestSchedIdle(t *testing.T) {
+	// this test is used to verify the sched idle support status
 	t.Parallel()
 
 	as := require.New(t)
 
+	// check if cpu.idle file exists in cgroup mount point
 	_, err1 := os.Stat("/sys/fs/cgroup/cpu/kubepods/cpu.idle")
 	_, err2 := os.Stat("/sys/fs/cgroup/kubepods/cpu.idle")
 
 	support := err1 == nil && err2 == nil
 
+	// verify if IsCPUIdleSupported returns the correct status
 	as.Equalf(support, cgroupcm.IsCPUIdleSupported(), "sched idle support status isn't correct")
 
 	if cgroupcm.IsCPUIdleSupported() {
-		absCgroupPath := common.GetAbsCgroupPath("cpu", "test")
+		// get absolute cgroup path for the given subsystem and relative path
+		absCgroupPath := cgroupcm.GetAbsCgroupPath("cpu", "test")
 
 		fs := &utilfs.DefaultFs{}
+		// create cgroup directory for testing
 		err := fs.MkdirAll(absCgroupPath, 0o755)
 
 		as.Nil(err)
 
 		var enableCPUIdle bool
+		// apply cpu idle configuration
 		_ = cgroupcmutils.ApplyCPUWithRelativePath("test", &cgroupcm.CPUData{CpuIdlePtr: &enableCPUIdle})
 
+		// verify if cpu.idle file is updated correctly
 		contents, err := ioutil.ReadFile(filepath.Join(absCgroupPath, "cpu.idle")) //nolint:gosec
 		as.Nil(err)
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/resize_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/resize_test.go
@@ -118,6 +118,13 @@ func TestSNBVPA(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 3, // 分配到numa0    (cpu0 -> reserved, cpu1,cpu8,cpu9 for snb)
 		AllocationResult:  "1,8-9",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"2"}}}}`,
+		},
 	}, resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	// resize exceed
@@ -209,6 +216,14 @@ func TestSNBVPA(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 3, // 分配到numa0    (cpu0 -> reserved, cpu1,cpu8,cpu9 for snb)
 		AllocationResult:  "1,8-9",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationInplaceUpdateResizingKey:       "true",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"3"}}}}`,
+		},
 	}, resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 }
 
@@ -359,6 +374,14 @@ func TestSNBInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 11, // 分配到numa0    (cpu0 -> reserved, cpu1~cpu5,cpu24~cpu29 for snb)
 		AllocationResult:  "1-5,24-29",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationAggregatedRequestsKey:          "{\"cpu\":\"3\"}",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"3"}}}}`,
+		},
 	}, allocationRes.PodResources[mainReq.PodUid].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	// reallocate for sidecar
@@ -381,6 +404,14 @@ func TestSNBInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 11, // 分配到numa0    (cpu0 -> reserved, cpu1~cpu5,cpu24~cpu29 for snb)
 		AllocationResult:  "1-5,24-29",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationAggregatedRequestsKey:          "{\"cpu\":\"3\"}",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"3"}}}}`,
+		},
 	}, allocationRes.PodResources[mainReq.PodUid].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	// check container allocation request
@@ -456,6 +487,15 @@ func TestSNBInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 11, // 分配到numa0    (cpu0 -> reserved, cpu1~cpu5,cpu24~cpu29 for snb)
 		AllocationResult:  "1-5,24-29",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationInplaceUpdateResizingKey:       "true",
+			consts.PodAnnotationAggregatedRequestsKey:          "{\"cpu\":\"4\"}",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"4"}}}}`,
+		},
 	}, resizeMainContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	as.NotNil(resizeMainContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName])
@@ -466,6 +506,15 @@ func TestSNBInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 11, // 分配到numa0    (cpu0 -> reserved, cpu1~cpu5,cpu24~cpu29 for snb)
 		AllocationResult:  "1-5,24-29",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationInplaceUpdateResizingKey:       "true",
+			consts.PodAnnotationAggregatedRequestsKey:          "{\"cpu\":\"4\"}",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"4"}}}}`,
+		},
 	}, resizeMainContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	mainContainerAllocation = dynamicPolicy.state.GetAllocationInfo(podUID, mainContainerName)
@@ -581,15 +630,25 @@ func TestSNBInplaceUpdateResizeWithSidecar(t *testing.T) {
 	as.Nil(err)
 
 	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID])
-	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName])
-	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
+	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName])
+	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
+	// reserve pool size: 2, reclaimed pool size: 4, share-NUMA0 pool size: 11
 	as.Equal(&pluginapi.ResourceAllocationInfo{
 		OciPropertyName:   util.OCIPropertyNameCPUSetCPUs,
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 11, // 分配到numa0    (cpu0 -> reserved, cpu1~cpu5,cpu24~cpu29 for snb)
 		AllocationResult:  "1-5,24-29",
-	}, resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationInplaceUpdateResizingKey:       "true",
+			consts.PodAnnotationAggregatedRequestsKey:          "{\"cpu\":\"5\"}",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"5"}}}}`,
+		},
+	}, resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName])
 	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
@@ -599,6 +658,15 @@ func TestSNBInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 11, // 分配到numa0    (cpu0 -> reserved, cpu1~cpu5,cpu24~cpu29 for snb)
 		AllocationResult:  "1-5,24-29",
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+			consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+			cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+			consts.PodAnnotationInplaceUpdateResizingKey:       "true",
+			consts.PodAnnotationAggregatedRequestsKey:          "{\"cpu\":\"5\"}",
+			coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"cpu":"5"}}}}`,
+		},
 	}, resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	mainContainerAllocation = dynamicPolicy.state.GetAllocationInfo(podUID, mainContainerName)
@@ -689,6 +757,9 @@ func TestNonBindingShareCoresInplaceUpdateResize(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+		},
 	}, resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	resizeReq := &pluginapi.ResourceRequest{
@@ -758,6 +829,10 @@ func TestNonBindingShareCoresInplaceUpdateResize(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:              consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationInplaceUpdateResizingKey: "true",
+		},
 	}, resp1.PodResources[req.PodUid].ContainerResources[testName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	allocation := dynamicPolicy.state.GetAllocationInfo(req.PodUid, testName)
@@ -840,6 +915,10 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:           consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationAggregatedRequestsKey: "{\"cpu\":\"3\"}",
+		},
 	}, allocationRes.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	mainReq := &pluginapi.ResourceRequest{
@@ -889,6 +968,10 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:           consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationAggregatedRequestsKey: "{\"cpu\":\"3\"}",
+		},
 	}, allocationRes.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	// no reallocate for share cores sidecar
@@ -947,6 +1030,11 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:              consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationInplaceUpdateResizingKey: "true",
+			consts.PodAnnotationAggregatedRequestsKey:    "{\"cpu\":\"4\"}",
+		},
 	}, resizeMainContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	as.NotNil(resizeMainContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName])
@@ -958,6 +1046,11 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:              consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationInplaceUpdateResizingKey: "true",
+			consts.PodAnnotationAggregatedRequestsKey:    "{\"cpu\":\"4\"}",
+		},
 	}, resizeMainContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	mainContainerAllocation = dynamicPolicy.state.GetAllocationInfo(podUID, mainContainerName)
@@ -1024,10 +1117,15 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:              consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationInplaceUpdateResizingKey: "true",
+			consts.PodAnnotationAggregatedRequestsKey:    "{\"cpu\":\"5\"}",
+		},
 	}, resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
-	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName])
-	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[mainContainerName].ResourceAllocation[string(v1.ResourceCPU)])
+	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName])
+	as.NotNil(resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 	// reserve pool size: 2, reclaimed pool size: 4, share pool size: 42
 	as.Equal(&pluginapi.ResourceAllocationInfo{
 		OciPropertyName:   util.OCIPropertyNameCPUSetCPUs,
@@ -1035,6 +1133,11 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
 		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		Annotations: map[string]string{
+			consts.PodAnnotationQoSLevelKey:              consts.PodAnnotationQoSLevelSharedCores,
+			consts.PodAnnotationInplaceUpdateResizingKey: "true",
+			consts.PodAnnotationAggregatedRequestsKey:    "{\"cpu\":\"5\"}",
+		},
 	}, resizeSidecarContainerAllocations.PodResources[podUID].ContainerResources[sidecarContainerName].ResourceAllocation[string(v1.ResourceCPU)])
 
 	mainContainerAllocation = dynamicPolicy.state.GetAllocationInfo(podUID, mainContainerName)
@@ -1089,7 +1192,9 @@ func TestReclaimedCoresVPA(t *testing.T) {
 								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
 							},
 							Annotations: map[string]string{
-								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: "false",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"0-2"}},"1":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"4-6"}}}}`,
 							},
 							QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
 						},
@@ -1167,6 +1272,11 @@ func TestReclaimedCoresVPA(t *testing.T) {
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
+							},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: "false",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"0-2"}},"1":{"allocated":{"cpu":"3"},"attributes":{"CpusetCpus":"4-6"}}}}`,
 							},
 						},
 					},
@@ -1293,6 +1403,9 @@ func TestReclaimedCoresVPA(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"1"}}}}`,
 							},
 						},
@@ -1421,6 +1534,9 @@ func TestReclaimedCoresVPA(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"cpu":"3"}}}}`,
 							},
 						},
@@ -1491,7 +1607,7 @@ func TestReclaimedCoresVPA(t *testing.T) {
 					},
 				},
 			},
-			requestQuantity:  4,
+			requestQuantity:  6,
 			expectedHintErr:  true,
 			expectedHintResp: nil,
 		},
@@ -1608,6 +1724,10 @@ func TestReclaimedCoresVPA(t *testing.T) {
 										Preferred: true,
 									},
 								},
+							},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
 							},
 						},
 					},
@@ -1738,7 +1858,7 @@ func TestReclaimedCoresVPA(t *testing.T) {
 			}
 
 			hintResp, err := dynamicPolicy.GetTopologyHints(context.Background(), hintReq)
-			as.Equalf(err != nil, tc.expectedHintErr, "expected hint error: %v, got: %v", tc.expectedHintErr, err)
+			as.Equalf(tc.expectedHintErr, err != nil, "expected hint error: %v, got: %v", tc.expectedHintErr, err)
 			as.Equal(tc.expectedHintResp, hintResp, "got unexpected hint response")
 
 			if tc.expectedHintErr {

--- a/pkg/agent/qrm-plugins/cpu/util/util.go
+++ b/pkg/agent/qrm-plugins/cpu/util/util.go
@@ -164,7 +164,9 @@ func RegenerateHints(allocationInfo *state.AllocationInfo, regenerate bool) map[
 	return hints
 }
 
-// PackAllocationResponse fills pluginapi.ResourceAllocationResponse with information from AllocationInfo and pluginapi.ResourceRequest
+// PackAllocationResponse assembles a ResourceAllocationResponse for the CPU plugin.
+// It populates the response with pod/container metadata and resource allocation results,
+// and directly applies the provided resourceAllocationAnnotations to the response.
 func PackAllocationResponse(allocationInfo *state.AllocationInfo, resourceName, ociPropertyName string,
 	isNodeResource, isScalarResource bool, req *pluginapi.ResourceRequest, resourceAllocationAnnotations ...map[string]string,
 ) (*pluginapi.ResourceAllocationResponse, error) {
@@ -213,16 +215,38 @@ func PackAllocationResponse(allocationInfo *state.AllocationInfo, resourceName, 
 	}, nil
 }
 
+// IsTopologyAllocationChanged checks if the topology allocation of a container has changed.
+func IsTopologyAllocationChanged(oldInfo, newInfo *state.AllocationInfo) bool {
+	// If this is a newly allocated container (oldInfo is nil), or we somehow lost newInfo, re-injection is needed.
+	if oldInfo == nil || newInfo == nil {
+		return true
+	}
+
+	// Check if any physical CPU allocation results, quantities, or NUMA-aware topology assignments have changed.
+	// These directly impact the topology info and NUMA node annotations we generate for UCE pods.
+	if !oldInfo.AllocationResult.Equals(newInfo.AllocationResult) ||
+		oldInfo.RequestQuantity != newInfo.RequestQuantity ||
+		!state.CheckAllocationInfoTopologyAwareAssignments(oldInfo, newInfo) {
+		return true
+	}
+	return false
+}
+
 // GetCPUTopologyAllocationsAnnotations returns the topology-aware CPU allocation annotations for a given container.
 // It handles different QoS levels:
 // - For DedicatedCores: uses the actual assigned CPUSet size on each NUMA node.
 // - For SharedCores/ReclaimedCores with NUMA binding: uses the pod's aggregated request quantity.
 // This function only processes main containers and returns nil for sidecars or invalid allocation info.
 func GetCPUTopologyAllocationsAnnotations(allocationInfo *state.AllocationInfo,
-	topologyAllocationAnnotationKey string, req *pluginapi.ResourceRequest,
+	topologyAllocationAnnotationKey string,
 ) (map[string]string, error) {
 	// Skip processing if allocation info is invalid or it's not the main container.
 	if allocationInfo == nil || !allocationInfo.CheckMainContainer() {
+		return nil, nil
+	}
+
+	// Skip processing if reclaimed cores but non-actual NUMA binding.
+	if allocationInfo.CheckReclaimedNonActualNUMABinding() {
 		return nil, nil
 	}
 
@@ -239,7 +263,7 @@ func GetCPUTopologyAllocationsAnnotations(allocationInfo *state.AllocationInfo,
 		}
 
 		// Use the aggregated pod request quantity for shared/reclaimed cores to represent the logical allocation.
-		_, reqFloat64, err := util.GetPodAggregatedRequestResource(req)
+		_, reqFloat64, err := GetPodAggregatedRequestResourceFromAllocationInfo(allocationInfo, v1.ResourceCPU)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get aggregated request resource: %v", err)
 		}
@@ -272,6 +296,19 @@ func GetCPUTopologyAllocationsAnnotations(allocationInfo *state.AllocationInfo,
 		topologyAllocation,
 		topologyAllocationAnnotationKey,
 	), nil
+}
+
+// GetPodAggregatedRequestResourceFromAllocationInfo returns both integer and float64 quantities for the main resource based on allocationInfo.
+// If the allocationInfo.Annotations contain aggregated resource keys, those values are used;
+// otherwise, it falls back to use quantities in allocationInfo.
+func GetPodAggregatedRequestResourceFromAllocationInfo(allocationInfo *state.AllocationInfo, resourceName v1.ResourceName) (int, float64, error) {
+	if allocationInfo == nil {
+		return 0, 0, fmt.Errorf("GetPodAggregatedRequestResourceFromAllocationInfo got nil allocationInfo")
+	}
+
+	return util.GetPodAggregatedRequestResourceByAnnotations(allocationInfo.Annotations, resourceName, func() (int, float64, error) {
+		return int(math.Ceil(allocationInfo.RequestQuantity)), allocationInfo.RequestQuantity, nil
+	})
 }
 
 // buildZoneAllocation creates a ZoneAllocation for a specific NUMA node.

--- a/pkg/agent/qrm-plugins/cpu/util/util_test.go
+++ b/pkg/agent/qrm-plugins/cpu/util/util_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	cpuconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/consts"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	"github.com/kubewharf/katalyst-core/pkg/config"
@@ -840,7 +841,6 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 	tests := []struct {
 		name         string
 		ai           *state.AllocationInfo
-		req          *pluginapi.ResourceRequest
 		wantNilAnno  bool
 		wantErr      bool
 		wantTopology v1alpha1.TopologyAllocation
@@ -848,7 +848,6 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 		{
 			name:        "nil allocation info returns nil",
 			ai:          nil,
-			req:         nil,
 			wantNilAnno: true,
 		},
 		{
@@ -858,12 +857,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 					ContainerType: pluginapi.ContainerType_MAIN.String(),
 				},
 				TopologyAwareAssignments: map[int]machine.CPUSet{},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 2,
-				},
+				RequestQuantity:          2,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{},
@@ -879,12 +873,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 					0: machine.NewCPUSet(0, 1),
 					2: machine.NewCPUSet(4),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 2,
-				},
+				RequestQuantity: 2,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -917,12 +906,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 					0: machine.NewCPUSet(0, 1),       // size 2 => "2"
 					1: machine.NewCPUSet(3, 5, 6, 7), // size 4 => "4"
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 4,
-				},
+				RequestQuantity: 4,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -958,12 +942,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 				TopologyAwareAssignments: map[int]machine.CPUSet{
 					0: machine.NewCPUSet(0, 1, 2),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 2,
-				},
+				RequestQuantity: 2,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -988,12 +967,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 				TopologyAwareAssignments: map[int]machine.CPUSet{
 					0: machine.NewCPUSet(0, 1, 2),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 0.5,
-				},
+				RequestQuantity: 0.5,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -1018,12 +992,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 				TopologyAwareAssignments: map[int]machine.CPUSet{
 					0: machine.NewCPUSet(0, 1, 2),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 0.125,
-				},
+				RequestQuantity: 0.125,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -1043,17 +1012,13 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 					QoSLevel:      consts.PodAnnotationQoSLevelReclaimedCores,
 					Annotations: map[string]string{
 						consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+						cpuconsts.CPUStateAnnotationKeyNUMAHint:          "1",
 					},
 				},
 				TopologyAwareAssignments: map[int]machine.CPUSet{
 					1: machine.NewCPUSet(4, 5),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 1.75,
-				},
+				RequestQuantity: 1.75,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -1076,12 +1041,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 					0: machine.NewCPUSet(0, 1),
 					1: machine.NewCPUSet(8, 9, 10),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 5,
-				},
+				RequestQuantity: 5,
 			},
 			wantTopology: v1alpha1.TopologyAllocation{
 				v1alpha1.TopologyTypeNuma: map[string]v1alpha1.ZoneAllocation{
@@ -1118,12 +1078,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 					0: machine.NewCPUSet(0),
 					1: machine.NewCPUSet(1),
 				},
-			},
-			req: &pluginapi.ResourceRequest{
-				ResourceName: string(v1.ResourceCPU),
-				ResourceRequests: map[string]float64{
-					string(v1.ResourceCPU): 2,
-				},
+				RequestQuantity: 2,
 			},
 			wantErr: true,
 		},
@@ -1133,7 +1088,7 @@ func TestGetCPUTopologyAllocationsAnnotations(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := GetCPUTopologyAllocationsAnnotations(tt.ai, coreconsts.QRMPodAnnotationTopologyAllocationKey, tt.req)
+			got, err := GetCPUTopologyAllocationsAnnotations(tt.ai, coreconsts.QRMPodAnnotationTopologyAllocationKey)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
@@ -1482,6 +1437,191 @@ func TestGetAggResourcePackagePinnedCPUSet(t *testing.T) {
 			got := GetAggResourcePackagePinnedCPUSet(tt.args.attributeSelector, tt.args.machineState)
 			if !got.Equals(tt.want) {
 				t.Errorf("GetAggResourcePackagePinnedCPUSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTopologyAllocationChanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		oldInfo  *state.AllocationInfo
+		newInfo  *state.AllocationInfo
+		expected bool
+	}{
+		{
+			name:     "old is nil",
+			oldInfo:  nil,
+			newInfo:  &state.AllocationInfo{},
+			expected: true,
+		},
+		{
+			name:     "new is nil",
+			oldInfo:  &state.AllocationInfo{},
+			newInfo:  nil,
+			expected: true,
+		},
+		{
+			name: "allocation result changed",
+			oldInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+			},
+			newInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 2),
+			},
+			expected: true,
+		},
+		{
+			name: "request quantity changed",
+			oldInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+				RequestQuantity:  2.0,
+			},
+			newInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+				RequestQuantity:  3.0,
+			},
+			expected: true,
+		},
+		{
+			name: "topology aware assignments changed",
+			oldInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+				RequestQuantity:  2.0,
+				TopologyAwareAssignments: map[int]machine.CPUSet{
+					0: machine.NewCPUSet(0),
+					1: machine.NewCPUSet(1),
+				},
+			},
+			newInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+				RequestQuantity:  2.0,
+				TopologyAwareAssignments: map[int]machine.CPUSet{
+					0: machine.NewCPUSet(0, 1),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no change",
+			oldInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+				RequestQuantity:  2.0,
+				TopologyAwareAssignments: map[int]machine.CPUSet{
+					0: machine.NewCPUSet(0),
+					1: machine.NewCPUSet(1),
+				},
+			},
+			newInfo: &state.AllocationInfo{
+				AllocationResult: machine.NewCPUSet(0, 1),
+				RequestQuantity:  2.0,
+				TopologyAwareAssignments: map[int]machine.CPUSet{
+					0: machine.NewCPUSet(0),
+					1: machine.NewCPUSet(1),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsTopologyAllocationChanged(tt.oldInfo, tt.newInfo)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetPodAggregatedRequestResourceFromAllocationInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		ai           *state.AllocationInfo
+		resourceName v1.ResourceName
+		wantInt      int
+		wantFloat    float64
+		wantErr      bool
+	}{
+		{
+			name:    "nil allocation info returns error",
+			ai:      nil,
+			wantErr: true,
+		},
+		{
+			name: "fallback to request quantity",
+			ai: &state.AllocationInfo{
+				RequestQuantity: 2.5,
+			},
+			resourceName: v1.ResourceCPU,
+			wantInt:      3,
+			wantFloat:    2.5,
+			wantErr:      false,
+		},
+		{
+			name: "use aggregated request from annotations",
+			ai: &state.AllocationInfo{
+				RequestQuantity: 2.5,
+				AllocationMeta: commonstate.AllocationMeta{
+					Annotations: map[string]string{
+						consts.PodAnnotationAggregatedRequestsKey: `{"cpu":"4"}`,
+					},
+				},
+			},
+			resourceName: v1.ResourceCPU,
+			wantInt:      4,
+			wantFloat:    4,
+			wantErr:      false,
+		},
+		{
+			name: "aggregated request from annotations with milli-cpu",
+			ai: &state.AllocationInfo{
+				RequestQuantity: 2.5,
+				AllocationMeta: commonstate.AllocationMeta{
+					Annotations: map[string]string{
+						consts.PodAnnotationAggregatedRequestsKey: `{"cpu":"500m"}`,
+					},
+				},
+			},
+			resourceName: v1.ResourceCPU,
+			wantInt:      1,
+			wantFloat:    0.5,
+			wantErr:      false,
+		},
+		{
+			name: "fallback when resource not in aggregated requests",
+			ai: &state.AllocationInfo{
+				RequestQuantity: 2.5,
+				AllocationMeta: commonstate.AllocationMeta{
+					Annotations: map[string]string{
+						consts.PodAnnotationAggregatedRequestsKey: `{"memory":"1Gi"}`,
+					},
+				},
+			},
+			resourceName: v1.ResourceCPU,
+			wantInt:      3,
+			wantFloat:    2.5,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotInt, gotFloat, err := GetPodAggregatedRequestResourceFromAllocationInfo(tt.ai, tt.resourceName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPodAggregatedRequestResourceFromAllocationInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				assert.Equal(t, tt.wantInt, gotInt)
+				assert.Equal(t, tt.wantFloat, gotFloat)
 			}
 		})
 	}

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -96,6 +96,11 @@ const (
 	movePagesWorkLimit    = 2
 )
 
+// AllocationHook is a hook function which can be registered and called when allocationInfo changes.
+// It is designed to intercept state updates and perform actions like injecting or updating annotations
+// (e.g., NUMA topology information) based on the differences between old and new allocation info.
+type AllocationHook func(resourceName v1.ResourceName, oldAllocationInfo, newAllocationInfo *state.AllocationInfo) error
+
 type DynamicPolicy struct {
 	sync.RWMutex
 	pluginapi.UnimplementedResourcePluginServer
@@ -167,6 +172,7 @@ type DynamicPolicy struct {
 	numaAllocationReactor                         reactor.AllocationReactor
 	numaBindResultResourceAllocationAnnotationKey string
 	topologyAllocationAnnotationKey               string
+	allocationHooks                               []AllocationHook
 
 	extraResourceNames []string
 }
@@ -244,6 +250,8 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		topologyAllocationAnnotationKey:               conf.TopologyAllocationAnnotationKey,
 		extraResourceNames:                            conf.ExtraMemoryResources,
 	}
+
+	policyImplement.RegisterAllocationHook(policyImplement.topologyAllocationHook)
 
 	policyImplement.allocationHandlers = map[string]util.AllocationHandler{
 		apiconsts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresAllocationHandler,
@@ -753,7 +761,9 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 					if applySidecarAllocationInfoFromMainContainer(allocationInfo, mainContainerAllocationInfo) {
 						general.Infof("pod: %s/%s sidecar container: %s update its allocation",
 							allocationInfo.PodNamespace, allocationInfo.PodName, allocationInfo.ContainerName)
-						p.state.SetAllocationInfo(resourceName, podUID, containerName, allocationInfo, true)
+						if hookErr := p.updateAllocationInfo(resourceName, podUID, containerName, nil, allocationInfo, true); hookErr != nil {
+							general.Errorf("updateAllocationInfo failed for pod: %s, container: %s: %v", podUID, containerName, hookErr)
+						}
 						needUpdateMachineState = true
 					}
 				}
@@ -1342,4 +1352,94 @@ func (p *DynamicPolicy) checkNonBindingShareCoresMemoryResource(req *pluginapi.R
 		"reqInt", reqInt)
 
 	return true, nil
+}
+
+// RegisterAllocationHook registers a hook that is called before allocation info is updated.
+// Currently only supports one hook per policy, but we maintain a list for future extension.
+func (p *DynamicPolicy) RegisterAllocationHook(hook AllocationHook) {
+	p.Lock()
+	defer p.Unlock()
+	p.allocationHooks = append(p.allocationHooks, hook)
+}
+
+// invokeAllocationHooks triggers all registered allocation hooks.
+// Note: This method must be called with the lock held by the caller if concurrency protection is needed.
+// We avoid internal locking here to prevent potential deadlocks when called from methods that already hold the lock.
+func (p *DynamicPolicy) invokeAllocationHooks(resourceName v1.ResourceName, oldInfo, newInfo *state.AllocationInfo) error {
+	for _, hook := range p.allocationHooks {
+		if err := hook(resourceName, oldInfo, newInfo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// invokeAllocationHooksForPodResourceEntries triggers allocation hooks for non-pool containers across all resources.
+// Note: This method must be called with the lock held by the caller to ensure state consistency
+// and avoid deadlocks due to nested locking.
+func (p *DynamicPolicy) invokeAllocationHooksForPodResourceEntries(curPodResourceEntries, newPodResourceEntries state.PodResourceEntries) error {
+	if len(p.allocationHooks) == 0 {
+		return nil
+	}
+
+	for resourceName, newPodEntries := range newPodResourceEntries {
+		for podUID, containerEntries := range newPodEntries {
+			for containerName, newAllocationInfo := range containerEntries {
+				var oldAllocationInfo *state.AllocationInfo
+				if curPodEntries, ok := curPodResourceEntries[resourceName]; ok {
+					if curContainerEntries, ok := curPodEntries[podUID]; ok {
+						oldAllocationInfo = curContainerEntries[containerName]
+					}
+				}
+				if err := p.invokeAllocationHooks(resourceName, oldAllocationInfo, newAllocationInfo); err != nil {
+					return fmt.Errorf("invokeAllocationHooks failed for resource: %s, pod: %s, container: %s: %v",
+						resourceName, podUID, containerName, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// updateAllocationInfo wraps state.SetAllocationInfo with hook execution.
+// If no hooks are registered, it avoids the overhead of retrieving the old allocation info.
+func (p *DynamicPolicy) updateAllocationInfo(resourceName v1.ResourceName, podUID, containerName string, oldAllocationInfo, allocationInfo *state.AllocationInfo, persist bool) error {
+	if len(p.allocationHooks) > 0 {
+		if oldAllocationInfo == nil {
+			oldAllocationInfo = p.state.GetAllocationInfo(resourceName, podUID, containerName)
+		}
+		if err := p.invokeAllocationHooks(resourceName, oldAllocationInfo, allocationInfo); err != nil {
+			return err
+		}
+	}
+
+	p.state.SetAllocationInfo(resourceName, podUID, containerName, allocationInfo, persist)
+	return nil
+}
+
+// topologyAllocationHook is the default hook that injects topology allocation annotations
+// into the allocation info when the topology allocation changes.
+func (p *DynamicPolicy) topologyAllocationHook(resourceName v1.ResourceName, oldInfo, newInfo *state.AllocationInfo) error {
+	if newInfo == nil || !newInfo.CheckMainContainer() || !newInfo.CheckNUMABinding() {
+		return nil
+	}
+
+	if !IsTopologyAllocationChanged(oldInfo, newInfo) {
+		return nil
+	}
+
+	if newInfo.CheckReclaimedActualNUMABinding() {
+		if newInfo.Annotations == nil {
+			newInfo.Annotations = make(map[string]string)
+		}
+		newInfo.Annotations[p.numaBindResultResourceAllocationAnnotationKey] = newInfo.NumaAllocationResult.String()
+	}
+
+	annotations := getMemoryTopologyAllocationsAnnotationsByAllocationInfo(resourceName, newInfo, p.topologyAllocationAnnotationKey)
+	if annotations != nil {
+		newInfo.Annotations = general.MergeAnnotations(newInfo.Annotations, annotations)
+	}
+
+	return nil
 }

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_allocation_handlers.go
@@ -222,7 +222,10 @@ func (p *DynamicPolicy) numaBindingAllocationHandler(ctx context.Context,
 	}
 
 	for resName, allocationInfo := range resourceAllocationInfo {
-		p.state.SetAllocationInfo(resName, req.PodUid, req.ContainerName, allocationInfo, persistCheckpoint)
+		oldAllocationInfo := p.state.GetAllocationInfo(resName, req.PodUid, req.ContainerName)
+		if err := p.updateAllocationInfo(resName, req.PodUid, req.ContainerName, oldAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, fmt.Errorf("updateAllocationInfo failed: %v", err)
+		}
 
 		// only v1.ResourceMemory can be adjusted
 		if resName == v1.ResourceMemory {
@@ -241,8 +244,6 @@ func (p *DynamicPolicy) numaBindingAllocationHandler(ctx context.Context,
 		}
 	}
 
-	resourceTopologyAllocationsAnnotations := getMemoryTopologyAllocationsAnnotations(resourceAllocationInfo, p.topologyAllocationAnnotationKey)
-
 	podResourceEntries = p.state.GetPodResourceEntries()
 	machineState, err = state.GenerateMachineStateFromPodEntries(p.state.GetMachineInfo(), p.state.GetMemoryTopology(), podResourceEntries,
 		p.state.GetMachineState(), p.state.GetReservedMemory(), p.extraResourceNames)
@@ -253,7 +254,7 @@ func (p *DynamicPolicy) numaBindingAllocationHandler(ctx context.Context,
 	}
 	p.state.SetMachineState(machineState, persistCheckpoint)
 
-	return packAllocationResponse(resourceAllocationInfo, req, resourceTopologyAllocationsAnnotations)
+	return p.getPackAllocationResponse(resourceAllocationInfo, req)
 }
 
 // reclaimedCoresBestEffortNUMABindingAllocationHandler allocates reclaimed cores with numa binding pods in best-effort manner.
@@ -297,8 +298,12 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 		}
 		general.Infof("pod: %s/%s, container: %s request to memory inplace update resize allocation, request: %d->%d",
 			req.PodNamespace, req.PodName, req.ContainerName, allocationInfo.AggregatedQuantity, podAggregatedRequest)
-		allocationInfo.AggregatedQuantity = uint64(podAggregatedRequest)
-		p.state.SetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName, allocationInfo, persistCheckpoint)
+		newAllocationInfo := allocationInfo.Clone()
+		newAllocationInfo.AggregatedQuantity = uint64(podAggregatedRequest)
+		if err := p.updateAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName, allocationInfo, newAllocationInfo, persistCheckpoint); err != nil {
+			return nil, fmt.Errorf("updateAllocationInfo failed: %v", err)
+		}
+		allocationInfo = newAllocationInfo
 	} else {
 		if allocationInfo != nil {
 			if allocationInfo.AggregatedQuantity >= uint64(podAggregatedRequest) {
@@ -308,9 +313,9 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 					"containerName", req.ContainerName,
 					"memoryReq(bytes)", allocationInfo.AggregatedQuantity,
 					"currentResult(bytes)", allocationInfo.AggregatedQuantity)
-				return packAllocationResponse(map[v1.ResourceName]*state.AllocationInfo{
+				return p.getPackAllocationResponse(map[v1.ResourceName]*state.AllocationInfo{
 					v1.ResourceMemory: allocationInfo,
-				}, req, nil)
+				}, req)
 			}
 
 			general.InfoS("not meet requirement, clear record and re-allocate",
@@ -338,6 +343,8 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 			}
 		}
 
+		oldAllocationInfo := p.state.GetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName)
+
 		allocationInfo = &state.AllocationInfo{
 			AllocationMeta:     state.GenerateMemoryContainerAllocationMeta(req, apiconsts.PodAnnotationQoSLevelReclaimedCores),
 			AggregatedQuantity: uint64(podAggregatedRequest),
@@ -362,7 +369,9 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 
 		allocationInfo.NumaAllocationResult = numaAllocationResult
 
-		p.state.SetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName, oldAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, fmt.Errorf("updateAllocationInfo failed: %v", err)
+		}
 
 		machineState, err = state.GenerateMachineStateFromPodEntries(p.state.GetMachineInfo(), p.state.GetMemoryTopology(), p.state.GetPodResourceEntries(),
 			p.state.GetMachineState(), p.state.GetReservedMemory(), p.extraResourceNames)
@@ -379,8 +388,6 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 		}
 	}
 
-	var resourceTopologyAllocationsAnnotations map[v1.ResourceName]map[string]string
-
 	// we only support updating the NUMA allocation results for pods with explicit NUMA binding annotation
 	if qosutil.AnnotationsIndicateNUMABinding(req.Annotations) {
 		err = p.updateSpecifiedNUMAAllocation(ctx, allocationInfo)
@@ -389,17 +396,11 @@ func (p *DynamicPolicy) reclaimedCoresBestEffortNUMABindingAllocationHandler(ctx
 				req.PodNamespace, req.PodName, req.ContainerName, err)
 			return nil, fmt.Errorf("updateSpecifiedNUMAAllocation failed with error: %v", err)
 		}
-		resourceTopologyAllocationsAnnotations = getMemoryTopologyAllocationsAnnotations(map[v1.ResourceName]*state.AllocationInfo{
-			v1.ResourceMemory: allocationInfo,
-		}, p.topologyAllocationAnnotationKey)
 	}
 
-	resp, err := packAllocationResponse(map[v1.ResourceName]*state.AllocationInfo{
+	resp, err := p.getPackAllocationResponse(map[v1.ResourceName]*state.AllocationInfo{
 		v1.ResourceMemory: allocationInfo,
-	}, req,
-		map[v1.ResourceName]map[string]string{v1.ResourceMemory: p.getReclaimedResourceAllocationAnnotations(allocationInfo)},
-		resourceTopologyAllocationsAnnotations,
-	)
+	}, req)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -459,7 +460,9 @@ func (p *DynamicPolicy) numaBindingAllocationSidecarHandler(_ context.Context,
 	}
 
 	for resourceName, allocationInfo := range resourceAllocationInfo {
-		p.state.SetAllocationInfo(resourceName, req.PodUid, req.ContainerName, allocationInfo, persistCheckpoint)
+		if err := p.updateAllocationInfo(resourceName, req.PodUid, req.ContainerName, nil, allocationInfo, persistCheckpoint); err != nil {
+			return nil, fmt.Errorf("updateAllocationInfo failed: %v", err)
+		}
 	}
 
 	podResourceEntries = p.state.GetPodResourceEntries()
@@ -472,7 +475,7 @@ func (p *DynamicPolicy) numaBindingAllocationSidecarHandler(_ context.Context,
 	}
 	p.state.SetMachineState(resourcesState, persistCheckpoint)
 
-	resp, err := packAllocationResponse(resourceAllocationInfo, req, nil)
+	resp, err := p.getPackAllocationResponse(resourceAllocationInfo, req)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -518,7 +521,10 @@ func (p *DynamicPolicy) allocateNUMAsWithoutNUMABindingPods(_ context.Context,
 	}
 
 	for resourceName, allocationInfo := range resourceAllocationInfo {
-		p.state.SetAllocationInfo(resourceName, req.PodUid, req.ContainerName, allocationInfo, persistCheckpoint)
+		oldAllocationInfo := p.state.GetAllocationInfo(resourceName, req.PodUid, req.ContainerName)
+		if err := p.updateAllocationInfo(resourceName, req.PodUid, req.ContainerName, oldAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+			return nil, fmt.Errorf("updateAllocationInfo failed: %v", err)
+		}
 	}
 
 	podResourceEntries := p.state.GetPodResourceEntries()
@@ -531,7 +537,7 @@ func (p *DynamicPolicy) allocateNUMAsWithoutNUMABindingPods(_ context.Context,
 		return nil, fmt.Errorf("calculate resourceState by updated pod entries failed with error: %v", err)
 	}
 
-	resp, err := packAllocationResponse(resourceAllocationInfo, req, nil)
+	resp, err := p.getPackAllocationResponse(resourceAllocationInfo, req)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -558,12 +564,15 @@ func (p *DynamicPolicy) allocateTargetNUMAs(req *pluginapi.ResourceRequest,
 			req.PodNamespace, req.PodName, req.ContainerName, allocationInfo.NumaAllocationResult.String(), targetNUMAs.String())
 	}
 
+	oldAllocationInfo := p.state.GetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName)
 	allocationInfo = &state.AllocationInfo{
 		AllocationMeta:       state.GenerateMemoryContainerAllocationMeta(req, qosLevel),
 		NumaAllocationResult: targetNUMAs.Clone(),
 	}
 
-	p.state.SetAllocationInfo(v1.ResourceMemory, allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, persistCheckpoint)
+	if err := p.updateAllocationInfo(v1.ResourceMemory, allocationInfo.PodUid, allocationInfo.ContainerName, oldAllocationInfo, allocationInfo, persistCheckpoint); err != nil {
+		return nil, fmt.Errorf("updateAllocationInfo failed: %v", err)
+	}
 	podResourceEntries := p.state.GetPodResourceEntries()
 
 	machineState, err := state.GenerateMachineStateFromPodEntries(p.state.GetMachineInfo(), p.state.GetMemoryTopology(), podResourceEntries,
@@ -574,9 +583,9 @@ func (p *DynamicPolicy) allocateTargetNUMAs(req *pluginapi.ResourceRequest,
 		return nil, fmt.Errorf("calculate machineState by updated pod entries failed with error: %v", err)
 	}
 
-	resp, err := packAllocationResponse(map[v1.ResourceName]*state.AllocationInfo{
+	resp, err := p.getPackAllocationResponse(map[v1.ResourceName]*state.AllocationInfo{
 		v1.ResourceMemory: allocationInfo,
-	}, req, nil)
+	}, req)
 	if err != nil {
 		general.Errorf("pod: %s/%s, container: %s packAllocationResponse failed with error: %v",
 			req.PodNamespace, req.PodName, req.ContainerName, err)
@@ -617,6 +626,10 @@ func (p *DynamicPolicy) adjustAllocationEntries(persistCheckpoint bool) error {
 		return fmt.Errorf("calculate machineState by updated pod entries failed with error: %v", err)
 	}
 
+	if err := p.invokeAllocationHooksForPodResourceEntries(p.state.GetPodResourceEntries(), podResourceEntries); err != nil {
+		return fmt.Errorf("invokeAllocationHooksForPodResourceEntries failed: %v", err)
+	}
+
 	p.state.SetPodResourceEntries(podResourceEntries, false)
 	p.state.SetMachineState(resourcesMachineState, false)
 	if persistCheckpoint {
@@ -633,9 +646,9 @@ func (p *DynamicPolicy) adjustAllocationEntries(persistCheckpoint bool) error {
 	return nil
 }
 
-// calculateMemoryAllocation will not store the allocation in states, instead,
-// it will update the passed by machineState in-place; so the function will be
-// called `calculateXXX` rather than `allocateXXX`
+// calculateMemoryAllocation determines the memory distribution across NUMA nodes based on request hints and QoS requirements.
+// It supports exclusive allocation and shared allocation with options for even distribution.
+// Note: This function updates the provided machineState in-place.
 func (p *DynamicPolicy) calculateMemoryAllocation(req *pluginapi.ResourceRequest, machineState state.NUMANodeMap, qosLevel string, podAggregatedRequest int) error {
 	numaBinding := qosutil.AnnotationsIndicateNUMABinding(req.Annotations)
 	numaExclusive := qosutil.AnnotationsIndicateNUMAExclusive(req.Annotations)
@@ -810,9 +823,29 @@ func calculateMemoryInNumaNodes(req *pluginapi.ResourceRequest,
 	return reqQuantity, nil
 }
 
-// packAllocationResponse fills pluginapi.ResourceAllocationResponse with information from map of resource to AllocationInfo and pluginapi.ResourceRequest
+// getPackAllocationResponse gathers exported annotations for each resource and packs the allocation response.
+func (p *DynamicPolicy) getPackAllocationResponse(resourceAllocationInfo map[v1.ResourceName]*state.AllocationInfo, req *pluginapi.ResourceRequest) (*pluginapi.ResourceAllocationResponse, error) {
+	var resourceAllocationAnnotations map[v1.ResourceName]map[string]string
+	for resName, ai := range resourceAllocationInfo {
+		if ai == nil {
+			continue
+		}
+		// Return all annotations as requested.
+		if len(ai.Annotations) > 0 {
+			if resourceAllocationAnnotations == nil {
+				resourceAllocationAnnotations = make(map[v1.ResourceName]map[string]string)
+			}
+			resourceAllocationAnnotations[resName] = ai.Annotations
+		}
+	}
+	return packAllocationResponse(resourceAllocationInfo, req, resourceAllocationAnnotations)
+}
+
+// packAllocationResponse assembles a ResourceAllocationResponse for the memory plugin.
+// It populates the response with pod/container metadata and resource allocation results for all memory-related resources.
+// It directly applies the pre-processed resourceAllocationAnnotations to each resource's allocation info.
 func packAllocationResponse(resourceAllocationInfo map[v1.ResourceName]*state.AllocationInfo, req *pluginapi.ResourceRequest,
-	resourceAllocationAnnotations ...map[v1.ResourceName]map[string]string,
+	resourceAllocationAnnotations map[v1.ResourceName]map[string]string,
 ) (*pluginapi.ResourceAllocationResponse, error) {
 	if resourceAllocationInfo == nil {
 		return nil, fmt.Errorf("packAllocationResponse got nil resourceAllocationInfo")
@@ -842,14 +875,9 @@ func packAllocationResponse(resourceAllocationInfo map[v1.ResourceName]*state.Al
 			continue
 		}
 
-		mergedResourceAnnotations := make([]map[string]string, 0, len(resourceAllocationAnnotations))
-		for _, ra := range resourceAllocationAnnotations {
-			if ra == nil {
-				continue
-			}
-			if annos, ok := ra[resourceName]; ok {
-				mergedResourceAnnotations = append(mergedResourceAnnotations, annos)
-			}
+		var resourceAnnotations map[string]string
+		if resourceAllocationAnnotations != nil {
+			resourceAnnotations = resourceAllocationAnnotations[resourceName]
 		}
 
 		topologyAssignments := make(map[uint64]uint64)
@@ -861,7 +889,7 @@ func packAllocationResponse(resourceAllocationInfo map[v1.ResourceName]*state.Al
 			OciPropertyName:     util.OCIPropertyNameCPUSetMems,
 			IsNodeResource:      false,
 			IsScalarResource:    true,
-			Annotations:         general.MergeAnnotations(mergedResourceAnnotations...),
+			Annotations:         resourceAnnotations,
 			AllocatedQuantity:   float64(allocationInfo.AggregatedQuantity),
 			AllocationResult:    allocationInfo.NumaAllocationResult.String(),
 			TopologyAssignments: topologyAssignments,
@@ -1130,20 +1158,6 @@ func (p *DynamicPolicy) getDefaultSystemCoresNUMAs(machineState state.NUMANodeMa
 		return p.topology.CPUDetails.NUMANodes()
 	}
 	return numaNodesWithoutNUMABindingAndNUMAExclusivePods
-}
-
-// getReclaimedResourceAllocationAnnotations return the resource allocation annotations for the given allocation.
-func (p *DynamicPolicy) getReclaimedResourceAllocationAnnotations(allocation *state.AllocationInfo) map[string]string {
-	resourceAllocationAnnotations := make(map[string]string)
-	if allocation.CheckReclaimedActualNUMABinding() {
-		resourceAllocationAnnotations[p.numaBindResultResourceAllocationAnnotationKey] = allocation.NumaAllocationResult.String()
-	}
-
-	if len(resourceAllocationAnnotations) == 0 {
-		return nil
-	}
-
-	return resourceAllocationAnnotations
 }
 
 // updateSpecifiedNUMAAllocation update NUMA allocation by allocation reactor.

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
@@ -56,6 +56,7 @@ import (
 	appagent "github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/advisorsvc"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	cpuconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/consts"
 	memconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/consts"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/memoryadvisor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/dynamicpolicy/oom"
@@ -176,6 +177,11 @@ func getTestDynamicPolicyWithInitialization(
 		extraResourceNames:                            fakeConf.ExtraMemoryResources,
 	}
 
+	// Important: We must register the topologyAllocationHook and set the annotation keys
+	// to ensure that the test environment correctly generates NUMA topology annotations
+	// in the allocation response, matching the production behavior.
+	policyImplement.RegisterAllocationHook(policyImplement.topologyAllocationHook)
+
 	policyImplement.allocationHandlers = map[string]util.AllocationHandler{
 		consts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresAllocationHandler,
 		consts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresAllocationHandler,
@@ -249,6 +255,8 @@ func getTestDynamicPolicyWithExtraResourcesWithInitialization(
 		extraResourceNames:                            fakeConfWithExtraResources.ExtraMemoryResources,
 	}
 
+	policyImplement.RegisterAllocationHook(policyImplement.topologyAllocationHook)
+
 	policyImplement.allocationHandlers = map[string]util.AllocationHandler{
 		consts.PodAnnotationQoSLevelSharedCores:    policyImplement.sharedCoresAllocationHandler,
 		consts.PodAnnotationQoSLevelDedicatedCores: policyImplement.dedicatedCoresAllocationHandler,
@@ -307,6 +315,7 @@ func TestCheckMemorySet(t *testing.T) {
 						Annotations: map[string]string{
 							consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelDedicatedCores,
 							consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+							cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 						},
 						Labels: map[string]string{
 							consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelDedicatedCores,
@@ -664,6 +673,9 @@ func TestAllocate(t *testing.T) {
 							AllocatedQuantity:   1073741824,
 							AllocationResult:    machine.NewCPUSet(0, 1, 2, 3).String(),
 							TopologyAssignments: map[uint64]uint64{},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
@@ -714,6 +726,9 @@ func TestAllocate(t *testing.T) {
 							AllocatedQuantity:   1073741824,
 							AllocationResult:    machine.NewCPUSet(0, 1, 2, 3).String(),
 							TopologyAssignments: map[uint64]uint64{},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
@@ -780,7 +795,10 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"7Gi"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive: consts.PodAnnotationMemoryEnhancementNumaExclusiveEnable,
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"memory":"7Gi"}}}}`,
 							},
 						},
 					},
@@ -839,7 +857,11 @@ func TestAllocate(t *testing.T) {
 								0: 2147483648,
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"2Gi"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive: "false",
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:            "0",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"memory":"2Gi"}}}}`,
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{
@@ -914,7 +936,10 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"7Gi"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                    consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:   consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive: consts.PodAnnotationMemoryEnhancementNumaExclusiveEnable,
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:   `{"Numa":{"0":{"allocated":{"memory":"7Gi"}}}}`,
 							},
 						},
 					},
@@ -984,6 +1009,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"2Gi"}}}}`,
 							},
 						},
@@ -1050,6 +1078,9 @@ func TestAllocate(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelSharedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"2Gi"}}}}`,
 							},
 						},
@@ -1101,6 +1132,9 @@ func TestAllocate(t *testing.T) {
 							AllocatedQuantity:   2147483648,
 							AllocationResult:    machine.NewCPUSet(0, 1, 2, 3).String(),
 							TopologyAssignments: map[uint64]uint64{},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
@@ -1112,6 +1146,9 @@ func TestAllocate(t *testing.T) {
 							AllocatedQuantity:   2147483648,
 							AllocationResult:    machine.NewCPUSet(0, 1, 2, 3).String(),
 							TopologyAssignments: map[uint64]uint64{},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
@@ -1167,6 +1204,9 @@ func TestAllocate(t *testing.T) {
 							AllocatedQuantity:   2147483648,
 							TopologyAssignments: map[uint64]uint64{},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                   consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:  consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:           "0",
 								coreconsts.QRMResourceAnnotationKeyNUMABindResult: "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey:  `{"Numa":{"0":{}}}`,
 							},
@@ -1228,6 +1268,9 @@ func TestAllocate(t *testing.T) {
 							AllocatedQuantity:   2147483648,
 							AllocationResult:    machine.NewCPUSet(0, 1, 2, 3).String(),
 							TopologyAssignments: map[uint64]uint64{},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{
 									nil,
@@ -1289,6 +1332,9 @@ func TestAllocate(t *testing.T) {
 								0: 2147483648,
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelSharedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"2Gi"}}}}`,
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
@@ -1310,6 +1356,9 @@ func TestAllocate(t *testing.T) {
 								0: 2147483648,
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelSharedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"hugepages-2Mi":"2Gi"}}}}`,
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
@@ -1378,7 +1427,12 @@ func TestAllocate(t *testing.T) {
 								1: 1073741824,
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"memory":"1Gi"}},"1":{"allocated":{"memory":"1Gi"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                              consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:             consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNuma: consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNumaEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive:           "false",
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:                      "0-1",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:             `{"Numa":{"0":{"allocated":{"memory":"1Gi"}},"1":{"allocated":{"memory":"1Gi"}}}}`,
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{
@@ -1400,7 +1454,12 @@ func TestAllocate(t *testing.T) {
 								1: 1073741824,
 							},
 							Annotations: map[string]string{
-								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"hugepages-2Mi":"1Gi"}},"1":{"allocated":{"hugepages-2Mi":"1Gi"}}}}`,
+								consts.PodAnnotationQoSLevelKey:                              consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:             consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNuma: consts.PodAnnotationCPUEnhancementDistributeEvenlyAcrossNumaEnable,
+								consts.PodAnnotationMemoryEnhancementNumaExclusive:           "false",
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:                      "0-1",
+								coreconsts.QRMPodAnnotationTopologyAllocationKey:             `{"Numa":{"0":{"allocated":{"hugepages-2Mi":"1Gi"}},"1":{"allocated":{"hugepages-2Mi":"1Gi"}}}}`,
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{
@@ -1486,6 +1545,9 @@ func TestAllocate(t *testing.T) {
 								0: 2147483648,
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelDedicatedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:          "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{"allocated":{"hugepages-2Mi":"2Gi"}}}}`,
 							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
@@ -1550,6 +1612,161 @@ func TestAllocate(t *testing.T) {
 			os.RemoveAll(tmpDir)
 		})
 	}
+}
+
+func TestDynamicPolicy_AllocationHooks(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		req          *pluginapi.ResourceRequest
+		hook         AllocationHook
+		expectErr    bool
+		verifyResult func(t *testing.T, policy *DynamicPolicy)
+	}{
+		{
+			name: "hook modifies allocation",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "modify-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "modify-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceMemory),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceMemory): 1024 * 1024 * 1024,
+				},
+				Hint: &pluginapi.TopologyHint{
+					Nodes:     []uint64{0},
+					Preferred: true,
+				},
+			},
+			hook: func(resourceName v1.ResourceName, oldAlloc, newAlloc *state.AllocationInfo) error {
+				if newAlloc.PodName == "modify-pod" {
+					if newAlloc.Annotations == nil {
+						newAlloc.Annotations = make(map[string]string)
+					}
+					newAlloc.Annotations["hook-modified"] = "true"
+				}
+				return nil
+			},
+			expectErr: false,
+			verifyResult: func(t *testing.T, policy *DynamicPolicy) {
+				allocInfo := policy.state.GetAllocationInfo(v1.ResourceMemory, "modify-pod-uid", "c1")
+				require.NotNil(t, allocInfo)
+				require.Equal(t, "true", allocInfo.Annotations["hook-modified"])
+			},
+		},
+		{
+			name: "hook returns error",
+			req: &pluginapi.ResourceRequest{
+				PodUid:        "error-pod-uid",
+				PodNamespace:  "default",
+				PodName:       "error-pod",
+				ContainerName: "c1",
+				ContainerType: pluginapi.ContainerType_MAIN,
+				ResourceName:  string(v1.ResourceMemory),
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				},
+				ResourceRequests: map[string]float64{
+					string(v1.ResourceMemory): 1024 * 1024 * 1024,
+				},
+				Hint: &pluginapi.TopologyHint{
+					Nodes:     []uint64{0},
+					Preferred: true,
+				},
+			},
+			hook: func(resourceName v1.ResourceName, oldAlloc, newAlloc *state.AllocationInfo) error {
+				return fmt.Errorf("hook error")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir, err := ioutil.TempDir("", "checkpoint-TestAllocationHooks")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+
+			cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+			require.NoError(t, err)
+			machineInfo := &info.MachineInfo{}
+
+			policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, tmpDir)
+			require.NoError(t, err)
+
+			policy.RegisterAllocationHook(tc.hook)
+
+			_, err = policy.Allocate(context.Background(), tc.req)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tc.verifyResult != nil {
+					tc.verifyResult(t, policy)
+				}
+			}
+		})
+	}
+}
+
+func TestDynamicPolicy_InvokeAllocationHooksForPodResourceEntries(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestInvokeAllocationHooks")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+	machineInfo := &info.MachineInfo{}
+
+	policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, tmpDir)
+	require.NoError(t, err)
+
+	hookCalled := false
+	policy.RegisterAllocationHook(func(resourceName v1.ResourceName, oldAlloc, newAlloc *state.AllocationInfo) error {
+		if newAlloc.PodName == "test-pod" {
+			hookCalled = true
+		}
+		return nil
+	})
+
+	curEntries := state.PodResourceEntries{
+		v1.ResourceMemory: state.PodEntries{
+			"test-pod-uid": state.ContainerEntries{
+				"c1": &state.AllocationInfo{
+					AllocationMeta: commonstate.AllocationMeta{
+						PodUid:  "test-pod-uid",
+						PodName: "test-pod",
+					},
+				},
+			},
+		},
+	}
+	newEntries := state.PodResourceEntries{
+		v1.ResourceMemory: state.PodEntries{
+			"test-pod-uid": state.ContainerEntries{
+				"c1": &state.AllocationInfo{
+					AllocationMeta: commonstate.AllocationMeta{
+						PodUid:  "test-pod-uid",
+						PodName: "test-pod",
+					},
+				},
+			},
+		},
+	}
+
+	err = policy.invokeAllocationHooksForPodResourceEntries(curEntries, newEntries)
+	require.NoError(t, err)
+	require.True(t, hookCalled)
 }
 
 func TestAllocateForPod(t *testing.T) {
@@ -2975,11 +3192,12 @@ func TestGetResourcesAllocation(t *testing.T) {
 				}
 			},
 			expectedMemory: &pluginapi.ResourceAllocationInfo{
-				OciPropertyName:   util.OCIPropertyNameCPUSetMems,
-				IsNodeResource:    false,
-				IsScalarResource:  true,
-				AllocatedQuantity: 0,
-				AllocationResult:  machine.NewCPUSet(1, 2, 3).String(),
+				OciPropertyName:     util.OCIPropertyNameCPUSetMems,
+				IsNodeResource:      false,
+				IsScalarResource:    true,
+				AllocatedQuantity:   0,
+				AllocationResult:    machine.NewCPUSet(1, 2, 3).String(),
+				TopologyAssignments: map[uint64]uint64{},
 			},
 		},
 		{
@@ -5126,7 +5344,7 @@ func TestSNBMemoryAdmitWithSidecarReallocate(t *testing.T) {
 
 	as := require.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryVPAWithSidecar")
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryAdmitWithSidecarReallocate")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/resize_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/resize_test.go
@@ -36,12 +36,12 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
-func TestSNBMemoryVPA(t *testing.T) {
+func TestSNBMemoryResize(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryVPA")
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryResize")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -205,12 +205,12 @@ func TestSNBMemoryVPA(t *testing.T) {
 	as.NotNil(err)
 }
 
-func TestSNBMemoryVPAWithZeroRequest(t *testing.T) {
+func TestSNBMemoryResizeWithZeroRequest(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryVPAWithZeroRequest")
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryResizeWithZeroRequest")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -351,12 +351,12 @@ func TestSNBMemoryVPAWithZeroRequest(t *testing.T) {
 	as.Equal(float64(2147483648), resizeAllocation.PodResources[req.PodUid].ContainerResources[req.ContainerName].ResourceAllocation[string(v1.ResourceMemory)].AllocatedQuantity)
 }
 
-func TestSNBMemoryVPAWithSidecar(t *testing.T) {
+func TestSNBMemoryResizeWithSidecar(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryVPAWithSidecar")
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestSNBMemoryResizeWithSidecar")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -768,12 +768,12 @@ func TestSNBMemoryVPAWithSidecar(t *testing.T) {
 	as.Nil(err)
 }
 
-func TestNonBindingShareCoresMemoryVPA(t *testing.T) {
+func TestNonBindingShareCoresMemoryResize(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestNonBindingShareCoresMemoryVPA")
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestNonBindingShareCoresMemoryResize")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -877,12 +877,12 @@ func TestNonBindingShareCoresMemoryVPA(t *testing.T) {
 	as.NotNil(err)
 }
 
-func TestNonBindingShareCoresMemoryVPAWithSidecar(t *testing.T) {
+func TestNonBindingShareCoresMemoryResizeWithSidecar(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestNonBindingShareCoresMemoryVPAWithSidecar")
+	tmpDir, err := ioutil.TempDir("", "checkpoint-TestNonBindingShareCoresMemoryResizeWithSidecar")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
 
@@ -1061,7 +1061,7 @@ func TestNonBindingShareCoresMemoryVPAWithSidecar(t *testing.T) {
 	as.NotNil(err)
 }
 
-func TestRNBMemoryVPA(t *testing.T) {
+func TestRNBMemoryResize(t *testing.T) {
 	t.Parallel()
 
 	as := require.New(t)
@@ -1154,6 +1154,9 @@ func TestRNBMemoryVPA(t *testing.T) {
 							AllocatedQuantity:   3221225472,
 							AllocationResult:    machine.NewCPUSet(0, 1, 2, 3).String(),
 							TopologyAssignments: map[uint64]uint64{},
+							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+							},
 							ResourceHints: &pluginapi.ListOfTopologyHints{
 								Hints: []*pluginapi.TopologyHint{nil},
 							},
@@ -1258,6 +1261,9 @@ func TestRNBMemoryVPA(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                   consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:  consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:           "0",
 								coreconsts.QRMResourceAnnotationKeyNUMABindResult: "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey:  `{"Numa":{"0":{}}}`,
 							},
@@ -1363,6 +1369,9 @@ func TestRNBMemoryVPA(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                   consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding:  consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+								cpuconsts.CPUStateAnnotationKeyNUMAHint:           "0",
 								coreconsts.QRMResourceAnnotationKeyNUMABindResult: "0",
 								coreconsts.QRMPodAnnotationTopologyAllocationKey:  `{"Numa":{"0":{}}}`,
 							},
@@ -1503,6 +1512,8 @@ func TestRNBMemoryVPA(t *testing.T) {
 								},
 							},
 							Annotations: map[string]string{
+								consts.PodAnnotationQoSLevelKey:                  consts.PodAnnotationQoSLevelReclaimedCores,
+								consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
 								coreconsts.QRMPodAnnotationTopologyAllocationKey: `{"Numa":{"0":{},"1":{}}}`,
 							},
 						},

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/util.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/util.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 	utilkubeconfig "github.com/kubewharf/katalyst-core/pkg/util/kubelet/config"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
 func GetFullyDropCacheBytes(container *v1.Container) int64 {
@@ -218,6 +219,51 @@ func applySidecarAllocationInfoFromMainContainer(sidecarAllocationInfo, mainAllo
 	}
 
 	return changed
+}
+
+// IsTopologyAllocationChanged checks if the memory topology allocation of a container has changed.
+func IsTopologyAllocationChanged(oldInfo, newInfo *state.AllocationInfo) bool {
+	if oldInfo == nil || newInfo == nil {
+		return true
+	}
+
+	return !oldInfo.NumaAllocationResult.Equals(newInfo.NumaAllocationResult) ||
+		oldInfo.AggregatedQuantity != newInfo.AggregatedQuantity ||
+		!machine.MemoryDetails(oldInfo.TopologyAwareAllocations).Equal(newInfo.TopologyAwareAllocations)
+}
+
+// getMemoryTopologyAllocationsAnnotationsByAllocationInfo gets the memory topology allocation for a specific allocation info in the form of annotations.
+func getMemoryTopologyAllocationsAnnotationsByAllocationInfo(resourceName v1.ResourceName, ai *state.AllocationInfo,
+	topologyAllocationAnnotationKey string,
+) map[string]string {
+	if ai == nil {
+		return nil
+	}
+
+	topologyAllocation := make(v1alpha1.TopologyAllocation)
+	topologyAllocation[v1alpha1.TopologyTypeNuma] = make(map[string]v1alpha1.ZoneAllocation)
+
+	// In the case where there are no topology aware allocations, we just report the numa nodes.
+	if ai.TopologyAwareAllocations == nil {
+		if ai.NumaAllocationResult.IsEmpty() {
+			return nil
+		}
+
+		numaNodes := ai.NumaAllocationResult.ToSliceNoSortInt()
+		for _, numaNode := range numaNodes {
+			topologyAllocation[v1alpha1.TopologyTypeNuma][strconv.Itoa(numaNode)] = v1alpha1.ZoneAllocation{}
+		}
+	} else {
+		for numaNode, allocated := range ai.TopologyAwareAllocations {
+			topologyAllocation[v1alpha1.TopologyTypeNuma][strconv.Itoa(numaNode)] = v1alpha1.ZoneAllocation{
+				Allocated: map[v1.ResourceName]resource.Quantity{
+					resourceName: *resource.NewQuantity(int64(allocated), resource.BinarySI),
+				},
+			}
+		}
+	}
+
+	return util.MakeTopologyAllocationResourceAllocationAnnotations(topologyAllocation, topologyAllocationAnnotationKey)
 }
 
 // getMemoryTopologyAllocationsAnnotations gets the memory topology allocation in the form of annotations.

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/util_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/util_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -285,6 +286,79 @@ func TestGetMemoryTopologyAllocationsAnnotations(t *testing.T) {
 					t.Fatalf("unexpected topology allocation for resource %q. got=%v, want=%v", resourceName, ta, want)
 				}
 			}
+		})
+	}
+}
+
+func TestIsTopologyAllocationChanged(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		oldInfo  *state.AllocationInfo
+		newInfo  *state.AllocationInfo
+		expected bool
+	}{
+		{
+			name:     "oldInfo is nil",
+			oldInfo:  nil,
+			newInfo:  &state.AllocationInfo{},
+			expected: true,
+		},
+		{
+			name:     "newInfo is nil",
+			oldInfo:  &state.AllocationInfo{},
+			newInfo:  nil,
+			expected: true,
+		},
+		{
+			name: "NumaAllocationResult changed",
+			oldInfo: &state.AllocationInfo{
+				NumaAllocationResult: machine.NewCPUSet(0),
+			},
+			newInfo: &state.AllocationInfo{
+				NumaAllocationResult: machine.NewCPUSet(1),
+			},
+			expected: true,
+		},
+		{
+			name: "AggregatedQuantity changed",
+			oldInfo: &state.AllocationInfo{
+				NumaAllocationResult: machine.NewCPUSet(0),
+				AggregatedQuantity:   1024,
+			},
+			newInfo: &state.AllocationInfo{
+				NumaAllocationResult: machine.NewCPUSet(0),
+				AggregatedQuantity:   2048,
+			},
+			expected: true,
+		},
+		{
+			name: "unchanged",
+			oldInfo: &state.AllocationInfo{
+				NumaAllocationResult: machine.NewCPUSet(0),
+				AggregatedQuantity:   1024,
+				TopologyAwareAllocations: map[int]uint64{
+					0: 1024,
+				},
+			},
+			newInfo: &state.AllocationInfo{
+				NumaAllocationResult: machine.NewCPUSet(0),
+				AggregatedQuantity:   1024,
+				TopologyAwareAllocations: map[int]uint64{
+					0: 1024,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := IsTopologyAllocationChanged(tc.oldInfo, tc.newInfo)
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/pkg/agent/qrm-plugins/util/util.go
+++ b/pkg/agent/qrm-plugins/util/util.go
@@ -435,24 +435,34 @@ func GetPodAggregatedRequestResourceMap(req *pluginapi.ResourceRequest) (map[v1.
 	return intQuantities, floatQuantities, nil
 }
 
-// GetPodAggregatedRequestResource returns both integer and float64 quantities for the main resource in the pod request.
-// If the pod has aggregated resource annotations, those values are used; otherwise, it falls back to the original
-// request quantities. Returns an error if any calculation fails.
-func GetPodAggregatedRequestResource(req *pluginapi.ResourceRequest) (int, float64, error) {
-	annotations := req.Annotations
+// GetPodAggregatedRequestResourceByAnnotations returns both integer and float64 quantities for the main resource based on annotations.
+// If the annotations contain aggregated resource keys, those values are used; otherwise, it falls back to the fallback function.
+// Returns an error if any calculation fails.
+func GetPodAggregatedRequestResourceByAnnotations(annotations map[string]string, resourceName v1.ResourceName, fallback func() (int, float64, error)) (int, float64, error) {
 	if annotations == nil {
-		return GetQuantityFromResourceReq(req)
+		return fallback()
 	}
 	value, ok := annotations[apiconsts.PodAnnotationAggregatedRequestsKey]
 	if !ok {
-		return GetQuantityFromResourceReq(req)
+		return fallback()
 	}
 	var resourceList v1.ResourceList
 	if err := json.Unmarshal([]byte(value), &resourceList); err != nil {
-		return GetQuantityFromResourceReq(req)
+		return fallback()
 	}
 
-	return calculateAggregatedResource(v1.ResourceName(req.ResourceName), resourceList)
+	if _, ok = resourceList[resourceName]; !ok {
+		return fallback()
+	}
+
+	return calculateAggregatedResource(resourceName, resourceList)
+}
+
+// GetPodAggregatedRequestResource returns both integer and float64 quantities for the main resource in the pod request.
+func GetPodAggregatedRequestResource(req *pluginapi.ResourceRequest) (int, float64, error) {
+	return GetPodAggregatedRequestResourceByAnnotations(req.Annotations, v1.ResourceName(req.ResourceName), func() (int, float64, error) {
+		return GetQuantityFromResourceReq(req)
+	})
 }
 
 func calculateAggregatedResource(resourceName v1.ResourceName, resourceList v1.ResourceList) (int, float64, error) {

--- a/pkg/agent/qrm-plugins/util/util_test.go
+++ b/pkg/agent/qrm-plugins/util/util_test.go
@@ -418,6 +418,68 @@ func TestGetNUMANodesCountToFitCPUReq(t *testing.T) {
 	}
 }
 
+func TestGetPodAggregatedRequestResourceByAnnotations(t *testing.T) {
+	t.Parallel()
+
+	rl := v1.ResourceList{
+		v1.ResourceCPU: *resource.NewQuantity(2, resource.DecimalSI),
+	}
+	b, _ := json.Marshal(rl)
+
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		resName       v1.ResourceName
+		fallback      func() (int, float64, error)
+		expectedInt   int
+		expectedFloat float64
+	}{
+		{
+			name:          "empty annotations",
+			annotations:   nil,
+			resName:       v1.ResourceCPU,
+			fallback:      func() (int, float64, error) { return 1, 1.0, nil },
+			expectedInt:   1,
+			expectedFloat: 1.0,
+		},
+		{
+			name:          "no aggregated key",
+			annotations:   map[string]string{"k1": "v1"},
+			resName:       v1.ResourceCPU,
+			fallback:      func() (int, float64, error) { return 1, 1.0, nil },
+			expectedInt:   1,
+			expectedFloat: 1.0,
+		},
+		{
+			name:          "valid aggregated json",
+			annotations:   map[string]string{consts.PodAnnotationAggregatedRequestsKey: string(b)},
+			resName:       v1.ResourceCPU,
+			fallback:      func() (int, float64, error) { return 1, 1.0, nil },
+			expectedInt:   2,
+			expectedFloat: 2.0,
+		},
+		{
+			name:          "valid aggregated json but resource missing",
+			annotations:   map[string]string{consts.PodAnnotationAggregatedRequestsKey: string(b)},
+			resName:       v1.ResourceMemory,
+			fallback:      func() (int, float64, error) { return 1, 1.0, nil },
+			expectedInt:   1,
+			expectedFloat: 1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotInt, gotFloat, err := GetPodAggregatedRequestResourceByAnnotations(tt.annotations, tt.resName, tt.fallback)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedInt, gotInt)
+			assert.Equal(t, tt.expectedFloat, gotFloat)
+		})
+	}
+}
+
 func TestGetNUMANodesCountToFitMemoryReq(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/config/agent/qrm/qrm_base.go
+++ b/pkg/config/agent/qrm/qrm_base.go
@@ -39,7 +39,7 @@ type GenericQRMPluginConfiguration struct {
 	// EnableSNBHighNumaPreference indicates whether to enable high numa preference for snb pods
 	// if set true, snb pod will be preferentially allocated on high numa node
 	EnableSNBHighNumaPreference bool
-	// IsInMemoryStore indicates whether we want to store the state in memory or on disk
+	// EnableInMemoryState indicates whether we want to store the state in memory or on disk
 	// if set true, the state will be stored in tmpfs
 	EnableInMemoryState bool
 	// TopologyAllocationAnnotationKey is the annotation key that indicates the topology-aware allocations of containers.


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features/Refactor/Bug fixes
#### What this PR does / why we need it:
- Fixes memory NUMA binding validation for shared cores
- Introduces allocation hooks framework for CPU dynamic policy
- Renames IsInMemoryStore to EnableInMemoryState in QRM base configuration for better semantics
- Enhances utility functions for resource extraction from pod annotations
- Integrates allocation hooks into both CPU and Memory DynamicPolicy
- Adds topology assignments support in allocation responses
- Improves memory advisor handler split for non-Linux platforms
- Fixes deadlocks and adds comprehensive tests for hooks
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer: