### PR TITLE
feat(gpu qrm): add more metrics for gpu plugins

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -46,14 +46,17 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/util"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/metric"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
 const (
-	gpuReporterPluginName      = "gpu-reporter-plugin"
-	propertyNameGPUTopology    = "gpu_topology_attribute_key"
-	defaultReportRetryInterval = 5 * time.Second
-	metricGetPodListFailed     = "qrm_gpu_reporter_get_pod_list_failed"
+	gpuReporterPluginName                       = "gpu-reporter-plugin"
+	propertyNameGPUTopology                     = "gpu_topology_attribute_key"
+	defaultReportRetryInterval                  = 5 * time.Second
+	metricGetPodListFailed                      = "qrm_gpu_reporter_get_pod_list_failed"
+	metricAddKubeletCheckpointAllocationsFailed = "qrm_gpu_reporter_add_kubelet_checkpoint_allocations_failed"
+	metricEnsureKubeletDevicePluginPathFailed   = "qrm_gpu_reporter_ensure_kubelet_device_plugin_path_failed"
 )
 
 var zeroQuantity = *resource.NewQuantity(0, resource.DecimalSI)
@@ -187,6 +190,11 @@ func (p *gpuReporterPlugin) Start() (err error) {
 	if p.enableKubeletCheckpointFallback && p.kubeletDevicePluginPath != "" {
 		err = general.EnsureDirectory(p.kubeletDevicePluginPath)
 		if err != nil {
+			if p.emitter != nil {
+				_ = p.emitter.StoreInt64(metricEnsureKubeletDevicePluginPathFailed, 1, metrics.MetricTypeNameRaw,
+					metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(err)},
+					metrics.MetricTag{Key: "path", Val: metric.MetricTagValueFormat(p.kubeletDevicePluginPath)})
+			}
 			return fmt.Errorf("ensure kubelet device plugin path %s exists failed: %w", p.kubeletDevicePluginPath, err)
 		}
 
@@ -506,6 +514,10 @@ func (p *gpuReporterPlugin) getZoneAllocations(machineState state.AllocationReso
 	// Add allocations from kubelet device manager checkpoint as a fallback.
 	if p.enableKubeletCheckpointFallback {
 		if err := p.addKubeletCheckpointAllocations(idToAllocations); err != nil {
+			if p.emitter != nil {
+				_ = p.emitter.StoreInt64(metricAddKubeletCheckpointAllocationsFailed, 1, metrics.MetricTypeNameRaw,
+					metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(err)})
+			}
 			return nil, err
 		}
 	}

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -2520,3 +2520,164 @@ func TestGpuReporterPlugin_StartDisabledFallback(t *testing.T) {
 	err = p.Stop()
 	assert.NoError(t, err)
 }
+
+type mockMetricsEmitter struct {
+	metrics.DummyMetrics
+	storedInt64 map[string][]int64
+	storedTags  map[string][][]metrics.MetricTag
+}
+
+func newMockMetricsEmitter() *mockMetricsEmitter {
+	return &mockMetricsEmitter{
+		storedInt64: make(map[string][]int64),
+		storedTags:  make(map[string][][]metrics.MetricTag),
+	}
+}
+
+func (m *mockMetricsEmitter) StoreInt64(key string, val int64, _ metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	m.storedInt64[key] = append(m.storedInt64[key], val)
+	m.storedTags[key] = append(m.storedTags[key], tags)
+	return nil
+}
+
+func (m *mockMetricsEmitter) WithTags(unit string, commonTags ...metrics.MetricTag) metrics.MetricEmitter {
+	w := &metrics.MetricTagWrapper{MetricEmitter: m}
+	return w.WithTags(unit, commonTags...)
+}
+
+// TestGpuReporterPlugin_GetZoneAllocations_KubeletCheckpointFailureEmitsMetric verifies that
+// when addKubeletCheckpointAllocations returns an error, getZoneAllocations emits the
+// metricAddKubeletCheckpointAllocationsFailed metric with the error_message tag and
+// propagates the error.
+func TestGpuReporterPlugin_GetZoneAllocations_KubeletCheckpointFailureEmitsMetric(t *testing.T) {
+	t.Parallel()
+
+	emitter := newMockMetricsEmitter()
+	checkpointErr := fmt.Errorf("boom: checkpoint manager exploded")
+
+	p := &gpuReporterPlugin{
+		ctx:                             context.TODO(),
+		emitter:                         emitter,
+		gpuDeviceNames:                  []string{"test-resource"},
+		enableKubeletCheckpointFallback: true,
+		checkpointManager: &mockCheckpointManager{
+			getErr: checkpointErr,
+		},
+	}
+
+	zoneAllocations, err := p.getZoneAllocations(state.AllocationResourcesMap{})
+	assert.Error(t, err)
+	assert.Nil(t, zoneAllocations)
+
+	vals := emitter.storedInt64[metricAddKubeletCheckpointAllocationsFailed]
+	assert.Equal(t, []int64{1}, vals, "expected failure metric to be emitted exactly once")
+
+	tagsList := emitter.storedTags[metricAddKubeletCheckpointAllocationsFailed]
+	assert.Len(t, tagsList, 1)
+
+	tagMap := make(map[string]string)
+	for _, tag := range tagsList[0] {
+		tagMap[tag.Key] = tag.Val
+	}
+	assert.NotEmpty(t, tagMap["error_message"], "expected error_message tag to be set")
+}
+
+// TestGpuReporterPlugin_GetZoneAllocations_KubeletCheckpointFailureNilEmitter verifies
+// that when the emitter is nil, the failure path does not panic and the error is still
+// propagated.
+func TestGpuReporterPlugin_GetZoneAllocations_KubeletCheckpointFailureNilEmitter(t *testing.T) {
+	t.Parallel()
+
+	p := &gpuReporterPlugin{
+		ctx:                             context.TODO(),
+		emitter:                         nil,
+		gpuDeviceNames:                  []string{"test-resource"},
+		enableKubeletCheckpointFallback: true,
+		checkpointManager: &mockCheckpointManager{
+			getErr: fmt.Errorf("checkpoint failure"),
+		},
+	}
+
+	zoneAllocations, err := p.getZoneAllocations(state.AllocationResourcesMap{})
+	assert.Error(t, err)
+	assert.Nil(t, zoneAllocations)
+}
+
+// TestGpuReporterPlugin_StartEnsureKubeletDevicePluginPathFailure verifies that when the
+// kubelet device plugin path cannot be created (because a regular file occupies the parent
+// component of the requested path), Start returns an error and the
+// metricEnsureKubeletDevicePluginPathFailed metric is emitted with the error_message and
+// path tags.
+func TestGpuReporterPlugin_StartEnsureKubeletDevicePluginPathFailure(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := os.MkdirTemp("", "kubelet-device-plugin-ensure-fail")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a regular file; its sub-path cannot be created as a directory because the
+	// parent is a file, which forces general.EnsureDirectory -> MkdirAll to fail.
+	parentFile := filepath.Join(tempDir, "not-a-dir")
+	err = os.WriteFile(parentFile, []byte("blocker"), 0o644)
+	assert.NoError(t, err)
+	invalidPath := filepath.Join(parentFile, "child")
+
+	emitter := newMockMetricsEmitter()
+
+	p := &gpuReporterPlugin{
+		emitter:                         emitter,
+		kubeletDevicePluginPath:         invalidPath,
+		enableKubeletCheckpointFallback: true,
+		reportNotifyCh:                  make(chan struct{}, 1),
+	}
+
+	err = p.Start()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ensure kubelet device plugin path")
+
+	// metric should be emitted exactly once with the expected tags
+	vals := emitter.storedInt64[metricEnsureKubeletDevicePluginPathFailed]
+	assert.Equal(t, []int64{1}, vals, "expected ensure-path failure metric to be emitted exactly once")
+
+	tagsList := emitter.storedTags[metricEnsureKubeletDevicePluginPathFailed]
+	assert.Len(t, tagsList, 1)
+
+	tagMap := make(map[string]string)
+	for _, tag := range tagsList[0] {
+		tagMap[tag.Key] = tag.Val
+	}
+	assert.NotEmpty(t, tagMap["error_message"], "expected error_message tag to be set")
+	assert.NotEmpty(t, tagMap["path"], "expected path tag to be set")
+
+	// The plugin should not be marked as started since Start failed.
+	p.RLock()
+	assert.False(t, p.started)
+	p.RUnlock()
+}
+
+// TestGpuReporterPlugin_StartEnsureKubeletDevicePluginPathFailureNilEmitter verifies that
+// when EnsureDirectory fails and the emitter is nil, Start does not panic and still
+// returns the wrapped error.
+func TestGpuReporterPlugin_StartEnsureKubeletDevicePluginPathFailureNilEmitter(t *testing.T) {
+	t.Parallel()
+
+	tempDir, err := os.MkdirTemp("", "kubelet-device-plugin-ensure-fail-nil")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	parentFile := filepath.Join(tempDir, "not-a-dir")
+	err = os.WriteFile(parentFile, []byte("blocker"), 0o644)
+	assert.NoError(t, err)
+	invalidPath := filepath.Join(parentFile, "child")
+
+	p := &gpuReporterPlugin{
+		emitter:                         nil,
+		kubeletDevicePluginPath:         invalidPath,
+		enableKubeletCheckpointFallback: true,
+		reportNotifyCh:                  make(chan struct{}, 1),
+	}
+
+	err = p.Start()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ensure kubelet device plugin path")
+}

--- a/pkg/agent/qrm-plugins/gpu/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/gpu/staticpolicy/policy.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/metric"
 )
 
 // StaticPolicy is the static gpu policy
@@ -710,6 +711,13 @@ func (p *StaticPolicy) AllocateAssociatedDevice(
 			if deviceType != "" {
 				_ = p.removeContainer(req.ResourceRequest.PodUid, req.ResourceRequest.ContainerName, v1.ResourceName(deviceType))
 			}
+
+			metricTags := []metrics.MetricTag{
+				{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)},
+				{Key: "device_name", Val: req.DeviceName},
+				{Key: "accompany_resource_name", Val: req.AccompanyResourceName},
+			}
+			_ = p.emitter.StoreInt64(util.MetricNameAllocateAssociatedDeviceFailed, 1, metrics.MetricTypeNameRaw, metricTags...)
 		}
 		p.Unlock()
 	}()

--- a/pkg/agent/qrm-plugins/gpu/staticpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/gpu/staticpolicy/policy_test.go
@@ -34,12 +34,37 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/customdeviceplugin"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/resourceplugin"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm/statedirectory"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
+
+type mockMetricsEmitter struct {
+	metrics.DummyMetrics
+	storedInt64 map[string][]int64
+	storedTags  map[string][][]metrics.MetricTag
+}
+
+func newMockMetricsEmitter() *mockMetricsEmitter {
+	return &mockMetricsEmitter{
+		storedInt64: make(map[string][]int64),
+		storedTags:  make(map[string][][]metrics.MetricTag),
+	}
+}
+
+func (m *mockMetricsEmitter) StoreInt64(key string, val int64, _ metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	m.storedInt64[key] = append(m.storedInt64[key], val)
+	m.storedTags[key] = append(m.storedTags[key], tags)
+	return nil
+}
+
+func (m *mockMetricsEmitter) WithTags(unit string, commonTags ...metrics.MetricTag) metrics.MetricEmitter {
+	w := &metrics.MetricTagWrapper{MetricEmitter: m}
+	return w.WithTags(unit, commonTags...)
+}
 
 const (
 	testResourcePluginName      = "resource-plugin-stub"
@@ -851,6 +876,67 @@ func TestStaticPolicy_AllocateAssociatedDevices(t *testing.T) {
 	resp, err = policy.AllocateAssociatedDevice(context.Background(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestStaticPolicy_AllocateAssociatedDevices_EmitsFailureMetric(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestStaticPolicy(t)
+	emitter := newMockMetricsEmitter()
+	policy.emitter = emitter
+
+	policy.RegisterResourcePlugin(resourceplugin.NewResourcePluginStub(policy.BasePlugin))
+	policy.RegisterCustomDevicePlugin(customdeviceplugin.NewCustomDevicePluginStub(policy.BasePlugin))
+
+	registerGeneratorWithTopology(t, policy, testResourcePluginName)
+	registerGeneratorWithTopology(t, policy, testCustomDevicePluginName)
+
+	podUID := string(uuid.NewUUID())
+	testName := "test"
+
+	// req passes ensureState (valid DeviceName + AccompanyResourceName) so the deferred
+	// failure-metric block is reached, but the DeviceRequest list does not contain an entry
+	// matching DeviceName, so AllocateAssociatedDevice returns an error and the failure metric
+	// is emitted from the defer.
+	req := &pluginapi.AssociatedDeviceRequest{
+		ResourceRequest: &pluginapi.ResourceRequest{
+			PodUid:        podUID,
+			PodNamespace:  testName,
+			PodName:       testName,
+			ContainerName: testName,
+			ContainerType: pluginapi.ContainerType_MAIN,
+			ResourceName:  testResourcePluginName,
+			ResourceRequests: map[string]float64{
+				testResourcePluginName: 2,
+			},
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		DeviceRequest: []*pluginapi.DeviceRequest{
+			// Intentionally a different device name so no targetDeviceReq is found.
+			{DeviceName: "some-other-device"},
+		},
+		DeviceName:            testCustomDevicePluginName,
+		AccompanyResourceName: testResourcePluginName,
+	}
+
+	resp, err := policy.AllocateAssociatedDevice(context.Background(), req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+
+	vals := emitter.storedInt64[util.MetricNameAllocateAssociatedDeviceFailed]
+	assert.Equal(t, []int64{1}, vals, "expected failure metric to be emitted exactly once")
+
+	tagsList := emitter.storedTags[util.MetricNameAllocateAssociatedDeviceFailed]
+	assert.Len(t, tagsList, 1)
+
+	tagMap := make(map[string]string)
+	for _, tag := range tagsList[0] {
+		tagMap[tag.Key] = tag.Val
+	}
+	assert.Equal(t, testCustomDevicePluginName, tagMap["device_name"])
+	assert.Equal(t, testResourcePluginName, tagMap["accompany_resource_name"])
+	assert.NotEmpty(t, tagMap["error_message"])
 }
 
 func registerGeneratorWithTopology(t *testing.T, policy *StaticPolicy, resourceName string) {

--- a/pkg/agent/qrm-plugins/util/consts.go
+++ b/pkg/agent/qrm-plugins/util/consts.go
@@ -31,6 +31,7 @@ const (
 	MetricNameCheckApplyV1Error                       = "check_apply_v1_error"
 	MetricNameGetAccompanyResourceTopologyHintsFailed = "get_accompany_resource_topology_hints_failed"
 	MetricNameAllocateAccompanyResourceFailed         = "allocate_accompany_resource_failed"
+	MetricNameAllocateAssociatedDeviceFailed          = "allocate_associated_device_failed"
 	MetricNameReleaseAccompanyResourceFailed          = "release_accompany_resource_failed"
 	MetricNameSyncResourcePackagePinnedCPUSetFailed   = "sync_resource_package_pinned_cpuset_failed"
 	MetricNameResourcePackagePinnedCPUSetSize         = "resource_package_pinned_cpuset_size"


### PR DESCRIPTION
add a new error metric for failed associated device allocation in gpu qrm plugin, and emit the metric when allocate associated device fails with error message tag

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
