### PR TITLE
feat(memory): support SetMemTHPSHM

### DIFF
--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
@@ -177,7 +177,7 @@ func TestSetMemCompact(t *testing.T) {
 func TestSetMemTHP(t *testing.T) {
 	t.Parallel()
 
-	// This test mutates package-level vars (thpEnabledPath), so serialize it.
+	// This test mutates package-level vars (thpEnabledPath/thpShmemEnabledPath), so serialize it.
 	setMemTHPTestMu.Lock()
 	defer setMemTHPTestMu.Unlock()
 
@@ -214,11 +214,18 @@ func TestSetMemTHP(t *testing.T) {
 	}, nil, &dynamicconfig.DynamicAgentConfiguration{}, nil, nil)
 
 	// THPDefaultConfig=never: fast-path to disable THP directly.
-	oldPath := thpEnabledPath
+	oldEnabledPath := thpEnabledPath
+	oldShmemPath := thpShmemEnabledPath
 	f := createTempFile(t, "always [madvise] never\n")
+	shmemFile := createTempFile(t, "always within_size [advise] never deny force\n")
 	defer os.Remove(f)
-	defer func() { thpEnabledPath = oldPath }()
+	defer os.Remove(shmemFile)
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		thpShmemEnabledPath = oldShmemPath
+	}()
 	thpEnabledPath = f
+	thpShmemEnabledPath = shmemFile
 
 	SetMemTHP(&coreconfig.Configuration{
 		AgentConfiguration: &agent.AgentConfiguration{
@@ -238,6 +245,9 @@ func TestSetMemTHP(t *testing.T) {
 	b, rerr := os.ReadFile(f)
 	assert.NoError(t, rerr)
 	assert.Equal(t, "never\n", string(b))
+	b, rerr = os.ReadFile(shmemFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "deny\n", string(b))
 
 	res := general.GetRegisterReadinessCheckResult()
 	check, ok := res[general.HealthzCheckName(memconsts.SetMemTHP)]
@@ -283,12 +293,19 @@ func TestDoMemTHPDisable(t *testing.T) {
 	setMemTHPTestMu.Lock()
 	defer setMemTHPTestMu.Unlock()
 
-	oldPath := thpEnabledPath
-	defer func() { thpEnabledPath = oldPath }()
+	oldEnabledPath := thpEnabledPath
+	oldShmemPath := thpShmemEnabledPath
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		thpShmemEnabledPath = oldShmemPath
+	}()
 
 	thpFile := createTempFile(t, "always [madvise] never\n")
+	shmemFile := createTempFile(t, "always within_size [advise] never deny force\n")
 	defer os.Remove(thpFile)
+	defer os.Remove(shmemFile)
 	thpEnabledPath = thpFile
+	thpShmemEnabledPath = shmemFile
 
 	metaServer, err := makeMetaServer()
 	assert.NoError(t, err)
@@ -303,6 +320,9 @@ func TestDoMemTHPDisable(t *testing.T) {
 	b, rerr := os.ReadFile(thpFile)
 	assert.NoError(t, rerr)
 	assert.Equal(t, "never\n", string(b))
+	b, rerr = os.ReadFile(shmemFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "deny\n", string(b))
 }
 
 func TestDoMemTHPEnable(t *testing.T) {
@@ -311,12 +331,19 @@ func TestDoMemTHPEnable(t *testing.T) {
 	setMemTHPTestMu.Lock()
 	defer setMemTHPTestMu.Unlock()
 
-	oldPath := thpEnabledPath
-	defer func() { thpEnabledPath = oldPath }()
+	oldEnabledPath := thpEnabledPath
+	oldShmemPath := thpShmemEnabledPath
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		thpShmemEnabledPath = oldShmemPath
+	}()
 
 	thpFile := createTempFile(t, "always madvise [never]\n")
+	shmemFile := createTempFile(t, "always within_size advise [never] deny force\n")
 	defer os.Remove(thpFile)
+	defer os.Remove(shmemFile)
 	thpEnabledPath = thpFile
+	thpShmemEnabledPath = shmemFile
 
 	metaServer, err := makeMetaServer()
 	assert.NoError(t, err)
@@ -331,6 +358,9 @@ func TestDoMemTHPEnable(t *testing.T) {
 	b, rerr := os.ReadFile(thpFile)
 	assert.NoError(t, rerr)
 	assert.Equal(t, "madvise\n", string(b))
+	b, rerr = os.ReadFile(shmemFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "advise\n", string(b))
 }
 
 func TestDoMemTHPEnableSkippedDueToMissingOrders(t *testing.T) {
@@ -339,12 +369,19 @@ func TestDoMemTHPEnableSkippedDueToMissingOrders(t *testing.T) {
 	setMemTHPTestMu.Lock()
 	defer setMemTHPTestMu.Unlock()
 
-	oldPath := thpEnabledPath
-	defer func() { thpEnabledPath = oldPath }()
+	oldEnabledPath := thpEnabledPath
+	oldShmemPath := thpShmemEnabledPath
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		thpShmemEnabledPath = oldShmemPath
+	}()
 
 	thpFile := createTempFile(t, "never\n")
+	shmemFile := createTempFile(t, "never\n")
 	defer os.Remove(thpFile)
+	defer os.Remove(shmemFile)
 	thpEnabledPath = thpFile
+	thpShmemEnabledPath = shmemFile
 
 	metaServer, err := makeMetaServer()
 	assert.NoError(t, err)
@@ -357,6 +394,9 @@ func TestDoMemTHPEnableSkippedDueToMissingOrders(t *testing.T) {
 	assert.NoError(t, err)
 
 	b, rerr := os.ReadFile(thpFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "never\n", string(b))
+	b, rerr = os.ReadFile(shmemFile)
 	assert.NoError(t, rerr)
 	assert.Equal(t, "never\n", string(b))
 }
@@ -412,6 +452,57 @@ func TestEnableTHPMadviseAtPath(t *testing.T) {
 	b, rerr = os.ReadFile(f2)
 	assert.NoError(t, rerr)
 	assert.Equal(t, "madvise\n", string(b))
+}
+
+func TestEnableTHPAdviseAtPath(t *testing.T) {
+	t.Parallel()
+
+	// already advise
+	f1 := createTempFile(t, "always within_size [advise] never deny force\n")
+	defer os.Remove(f1)
+	err := setTHPModeAtPath(f1, "advise")
+	assert.NoError(t, err)
+	b, rerr := os.ReadFile(f1)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "always within_size [advise] never deny force\n", string(b))
+
+	// should set advise
+	f2 := createTempFile(t, "always within_size advise [never] deny force\n")
+	defer os.Remove(f2)
+	err = setTHPModeAtPath(f2, "advise")
+	assert.NoError(t, err)
+	b, rerr = os.ReadFile(f2)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "advise\n", string(b))
+}
+
+func TestDisableTHPDenyAtPath(t *testing.T) {
+	t.Parallel()
+
+	// already deny
+	f1 := createTempFile(t, "always within_size advise never [deny] force\n")
+	defer os.Remove(f1)
+	err := setTHPModeAtPath(f1, "deny")
+	assert.NoError(t, err)
+	b, rerr := os.ReadFile(f1)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "always within_size advise never [deny] force\n", string(b))
+
+	// should set deny
+	f2 := createTempFile(t, "always within_size [advise] never deny force\n")
+	defer os.Remove(f2)
+	err = setTHPModeAtPath(f2, "deny")
+	assert.NoError(t, err)
+	b, rerr = os.ReadFile(f2)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "deny\n", string(b))
+}
+
+func TestSetTHPModeAtPathIfExistsMissing(t *testing.T) {
+	t.Parallel()
+
+	err := setTHPModeAtPathIfExists("/tmp/path/does/not/exist/shmem_enabled", "advise")
+	assert.NoError(t, err)
 }
 
 func TestSetTHPModeAtPathInvalid(t *testing.T) {

--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
@@ -20,6 +20,7 @@ limitations under the License.
 package fragmem
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -218,7 +219,7 @@ func setTHPMode(enabledMode, shmemMode string) error {
 
 func setTHPModeAtPathIfExists(path, mode string) error {
 	err := setTHPModeAtPath(path, mode)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && errors.Is(err, os.ErrNotExist) {
 		general.Infof("THP path %s not found, skip applying mode %q", path, mode)
 		return nil
 	}

--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
@@ -21,6 +21,7 @@ package fragmem
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
@@ -37,6 +38,8 @@ import (
 )
 
 const (
+	thpModeAdvise  = "advise"
+	thpModeDeny    = "deny"
 	thpModeMadvise = "madvise"
 	thpModeAlways  = "always"
 	thpModeNever   = "never"
@@ -50,6 +53,10 @@ const (
 // thpEnabledPath is the sysfs path we write to when tuning THP.
 // It is a var (not const) so tests can override it with a temp file.
 var thpEnabledPath = procfsm.TransparentHugepageEnabledPath
+
+// thpShmemEnabledPath is the sysfs path for tmpfs/shmem THP mode.
+// It is a var (not const) so tests can override it with a temp file.
+var thpShmemEnabledPath = procfsm.TransparentHugepageShmemEnabledPath
 
 type thpDecision int
 
@@ -89,7 +96,7 @@ func SetMemTHP(conf *coreconfig.Configuration,
 	// If THPDefaultConfig is "never", fast-path to disable THP directly.
 	if mode == thpModeNever {
 		general.Infof("SetMemTHP: THPDefaultConfig=never, disable THP directly")
-		if err := setTHPModeAtPath(thpEnabledPath, thpModeNever); err != nil {
+		if err := setTHPMode(thpModeNever, thpModeDeny); err != nil {
 			errList = append(errList, err)
 		}
 		return
@@ -146,7 +153,7 @@ func doMemTHP(conf *coreconfig.Configuration, metaServer *metaserver.MetaServer,
 	switch decision {
 	case thpDecisionDisable:
 		general.Infof("THP disable triggered: maxHighOrderScore=%.1f numa=%d threshold=%.1f", maxScore, maxNumaID, threshold)
-		return setTHPModeAtPath(thpEnabledPath, thpModeNever)
+		return setTHPMode(thpModeNever, thpModeDeny)
 	case thpDecisionEnable:
 		// Be conservative: only try to recover when we have valid scores for all NUMA nodes.
 		// If metrics are missing on any NUMA node, keep current THP mode unchanged.
@@ -155,8 +162,8 @@ func doMemTHP(conf *coreconfig.Configuration, metaServer *metaserver.MetaServer,
 			if mode == "" {
 				mode = thpModeMadvise
 			}
-			general.Infof("THP enable triggered: maxHighOrderScore=%.1f enableThreshold=%.1f threshold=%.1f recoverTo=%s", maxScore, enableThreshold, threshold, mode)
-			return setTHPModeAtPath(thpEnabledPath, mode)
+			general.Infof("THP enable triggered: maxHighOrderScore=%.1f enableThreshold=%.1f threshold=%.1f recoverTo=%s shmemRecoverTo=%s", maxScore, enableThreshold, threshold, mode, thpModeAdvise)
+			return setTHPMode(mode, thpModeAdvise)
 		}
 		general.Infof("THP enable skipped due to missing metrics: maxHighOrderScore=%.1f enableThreshold=%.1f threshold=%.1f missingScore=%d", maxScore, enableThreshold, threshold, missingScore)
 		return nil
@@ -196,12 +203,34 @@ func decideTHPDecision(maxScore, threshold float64) thpDecision {
 	return thpDecisionNone
 }
 
+func setTHPMode(enabledMode, shmemMode string) error {
+	var errList []error
+
+	if err := setTHPModeAtPath(thpEnabledPath, enabledMode); err != nil {
+		errList = append(errList, err)
+	}
+	if err := setTHPModeAtPathIfExists(thpShmemEnabledPath, shmemMode); err != nil {
+		errList = append(errList, err)
+	}
+
+	return k8serrors.NewAggregate(errList)
+}
+
+func setTHPModeAtPathIfExists(path, mode string) error {
+	err := setTHPModeAtPath(path, mode)
+	if err != nil && os.IsNotExist(err) {
+		general.Infof("THP path %s not found, skip applying mode %q", path, mode)
+		return nil
+	}
+	return err
+}
+
 func setTHPModeAtPath(path, mode string) error {
 	normalizedMode := normalizeTHPMode(mode)
 	switch normalizedMode {
-	case thpModeMadvise, thpModeAlways, thpModeNever:
+	case thpModeAdvise, thpModeDeny, thpModeMadvise, thpModeAlways, thpModeNever:
 	default:
-		return fmt.Errorf("invalid THP mode %q, expected one of %q/%q/%q", normalizedMode, thpModeMadvise, thpModeAlways, thpModeNever)
+		return fmt.Errorf("invalid THP mode %q, expected one of %q/%q/%q/%q/%q", normalizedMode, thpModeAdvise, thpModeDeny, thpModeMadvise, thpModeAlways, thpModeNever)
 	}
 
 	content, err := procfsm.ReadFileNoStat(path)

--- a/pkg/util/procfs/manager/procfs_linux.go
+++ b/pkg/util/procfs/manager/procfs_linux.go
@@ -42,6 +42,8 @@ const (
 
 	// TransparentHugepageEnabledPath is a kernel sysfs interface to configure THP behavior.
 	TransparentHugepageEnabledPath = "/sys/kernel/mm/transparent_hugepage/enabled"
+	// TransparentHugepageShmemEnabledPath is a kernel sysfs interface to configure THP behavior for tmpfs/shmem.
+	TransparentHugepageShmemEnabledPath = "/sys/kernel/mm/transparent_hugepage/shmem_enabled"
 )
 
 type manager struct {


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:
We need to support thp.shm dynamically.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved Linux transparent huge page (THP) handling by configuring both standard memory and tmpfs/shmem THP settings when available.
  - Added support for additional THP mode strings and more precise mode updates.

- **Bug Fixes**
  - Now skips shmem THP configuration when the system doesn’t expose the setting, preventing failed THP operations.
  - Improved correctness of THP enable/disable behavior across supported modes.

- **Tests**
  - Expanded Linux THP coverage to validate updates at specific paths, including cases with pre-existing mode markers and missing-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->