### PR TITLE
feat(cpu): add irq affinity mode and isolcpus exclusion support

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/cpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/cpu_plugin.go
@@ -17,6 +17,7 @@ limitations under the License.
 package qrm
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -26,6 +27,7 @@ import (
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/qrm/hintoptimizer"
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options/qrm/irqtuner"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	irqutil "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/utils"
 	qrmconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/qrm"
 )
 
@@ -57,6 +59,8 @@ type CPUDynamicPolicyOptions struct {
 	EnableDefaultSharedCoresCPUBurst                   bool
 	EnableCPUBurstForMainContainerOnly                 bool
 	IRQForbiddenPinnedResourcePackageAttributeSelector string
+	IRQAffinityMode                                    string
+	ExcludeIsolCPUsFromIRQ                             bool
 	*irqtuner.IRQTunerOptions
 	*hintoptimizer.HintOptimizerOptions
 }
@@ -87,6 +91,8 @@ func NewCPUOptions() *CPUOptions {
 			NUMABindingResultAnnotationKey: consts.PodAnnotationNUMABindResultKey,
 			NUMANumberAnnotationKey:        consts.PodAnnotationCPUEnhancementNumaNumber,
 			NUMAIDsAnnotationKey:           consts.PodAnnotationCPUEnhancementNumaIDs,
+			IRQAffinityMode:                irqutil.IRQAffinityModeNonReserved,
+			ExcludeIsolCPUsFromIRQ:         false,
 			HintOptimizerOptions:           hintoptimizer.NewHintOptimizerOptions(),
 			IRQTunerOptions:                irqtuner.NewIRQTunerOptions(),
 		},
@@ -148,6 +154,11 @@ func (o *CPUOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&o.IRQForbiddenPinnedResourcePackageAttributeSelector, "irq-forbidden-pinned-resource-package-attribute-selector",
 		o.IRQForbiddenPinnedResourcePackageAttributeSelector, "The selector to filter pinned resource packages that are"+
 			"forbidden for irq binding.")
+	fs.StringVar(&o.IRQAffinityMode, "irq-affinity-mode", o.IRQAffinityMode,
+		"The IRQ affinity mode. Valid values: \"non-reserved\" (default, IRQ binds to non-reserved CPUs) "+
+			"or \"reserved-only\" (IRQ binds to reserved CPUs only).")
+	fs.BoolVar(&o.ExcludeIsolCPUsFromIRQ, "exclude-isolcpus-from-irq", o.ExcludeIsolCPUsFromIRQ,
+		"if set true, kernel isolcpus parsed from /proc/cmdline will be excluded from IRQ-eligible cores")
 	o.HintOptimizerOptions.AddFlags(fss)
 	o.IRQTunerOptions.AddFlags(fss)
 }
@@ -178,6 +189,14 @@ func (o *CPUOptions) ApplyTo(conf *qrmconfig.CPUQRMPluginConfig) error {
 		return err
 	}
 	conf.IRQForbiddenPinnedResourcePackageAttributeSelector = selector
+	switch o.IRQAffinityMode {
+	case irqutil.IRQAffinityModeNonReserved, irqutil.IRQAffinityModeReservedOnly:
+	default:
+		return fmt.Errorf("invalid --irq-affinity-mode %q, valid values: %q, %q",
+			o.IRQAffinityMode, irqutil.IRQAffinityModeNonReserved, irqutil.IRQAffinityModeReservedOnly)
+	}
+	conf.IRQAffinityMode = o.IRQAffinityMode
+	conf.ExcludeIsolCPUsFromIRQ = o.ExcludeIsolCPUsFromIRQ
 	if err := o.HintOptimizerOptions.ApplyTo(conf.HintOptimizerConfiguration); err != nil {
 		return err
 	}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux.go
@@ -2639,6 +2639,7 @@ func (ic *IrqTuningController) getNumaQualifiedCCDsForBalanceFairPolicy(numa int
 		}
 
 		// if at least 2/3 cpus of ccd are qualified, then this ccd is qualified
+		// todo it may ignore some numas with only few qualified cores
 		if qualifiedCoresCount >= len(ccdCPUList)*2/3 {
 			qualifiedCCDs = append(qualifiedCCDs, ccd)
 		}
@@ -2999,6 +3000,15 @@ retry:
 	qualifiedNumas = tmpQualifiedNumas
 
 	if len(qualifiedNumas) == 0 {
+		if ccdsBalance {
+			// In some cases, each NUMA node has only a small number of qualified cores.
+			// The system then cannot locate any eligible CCDs per NUMA node.
+			// It falls back to disabling CCD balancing and selects those limited available qualified cores instead.
+			ccdsBalance = false
+			numasWithNotEnoughQualifiedResource = []int{}
+			general.Warningf("%s failed to find qualified numa for nic %s irq affinity with balance-fair policy, try without ccdsBalance", IrqTuningLogPrefix, nic)
+			goto retry
+		}
 		return fmt.Errorf("no qualified numa for nic %s irq affinity with balance-fair policy", nic)
 	}
 
@@ -3115,6 +3125,7 @@ func (ic *IrqTuningController) tuneNicIrqsAffinityLLCDomainsFairly(nic *NicInfo,
 	if ic.CPUInfo.CPUVendor == cpuid.Intel {
 		return ic.tuneNicIrqsAffinityNumasFairly(nic, assignedSockets, false)
 	} else if ic.CPUInfo.CPUVendor == cpuid.AMD {
+		// todo support ccds balance config for amd in the future
 		return ic.tuneNicIrqsAffinityNumasFairly(nic, assignedSockets, true)
 	} else {
 		return fmt.Errorf("unsupport cpu arch: %s", ic.CPUInfo.CPUVendor)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/utils/types.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/utils/types.go
@@ -23,6 +23,13 @@ const (
 	DefaultIRQExclusiveMaxExpansionRate = 0.3
 	// DefaultIRQExclusiveMaxStepExpansionRate identifies the default irq exclusive maximum single-step expansion ratio.
 	DefaultIRQExclusiveMaxStepExpansionRate = 0.05
+
+	// IRQAffinityModeNonReserved means IRQ is allowed to bind to non-reserved CPUs only;
+	// reserved CPUs (and pinned-forbidden CPUs) are forbidden.
+	IRQAffinityModeNonReserved = "non-reserved"
+	// IRQAffinityModeReservedOnly means IRQ must bind to reserved CPUs only;
+	// all non-reserved CPUs (and pinned-forbidden CPUs) are forbidden.
+	IRQAffinityModeReservedOnly = "reserved-only"
 )
 
 var (

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner.go
@@ -153,19 +153,40 @@ func (p *DynamicPolicy) getPinnedResourcePackageIRQForbiddenCPUSet() machine.CPU
 
 // GetIRQForbiddenCores retrieves the cpu set of cores that are forbidden for irq binding.
 // The forbidden cores include:
-// 1. Reserved CPUs (system reserved).
-// 2. CPUs pinned by specific resource packages (as defined by the configuration).
+//  1. Either the reserved CPUs (when IRQAffinityMode == "non-reserved")
+//     or all non-reserved CPUs (when IRQAffinityMode == "reserved-only").
+//  2. CPUs pinned by specific resource packages (as defined by the configuration).
+//  3. Optionally, kernel isolcpus (when ExcludeIsolCPUsFromIRQ is true).
 func (p *DynamicPolicy) GetIRQForbiddenCores() (machine.CPUSet, error) {
 	forbiddenCores := machine.NewCPUSet()
 
-	// get irq forbidden cores from cpu plugin checkpoint
-	forbiddenCores = forbiddenCores.Union(p.reservedCPUs)
+	// 1. compute base forbidden set according to IRQ affinity mode.
+	switch p.conf.IRQAffinityMode {
+	case irqutil.IRQAffinityModeReservedOnly:
+		// IRQ must bind to reserved cores only -> forbid all non-reserved CPUs.
+		allCPUs := p.machineInfo.CPUDetails.CPUs()
+		forbiddenCores = forbiddenCores.Union(allCPUs.Difference(p.reservedCPUs))
+	default:
+		// IRQAffinityModeNonReserved (default): IRQ binds to non-reserved CPUs.
+		forbiddenCores = forbiddenCores.Union(p.reservedCPUs)
+	}
 
-	// get irq forbidden cores from pinned resource package
+	// 2. union forbidden cores from pinned resource packages.
 	irqForbiddenCPUSet := p.getPinnedResourcePackageIRQForbiddenCPUSet()
 	forbiddenCores = forbiddenCores.Union(irqForbiddenCPUSet)
 
-	general.Infof("get the irq forbidden cores %v", forbiddenCores)
+	// 3. optionally union kernel isolcpus.
+	// IsolatedCPUs lives on machineInfo.CPUTopology and is parsed once at init
+	// from /proc/cmdline. It is static across the agent lifetime (only changes
+	// on reboot), so we don't re-parse it at runtime.
+	if p.conf.ExcludeIsolCPUsFromIRQ {
+		if isol := p.machineInfo.IsolatedCPUs; !isol.IsEmpty() {
+			forbiddenCores = forbiddenCores.Union(isol)
+		}
+	}
+
+	general.Infof("get the irq forbidden cores: %v, isolated cpu cores: %v (mode=%s, excludeIsolcpus=%v)",
+		forbiddenCores, p.machineInfo.IsolatedCPUs, p.conf.IRQAffinityMode, p.conf.ExcludeIsolCPUsFromIRQ)
 	return forbiddenCores, nil
 }
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
@@ -265,98 +265,149 @@ func TestDynamicPolicy_ListContainers(t *testing.T) {
 func TestDynamicPolicy_GetIRQForbiddenCores(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "checkpoint-TestGetIRQForbiddenCores")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	// setupPolicy builds a fresh DynamicPolicy with reserved CPUs (0,1) and a
+	// pinned-forbidden resource package on NUMA 0 (CPUs 2,3). pkg2 (allowed) on
+	// NUMA 1 (CPUs 4,5) is filtered out by the selector.
+	setupPolicy := func(t *testing.T, name string) *DynamicPolicy {
+		t.Helper()
+		tmpDir, err := ioutil.TempDir("", "checkpoint-TestGetIRQForbiddenCores-"+name)
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(tmpDir) })
 
-	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 2)
-	require.NoError(t, err)
+		cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 2)
+		require.NoError(t, err)
 
-	policy, err := getTestDynamicPolicyWithoutInitialization(cpuTopology, tmpDir)
-	require.NoError(t, err)
+		policy, err := getTestDynamicPolicyWithoutInitialization(cpuTopology, tmpDir)
+		require.NoError(t, err)
 
-	// Mock reserved CPUs
-	policy.reservedCPUs = machine.NewCPUSet(0, 1)
+		policy.reservedCPUs = machine.NewCPUSet(0, 1)
 
-	// Prepare resource packages in NPD
-	npdFetcher := &npd.DummyNPDFetcher{
-		NPD: &nodev1alpha1.NodeProfileDescriptor{
-			Status: nodev1alpha1.NodeProfileDescriptorStatus{
-				NodeMetrics: []nodev1alpha1.ScopedNodeMetrics{
-					{
-						Scope: "resource-package",
-						Metrics: []nodev1alpha1.MetricValue{
-							{
-								MetricName: string(v1.ResourceCPU),
-								MetricLabels: map[string]string{
-									"package-name":  "pkg1",
-									"numa-id":       "0",
-									"pinned-cpuset": "true",
-									"type":          "forbidden",
+		npdFetcher := &npd.DummyNPDFetcher{
+			NPD: &nodev1alpha1.NodeProfileDescriptor{
+				Status: nodev1alpha1.NodeProfileDescriptorStatus{
+					NodeMetrics: []nodev1alpha1.ScopedNodeMetrics{
+						{
+							Scope: "resource-package",
+							Metrics: []nodev1alpha1.MetricValue{
+								{
+									MetricName: string(v1.ResourceCPU),
+									MetricLabels: map[string]string{
+										"package-name":  "pkg1",
+										"numa-id":       "0",
+										"pinned-cpuset": "true",
+										"type":          "forbidden",
+									},
+									Value:      *resource.NewQuantity(2, resource.DecimalSI),
+									Aggregator: func() *nodev1alpha1.Aggregator { a := nodev1alpha1.AggregatorMin; return &a }(),
 								},
-								Value:      *resource.NewQuantity(2, resource.DecimalSI),
-								Aggregator: func() *nodev1alpha1.Aggregator { a := nodev1alpha1.AggregatorMin; return &a }(),
-							},
-							{
-								MetricName: string(v1.ResourceCPU),
-								MetricLabels: map[string]string{
-									"package-name":  "pkg2",
-									"numa-id":       "1",
-									"pinned-cpuset": "true",
-									"type":          "allowed",
+								{
+									MetricName: string(v1.ResourceCPU),
+									MetricLabels: map[string]string{
+										"package-name":  "pkg2",
+										"numa-id":       "1",
+										"pinned-cpuset": "true",
+										"type":          "allowed",
+									},
+									Value:      *resource.NewQuantity(2, resource.DecimalSI),
+									Aggregator: func() *nodev1alpha1.Aggregator { a := nodev1alpha1.AggregatorMin; return &a }(),
 								},
-								Value:      *resource.NewQuantity(2, resource.DecimalSI),
-								Aggregator: func() *nodev1alpha1.Aggregator { a := nodev1alpha1.AggregatorMin; return &a }(),
 							},
 						},
 					},
 				},
 			},
+		}
+		policy.resourcePackageManager = resourcepackage.NewCachedResourcePackageManager(resourcepackage.NewResourcePackageManager(npdFetcher))
+		stopCh := make(chan struct{})
+		t.Cleanup(func() { close(stopCh) })
+		go policy.resourcePackageManager.Run(stopCh)
+		time.Sleep(100 * time.Millisecond)
+
+		machineState := policy.state.GetMachineState()
+		machineState[0].ResourcePackageStates = map[string]*state.ResourcePackageState{
+			"pkg1": {
+				PinnedCPUSet: machine.NewCPUSet(2, 3),
+				Attributes:   map[string]string{"type": "forbidden"},
+			},
+		}
+		machineState[1].ResourcePackageStates = map[string]*state.ResourcePackageState{
+			"pkg2": {
+				PinnedCPUSet: machine.NewCPUSet(4, 5),
+				Attributes:   map[string]string{"type": "other"},
+			},
+		}
+		policy.state.SetMachineState(machineState, false)
+
+		selector, err := labels.Parse("type=forbidden")
+		require.NoError(t, err)
+		policy.conf.IRQForbiddenPinnedResourcePackageAttributeSelector = selector
+
+		return policy
+	}
+
+	// All non-reserved CPUs in the dummy 16-CPU topology are 2..15 (reserved is 0,1).
+	allNonReserved := machine.NewCPUSet(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+
+	tcs := []struct {
+		name              string
+		mode              string
+		excludeIsolCPUs   bool
+		isolatedCPUs      machine.CPUSet
+		expectedForbidden machine.CPUSet
+	}{
+		{
+			name:              "non-reserved mode, isolcpus disabled",
+			mode:              irqutil.IRQAffinityModeNonReserved,
+			excludeIsolCPUs:   false,
+			isolatedCPUs:      machine.NewCPUSet(),
+			expectedForbidden: machine.NewCPUSet(0, 1, 2, 3),
+		},
+		{
+			name:              "reserved-only mode, isolcpus disabled",
+			mode:              irqutil.IRQAffinityModeReservedOnly,
+			excludeIsolCPUs:   false,
+			isolatedCPUs:      machine.NewCPUSet(),
+			expectedForbidden: allNonReserved.Union(machine.NewCPUSet(2, 3)),
+		},
+		{
+			name:              "exclude isolcpus enabled but IsolatedCPUs empty",
+			mode:              irqutil.IRQAffinityModeNonReserved,
+			excludeIsolCPUs:   true,
+			isolatedCPUs:      machine.NewCPUSet(),
+			expectedForbidden: machine.NewCPUSet(0, 1, 2, 3),
+		},
+		{
+			name:              "non-reserved mode + isolcpus 6,7",
+			mode:              irqutil.IRQAffinityModeNonReserved,
+			excludeIsolCPUs:   true,
+			isolatedCPUs:      machine.NewCPUSet(6, 7),
+			expectedForbidden: machine.NewCPUSet(0, 1, 2, 3, 6, 7),
+		},
+		{
+			name:              "reserved-only mode + isolcpus 6,7",
+			mode:              irqutil.IRQAffinityModeReservedOnly,
+			excludeIsolCPUs:   true,
+			isolatedCPUs:      machine.NewCPUSet(6, 7),
+			expectedForbidden: allNonReserved.Union(machine.NewCPUSet(2, 3)),
 		},
 	}
-	policy.resourcePackageManager = resourcepackage.NewCachedResourcePackageManager(resourcepackage.NewResourcePackageManager(npdFetcher))
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	// Run cached manager to populate cache
-	go policy.resourcePackageManager.Run(stopCh)
-	time.Sleep(100 * time.Millisecond)
 
-	// Mock machine state to include pinned CPUs for packages
-	// Note: In a real scenario, this state is populated by policy logic.
-	// Here we need to manually inject it into the state if we want GetAggResourcePackagePinnedCPUSet to find it.
-	// However, GetAggResourcePackagePinnedCPUSet reads from policy.state.GetMachineState().
-	// We need to update the machine state with ResourcePackagePinnedCPUSet.
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Assuming NUMA 0 has pkg1 pinned to CPUs 2, 3
-	// Assuming NUMA 1 has pkg2 pinned to CPUs 4, 5
-	machineState := policy.state.GetMachineState()
-	machineState[0].ResourcePackageStates = map[string]*state.ResourcePackageState{
-		"pkg1": {
-			PinnedCPUSet: machine.NewCPUSet(2, 3),
-			Attributes:   map[string]string{"type": "forbidden"},
-		},
+			policy := setupPolicy(t, tc.name)
+			policy.conf.IRQAffinityMode = tc.mode
+			policy.conf.ExcludeIsolCPUsFromIRQ = tc.excludeIsolCPUs
+			policy.machineInfo.IsolatedCPUs = tc.isolatedCPUs
+
+			forbiddenCores, err := policy.GetIRQForbiddenCores()
+			require.NoError(t, err)
+			assert.True(t, tc.expectedForbidden.Equals(forbiddenCores),
+				"case %q: expected %v, got %v", tc.name, tc.expectedForbidden, forbiddenCores)
+		})
 	}
-	machineState[1].ResourcePackageStates = map[string]*state.ResourcePackageState{
-		"pkg2": {
-			PinnedCPUSet: machine.NewCPUSet(4, 5),
-			Attributes:   map[string]string{"type": "other"},
-		},
-	}
-	policy.state.SetMachineState(machineState, false)
-
-	// Configure attribute selector
-	selector, err := labels.Parse("type=forbidden")
-	require.NoError(t, err)
-	policy.conf.IRQForbiddenPinnedResourcePackageAttributeSelector = selector
-
-	// Run the test
-	forbiddenCores, err := policy.GetIRQForbiddenCores()
-	require.NoError(t, err)
-
-	// Expected: Reserved CPUs (0, 1) + Pinned CPUs for pkg1 (2, 3) = (0, 1, 2, 3)
-	// pkg2 is excluded because type=allowed != type=forbidden
-	expected := machine.NewCPUSet(0, 1, 2, 3)
-	assert.True(t, expected.Equals(forbiddenCores), "expected %v, got %v", expected, forbiddenCores)
 }
 
 func TestDynamicPolicy_GetExclusiveIRQCPUSet(t *testing.T) {

--- a/pkg/config/agent/qrm/cpu_plugin.go
+++ b/pkg/config/agent/qrm/cpu_plugin.go
@@ -76,6 +76,17 @@ type CPUDynamicPolicyConfig struct {
 	// IRQForbiddenPinnedResourcePackageAttributeSelector is the selector to filter pinned resource packages that are
 	// forbidden for irq binding.
 	IRQForbiddenPinnedResourcePackageAttributeSelector labels.Selector
+	// IRQAffinityMode controls where IRQ can be bound.
+	// Valid values:
+	//   - "non-reserved" (default): IRQ is bound to non-reserved CPUs;
+	//     forbidden = reservedCPUs ∪ pinnedForbiddenCPUs.
+	//   - "reserved-only": IRQ is bound to reserved CPUs only;
+	//     forbidden = (allCPUs \ reservedCPUs) ∪ pinnedForbiddenCPUs.
+	IRQAffinityMode string
+	// ExcludeIsolCPUsFromIRQ indicates whether to exclude kernel isolcpus
+	// (parsed from /proc/cmdline) from IRQ-eligible cores. When true,
+	// isolcpus are added to the forbidden set.
+	ExcludeIsolCPUsFromIRQ bool
 
 	*hintoptimizer.HintOptimizerConfiguration
 	*irqtuner.IRQTunerConfiguration

--- a/pkg/util/machine/cmdline.go
+++ b/pkg/util/machine/cmdline.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+const (
+	procCmdlinePath = "/proc/cmdline"
+	isolCPUsKeyword = "isolcpus="
+)
+
+// isolCPUsKnownFlags is the set of well-known non-cpulist flag tokens that may
+// appear at the head of the isolcpus= value (e.g. "isolcpus=nohz,domain,managed_irq,1-3").
+// They are filtered out before parsing the remaining cpu list.
+var isolCPUsKnownFlags = map[string]struct{}{
+	"nohz":        {},
+	"domain":      {},
+	"managed_irq": {},
+}
+
+// GetIsolCPUSet parses isolcpus= from /proc/cmdline and returns a CPUSet.
+// Supports forms like "isolcpus=1-3,5" or "isolcpus=nohz,domain,managed_irq,1-3".
+// Returns an empty CPUSet when isolcpus= is not configured.
+//
+// On non-Linux platforms /proc/cmdline does not exist, so reading it fails and
+// the caller (which only invokes this on Linux init paths) treats the error
+// as a degraded empty set.
+func GetIsolCPUSet() (CPUSet, error) {
+	return parseIsolCPUSetFromCmdlineFile(procCmdlinePath)
+}
+
+// parseIsolCPUSetFromCmdlineFile is the testable form of GetIsolCPUSet that
+// reads from a caller-supplied cmdline file path. Keeping the IO boundary as
+// an explicit parameter avoids global mutable state, so unit tests can run
+// safely in parallel.
+func parseIsolCPUSetFromCmdlineFile(path string) (CPUSet, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return NewCPUSet(), fmt.Errorf("read %s failed: %v", path, err)
+	}
+
+	general.Infof("kernel cmdline: %s", string(raw))
+
+	for _, token := range strings.Fields(string(raw)) {
+		if !strings.HasPrefix(token, isolCPUsKeyword) {
+			continue
+		}
+
+		value := strings.TrimPrefix(token, isolCPUsKeyword)
+		if value == "" {
+			return NewCPUSet(), nil
+		}
+
+		segments := strings.Split(value, ",")
+		cpuListParts := make([]string, 0, len(segments))
+		for _, seg := range segments {
+			if seg == "" {
+				continue
+			}
+			if _, ok := isolCPUsKnownFlags[seg]; ok {
+				continue
+			}
+			// ignore "key=val" sub-options if any (defensive)
+			if strings.Contains(seg, "=") {
+				continue
+			}
+			cpuListParts = append(cpuListParts, seg)
+		}
+
+		if len(cpuListParts) == 0 {
+			return NewCPUSet(), nil
+		}
+
+		cs, err := Parse(strings.Join(cpuListParts, ","))
+		if err != nil {
+			return NewCPUSet(), fmt.Errorf("parse isolcpus value %q failed: %v", value, err)
+		}
+		return cs, nil
+	}
+
+	return NewCPUSet(), nil
+}

--- a/pkg/util/machine/cmdline_test.go
+++ b/pkg/util/machine/cmdline_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIsolCPUSetFromCmdlineFile(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct {
+		name        string
+		cmdline     string
+		expectedSet CPUSet
+		expectErr   bool
+	}{
+		{
+			name:        "no isolcpus configured",
+			cmdline:     "BOOT_IMAGE=/boot/vmlinuz root=/dev/sda1 ro quiet",
+			expectedSet: NewCPUSet(),
+		},
+		{
+			name:        "empty isolcpus value",
+			cmdline:     "BOOT_IMAGE=/boot/vmlinuz isolcpus= ro",
+			expectedSet: NewCPUSet(),
+		},
+		{
+			name:        "plain cpu list",
+			cmdline:     "BOOT_IMAGE=/boot/vmlinuz isolcpus=1-3,5 ro",
+			expectedSet: NewCPUSet(1, 2, 3, 5),
+		},
+		{
+			name:        "with known flags before cpu list",
+			cmdline:     "BOOT_IMAGE=/boot/vmlinuz isolcpus=nohz,domain,managed_irq,2-4,7 ro",
+			expectedSet: NewCPUSet(2, 3, 4, 7),
+		},
+		{
+			name:        "only flags, no cpu list",
+			cmdline:     "isolcpus=nohz,domain quiet",
+			expectedSet: NewCPUSet(),
+		},
+		{
+			name:        "ignore key=val sub-options",
+			cmdline:     "isolcpus=managed_irq,key=val,1-2 ro",
+			expectedSet: NewCPUSet(1, 2),
+		},
+		{
+			name:      "invalid cpu list value returns error",
+			cmdline:   "isolcpus=abc ro",
+			expectErr: true,
+		},
+		{
+			name:        "single cpu",
+			cmdline:     "isolcpus=8",
+			expectedSet: NewCPUSet(8),
+		},
+		{
+			name:        "consecutive whitespace separators",
+			cmdline:     "BOOT_IMAGE=/boot/vmlinuz   isolcpus=1,3   ro",
+			expectedSet: NewCPUSet(1, 3),
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			fakePath := filepath.Join(dir, "cmdline")
+			require.NoError(t, os.WriteFile(fakePath, []byte(tc.cmdline+"\n"), 0o644))
+
+			got, err := parseIsolCPUSetFromCmdlineFile(fakePath)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, tc.expectedSet.Equals(got),
+				"case %q: expected %v, got %v", tc.name, tc.expectedSet, got)
+		})
+	}
+}
+
+func TestParseIsolCPUSetFromCmdlineFile_ReadFileError(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseIsolCPUSetFromCmdlineFile(filepath.Join(t.TempDir(), "non-existent-cmdline"))
+	assert.Error(t, err)
+	assert.True(t, got.IsEmpty())
+}

--- a/pkg/util/machine/topology.go
+++ b/pkg/util/machine/topology.go
@@ -67,6 +67,12 @@ type CPUTopology struct {
 	NUMAToCPUs           NUMANodeInfo
 	CPUDetails           CPUDetails
 	CPUInfo              *CPUInfo
+
+	// IsolatedCPUs is parsed once from kernel boot parameter `isolcpus=`
+	// in /proc/cmdline. It is static across the agent lifetime because
+	// kernel cmdline can only be changed by reboot. Empty when isolcpus=
+	// is not configured.
+	IsolatedCPUs CPUSet
 }
 
 type MemoryDetails map[int]uint64
@@ -586,6 +592,15 @@ func Discover(machineInfo *info.MachineInfo) (*CPUTopology, *MemoryTopology, err
 		numaToCPUs[id] = cpuDetails.CPUsInNUMANodes(id)
 	}
 
+	// isolcpus comes from /proc/cmdline and only changes on reboot, so we read
+	// it once at init time. Failure here is non-fatal: we degrade to an empty
+	// set so the agent can still start on hosts without isolcpus configured.
+	isolatedCPUs, err := GetIsolCPUSet()
+	if err != nil {
+		general.Warningf("failed to parse isolcpus from kernel cmdline, fallback to empty set: %v", err)
+		isolatedCPUs = NewCPUSet()
+	}
+
 	return &CPUTopology{
 		NumCPUs:              machineInfo.NumCores,
 		NumSockets:           machineInfo.NumSockets,
@@ -595,6 +610,7 @@ func Discover(machineInfo *info.MachineInfo) (*CPUTopology, *MemoryTopology, err
 		NUMAToCPUs:           numaToCPUs,
 		CPUDetails:           cpuDetails,
 		CPUInfo:              cpuInfo,
+		IsolatedCPUs:         isolatedCPUs,
 	}, memoryTopology, nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->
Features
#### What this PR does / why we need it:
Add support for configuring IRQ affinity mode to restrict IRQ binding to either reserved or non-reserved CPUs, and allow excluding kernel isolated CPUs from IRQ eligible cores.

Changes include:
- Add IsolatedCPUs field to CPUTopology to parse and store isolcpus from kernel cmdline
- Implement isolcpus parsing for Linux platforms with proper flag filtering
- Add IRQ affinity mode configuration options to CPU QRM plugin config and CLI flags
- Update IRQ forbidden core calculation to respect affinity mode and isolated CPUs
- Refactor and expand IRQ tuner test cases to cover all new scenarios
#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
