### PR TITLE
feat(util/file): add multiple file event watcher aggregation utility

### DIFF
--- a/pkg/util/general/file.go
+++ b/pkg/util/general/file.go
@@ -31,6 +31,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -107,6 +108,60 @@ func RegisterFileEventWatcher(stop <-chan struct{}, fileWatcherInfo FileWatcherI
 	}()
 
 	return watcherCh, nil
+}
+
+// RegisterMultipleFileEventWatchers registers a watcher for each FileWatcherInfo
+// by delegating to RegisterFileEventWatcher, and merges the per-watcher signals
+// into a single returned channel. The returned channel receives a signal
+// whenever any of the underlying watchers fires, and is closed once all
+// underlying watchers have stopped (typically after stop is closed).
+func RegisterMultipleFileEventWatchers(stop <-chan struct{}, fileWatcherInfos ...FileWatcherInfo) (<-chan struct{}, error) {
+	aggregatedCh := make(chan struct{})
+
+	// register each underlying watcher up-front so any setup error is returned synchronously.
+	subChs := make([]<-chan struct{}, 0, len(fileWatcherInfos))
+	for _, info := range fileWatcherInfos {
+		ch, err := RegisterFileEventWatcher(stop, info)
+		if err != nil {
+			return nil, fmt.Errorf("register file event watcher for %v failed: %w", info, err)
+		}
+		subChs = append(subChs, ch)
+	}
+
+	// one forwarder goroutine per sub-channel fans signals into aggregatedCh.
+	var wg sync.WaitGroup
+	for _, ch := range subChs {
+		wg.Add(1)
+		go func(c <-chan struct{}) {
+			defer wg.Done()
+			for {
+				select {
+				case _, ok := <-c:
+					if !ok {
+						return
+					}
+					// inner <-stop is required: aggregatedCh is unbuffered, so
+					// without it a slow/absent consumer would deadlock the forwarder
+					// after stop is closed.
+					select {
+					case aggregatedCh <- struct{}{}:
+					case <-stop:
+						return
+					}
+				case <-stop:
+					return
+				}
+			}
+		}(ch)
+	}
+
+	// close aggregatedCh only after every forwarder has exited so callers can range over it safely.
+	go func() {
+		wg.Wait()
+		close(aggregatedCh)
+	}()
+
+	return aggregatedCh, nil
 }
 
 // SubDirWatcherInfo describes a directory tree (root + first-level children) to watch.

--- a/pkg/util/general/file_test.go
+++ b/pkg/util/general/file_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -812,6 +813,103 @@ func TestRegisterSubDirEventWatcher(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		select {
 		case _, ok := <-syncCh:
+			return !ok
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestRegisterFileEventWatcher(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	stop := make(chan struct{})
+	defer close(stop)
+
+	watcherCh, err := RegisterFileEventWatcher(stop, FileWatcherInfo{
+		Path: []string{dir},
+		Op:   fsnotify.Create | fsnotify.Write,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, watcherCh)
+
+	waitNotify := func(ch <-chan struct{}, timeout time.Duration) bool {
+		select {
+		case _, ok := <-ch:
+			return ok
+		case <-time.After(timeout):
+			return false
+		}
+	}
+
+	// Create a file in the watched directory -> expect notification.
+	created := filepath.Join(dir, "created.txt")
+	time.Sleep(200 * time.Millisecond) // allow watcher goroutine to add the path
+	assert.NoError(t, os.WriteFile(created, []byte("hello"), 0o644))
+	assert.True(t, waitNotify(watcherCh, 2*time.Second), "expect notification on file create")
+
+	// Filename filter: only notifications matching Filename should pass.
+	dir2 := t.TempDir()
+	stop2 := make(chan struct{})
+	defer close(stop2)
+
+	watcherCh2, err := RegisterFileEventWatcher(stop2, FileWatcherInfo{
+		Filename: "target.txt",
+		Path:     []string{dir2},
+		Op:       fsnotify.Create | fsnotify.Write,
+	})
+	assert.NoError(t, err)
+	time.Sleep(200 * time.Millisecond) // allow watcher goroutine to add the path
+
+	// Non-matching filename should be filtered out.
+	assert.NoError(t, os.WriteFile(filepath.Join(dir2, "other.txt"), []byte("x"), 0o644))
+	assert.False(t, waitNotify(watcherCh2, 300*time.Millisecond), "non-matching filename should be filtered")
+
+	// Matching filename should produce a notification.
+	assert.NoError(t, os.WriteFile(filepath.Join(dir2, "target.txt"), []byte("x"), 0o644))
+	assert.True(t, waitNotify(watcherCh2, 2*time.Second), "matching filename should notify")
+}
+
+func TestRegisterMultipleFileEventWatchers(t *testing.T) {
+	t.Parallel()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	stop := make(chan struct{})
+
+	aggregatedCh, err := RegisterMultipleFileEventWatchers(
+		stop,
+		FileWatcherInfo{Path: []string{dirA}, Op: fsnotify.Create | fsnotify.Write},
+		FileWatcherInfo{Path: []string{dirB}, Op: fsnotify.Create | fsnotify.Write},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, aggregatedCh)
+
+	waitNotify := func(timeout time.Duration) bool {
+		select {
+		case _, ok := <-aggregatedCh:
+			return ok
+		case <-time.After(timeout):
+			return false
+		}
+	}
+
+	time.Sleep(200 * time.Millisecond) // allow watcher goroutines to add their paths
+
+	// Event in the first underlying watcher's directory -> aggregated signal.
+	assert.NoError(t, os.WriteFile(filepath.Join(dirA, "a.txt"), []byte("x"), 0o644))
+	assert.True(t, waitNotify(2*time.Second), "expect signal from first watcher")
+
+	// Event in the second underlying watcher's directory -> aggregated signal.
+	assert.NoError(t, os.WriteFile(filepath.Join(dirB, "b.txt"), []byte("x"), 0o644))
+	assert.True(t, waitNotify(2*time.Second), "expect signal from second watcher")
+
+	// Closing stop should close the aggregated channel.
+	close(stop)
+	assert.Eventually(t, func() bool {
+		select {
+		case _, ok := <-aggregatedCh:
 			return !ok
 		default:
 			return false


### PR DESCRIPTION
Add RegisterMultipleFileEventWatchers function that aggregates multiple file watcher channels into one, plus corresponding unit tests for both single and multiple watcher cases.

The use case is for depending on the multiple files with different paths.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
