### PR TITLE
fix(gpu): short-circuit when device request count is 0

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu.go
@@ -167,6 +167,11 @@ func (p *GPUDevicePlugin) GetAssociatedDeviceTopologyHints(
 			return nil, fmt.Errorf("no target device plugin found for target device %s", req.DeviceName)
 		}
 
+		// Short circuit with nil hints when the request is 0
+		if targetDeviceReq.DeviceRequest == 0 {
+			return p.buildAssociatedDeviceHintsResponse(req, nil), nil
+		}
+
 		filterOccupiedDevicesFromRequest(targetDeviceReq, p.GetState().GetMachineState())
 
 		gpuTopology, err := p.DeviceTopologyRegistry.GetDeviceTopology(targetDeviceReq.DeviceName)

--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
@@ -565,6 +565,75 @@ func TestGPUDevicePlugin_GetAssociatedDeviceTopologyHints(t *testing.T) {
 			},
 		},
 		{
+			name:          "device request is 0 short-circuits with nil hints",
+			podUID:        "test-uid",
+			containerName: "test-container",
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+					Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0", "test-gpu-1"},
+						DeviceRequest:    0,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints:   nil,
+			},
+		},
+		{
+			name:          "device request is 0 short-circuits before filtering occupied devices",
+			podUID:        "test-uid",
+			containerName: "test-container",
+			otherResourceAllocationMap: map[v1.ResourceName]state.AllocationMap{
+				consts.ResourceMilliGPU: {
+					"test-gpu-0": &state.AllocationState{
+						PodEntries: state.PodEntries{
+							"another-pod": state.ContainerEntries{
+								"another-container": &state.AllocationInfo{},
+							},
+						},
+					},
+				},
+			},
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+					Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0", "test-gpu-1"},
+						DeviceRequest:    0,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints:   nil,
+			},
+		},
+		{
 			name:          "device topology does not exist",
 			podUID:        "test-uid",
 			containerName: "test-container",


### PR DESCRIPTION
Add early return in GetAssociatedDeviceTopologyHints when DeviceRequest is 0, and add corresponding test cases to verify the behavior works correctly even when devices are already occupied.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
