### PR TITLE
feat(lifecycle): add label keep list for CNR lifecycle controller

### DIFF
--- a/cmd/katalyst-controller/app/options/lifecycle.go
+++ b/cmd/katalyst-controller/app/options/lifecycle.go
@@ -20,10 +20,15 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	cliflag "k8s.io/component-base/cli/flag"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/controller"
 )
+
+type CNRLifecycleOptions struct {
+	LabelKeepKeys []string
+}
 
 type HealthzOptions struct {
 	DryRun        bool
@@ -49,6 +54,7 @@ type LifeCycleOptions struct {
 	EnableCNCLifecycle bool
 	EnableCNRLifecycle bool
 
+	*CNRLifecycleOptions
 	*HealthzOptions
 }
 
@@ -58,6 +64,9 @@ func NewLifeCycleOptions() *LifeCycleOptions {
 		EnableHealthz:      false,
 		EnableCNCLifecycle: true,
 		EnableCNRLifecycle: true,
+		CNRLifecycleOptions: &CNRLifecycleOptions{
+			LabelKeepKeys: []string{},
+		},
 		HealthzOptions: &HealthzOptions{
 			DryRun:        false,
 			NodeSelector:  "",
@@ -87,6 +96,9 @@ func (o *LifeCycleOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"whether to enable the cnc lifecycle controller")
 	fs.BoolVar(&o.EnableCNRLifecycle, "cnr-lifecycle-enabled", o.EnableCNRLifecycle,
 		"whether to enable the cnr lifecycle controller")
+
+	fs.StringSliceVar(&o.LabelKeepKeys, "cnr-lifecycle-label-keep-keys", o.LabelKeepKeys,
+		"label keys that should be preserved on CNR even when absent on the Node")
 
 	fs.BoolVar(&o.DryRun, "healthz-dry-run", o.DryRun,
 		"a bool to enable and disable dry-run logic of healthz controller.")
@@ -122,6 +134,11 @@ func (o *LifeCycleOptions) ApplyTo(c *controller.LifeCycleConfig) error {
 	c.EnableHealthz = o.EnableHealthz
 	c.EnableCNCLifecycle = o.EnableCNCLifecycle
 	c.EnableCNRLifecycle = o.EnableCNRLifecycle
+
+	if c.CNRLifecycleConfig == nil {
+		c.CNRLifecycleConfig = &controller.CNRLifecycleConfig{}
+	}
+	c.CNRLifecycleConfig.LabelKeepKeys = sets.NewString(o.LabelKeepKeys...)
 
 	c.DryRun = o.DryRun
 

--- a/pkg/config/controller/lifecycle.go
+++ b/pkg/config/controller/lifecycle.go
@@ -20,9 +20,15 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type CNRLifecycleConfig struct{}
+type CNRLifecycleConfig struct {
+	// LabelKeepKeys lists label keys that must NOT be removed from CNR
+	// even if the corresponding key is absent on the Node. Other Node-absent
+	// keys on CNR will be cleaned up during label sync.
+	LabelKeepKeys sets.String
+}
 
 type CNCLifecycleConfig struct{}
 
@@ -62,7 +68,7 @@ func NewLifeCycleConfig() *LifeCycleConfig {
 		EnableHealthz:      false,
 		EnableCNCLifecycle: true,
 		EnableCNRLifecycle: true,
-		CNRLifecycleConfig: &CNRLifecycleConfig{},
+		CNRLifecycleConfig: &CNRLifecycleConfig{LabelKeepKeys: sets.NewString()},
 		CNCLifecycleConfig: &CNCLifecycleConfig{},
 		HealthzConfig:      &HealthzConfig{},
 	}

--- a/pkg/controller/lifecycle/cnr.go
+++ b/pkg/controller/lifecycle/cnr.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -68,6 +69,10 @@ type CNRLifecycle struct {
 	// queue for node
 	syncQueue workqueue.RateLimitingInterface
 
+	// labelKeepKeys is the whitelist of label keys that must NOT be removed
+	// from CNR even when the corresponding key is absent on the Node.
+	labelKeepKeys sets.String
+
 	// metricsEmitter for emit metrics
 	metricsEmitter metrics.MetricEmitter
 }
@@ -75,7 +80,7 @@ type CNRLifecycle struct {
 func NewCNRLifecycle(ctx context.Context,
 	genericConf *generic.GenericConfiguration,
 	_ *controller.GenericControllerConfiguration,
-	_ *controller.CNRLifecycleConfig,
+	cnrLifecycleConfig *controller.CNRLifecycleConfig,
 	client *client.GenericClientSet,
 	nodeInformer coreinformers.NodeInformer,
 	cnrInformer informers.CustomNodeResourceInformer,
@@ -86,6 +91,11 @@ func NewCNRLifecycle(ctx context.Context,
 		client: client,
 		syncQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(),
 			cnrLifecycleControllerName),
+		labelKeepKeys: sets.NewString(),
+	}
+
+	if cnrLifecycleConfig != nil && cnrLifecycleConfig.LabelKeepKeys != nil {
+		cnrLifecycle.labelKeepKeys = cnrLifecycleConfig.LabelKeepKeys
 	}
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -319,7 +329,7 @@ func (cl *CNRLifecycle) updateOrCreateCNR(node *corev1.Node) error {
 	}
 
 	newCNR := cnr.DeepCopy()
-	newCNR.Labels = general.MergeMap(newCNR.Labels, node.Labels)
+	newCNR.Labels = mergeLabelsWithKeepList(cnr.Labels, node.Labels, cl.labelKeepKeys)
 	setCNROwnerReference(newCNR, node)
 	if apiequality.Semantic.DeepEqual(newCNR, cnr) {
 		return nil
@@ -345,4 +355,23 @@ func setCNROwnerReference(cnr *apis.CustomNodeResource, node *corev1.Node) {
 			BlockOwnerDeletion: &blocker,
 		},
 	}
+}
+
+// mergeLabelsWithKeepList builds the desired CNR label map:
+//   - take all labels from node;
+//   - for keys in keepKeys, preserve the value already on CNR if node does not have it.
+func mergeLabelsWithKeepList(cnrLabels, nodeLabels map[string]string, keepKeys sets.String) map[string]string {
+	result := make(map[string]string, len(nodeLabels)+keepKeys.Len())
+	for k, v := range nodeLabels {
+		result[k] = v
+	}
+	for k := range keepKeys {
+		if _, ok := nodeLabels[k]; ok {
+			continue
+		}
+		if v, ok := cnrLabels[k]; ok {
+			result[k] = v
+		}
+	}
+	return result
 }

--- a/pkg/controller/lifecycle/cnr_test.go
+++ b/pkg/controller/lifecycle/cnr_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/pointer"
 
@@ -171,13 +172,14 @@ func TestCNRLifecycle_updateOrCreateCNR(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
-		node *corev1.Node
-		cnr  *nodeapis.CustomNodeResource
+		node          *corev1.Node
+		cnr           *nodeapis.CustomNodeResource
+		labelKeepKeys sets.String
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		wantCNR *nodeapis.CustomNodeResource
+		name       string
+		fields     fields
+		wantLabels map[string]string
 	}{
 		{
 			name: "test-update",
@@ -199,23 +201,85 @@ func TestCNRLifecycle_updateOrCreateCNR(t *testing.T) {
 					},
 				},
 			},
-			wantCNR: &nodeapis.CustomNodeResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "node1",
-					Labels: map[string]string{
-						"test": "test-1",
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "v1",
-							Kind:               "Node",
-							Name:               "node1",
-							UID:                "",
-							Controller:         pointer.Bool(true),
-							BlockOwnerDeletion: pointer.Bool(true),
+			wantLabels: map[string]string{
+				"test": "test-1",
+			},
+		},
+		{
+			name: "clean-stale-label",
+			fields: fields{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"a": "1",
 						},
 					},
 				},
+				cnr: &nodeapis.CustomNodeResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"a":     "1",
+							"stale": "x",
+						},
+					},
+				},
+			},
+			wantLabels: map[string]string{
+				"a": "1",
+			},
+		},
+		{
+			name: "keep-list-preserve",
+			fields: fields{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"a": "1",
+						},
+					},
+				},
+				cnr: &nodeapis.CustomNodeResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"a":    "1",
+							"keep": "old",
+						},
+					},
+				},
+				labelKeepKeys: sets.NewString("keep"),
+			},
+			wantLabels: map[string]string{
+				"a":    "1",
+				"keep": "old",
+			},
+		},
+		{
+			name: "keep-list-overridden-by-node",
+			fields: fields{
+				node: &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"keep": "new",
+						},
+					},
+				},
+				cnr: &nodeapis.CustomNodeResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+						Labels: map[string]string{
+							"keep": "old",
+						},
+					},
+				},
+				labelKeepKeys: sets.NewString("keep"),
+			},
+			wantLabels: map[string]string{
+				"keep": "new",
 			},
 		},
 	}
@@ -242,9 +306,17 @@ func TestCNRLifecycle_updateOrCreateCNR(t *testing.T) {
 			)
 			assert.NoError(t, err)
 
-			// test cache not synced
+			if tt.fields.labelKeepKeys != nil {
+				cl.labelKeepKeys = tt.fields.labelKeepKeys
+			}
+
 			err = cl.updateOrCreateCNR(tt.fields.node)
 			assert.NoError(t, err)
+
+			gotCNR, err := cl.client.InternalClient.NodeV1alpha1().CustomNodeResources().Get(
+				context.Background(), tt.fields.node.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantLabels, gotCNR.Labels)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features
#### What this PR does / why we need it:
Add support to preserve specified label keys on CNR even when they are absent on the underlying Node. Introduce configurable LabelKeepKeys field in both the lifecycle config and CLI options, implement label merging logic that retains whitelisted stale labels, and add corresponding test cases to validate the behavior.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
