### PR TITLE
feat: add eviction plugin

### DIFF
--- a/cmd/base/options/generic.go
+++ b/cmd/base/options/generic.go
@@ -25,6 +25,7 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog/v2"
 
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/config/generic"
 	"github.com/kubewharf/katalyst-core/pkg/util/process"
 )
@@ -42,6 +43,7 @@ type GenericOptions struct {
 	// todo actually those auth info should be stored in secrets or somewhere like that
 	GenericEndpoint             string
 	GenericEndpointHandleChains []string
+	PodSaleModeAnnotationKey    string
 
 	qosOptions     *QoSOptions
 	metricsOptions *MetricsOptions
@@ -57,6 +59,7 @@ func NewGenericOptions() *GenericOptions {
 		EnableHealthzCheck:        false,
 		TransformedInformerForPod: false,
 		GenericEndpoint:           ":9316",
+		PodSaleModeAnnotationKey:  apiconsts.PodAnnotationSaleModeKey,
 		qosOptions:                NewQoSOptions(),
 		metricsOptions:            NewMetricsOptions(),
 		logsOptions:               NewLogsOptions(),
@@ -92,6 +95,8 @@ func (o *GenericOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"the endpoint of generic purpose, which will use as prometheus, health check and profiling")
 	fs.StringSliceVar(&o.GenericEndpointHandleChains, "generic-handler-chains", o.GenericEndpointHandleChains,
 		"this flag defines the handler chains that should be enabled")
+	fs.StringVar(&o.PodSaleModeAnnotationKey, "pod-sale-mode-annotation-key", o.PodSaleModeAnnotationKey,
+		"The pod annotation key used to read pod sale mode")
 
 	o.qosOptions.AddFlags(fs)
 	o.metricsOptions.AddFlags(fs)
@@ -111,6 +116,7 @@ func (o *GenericOptions) ApplyTo(c *generic.GenericConfiguration) error {
 
 	c.GenericEndpoint = o.GenericEndpoint
 	c.GenericEndpointHandleChains = o.GenericEndpointHandleChains
+	c.PodSaleModeAnnotationKey = o.PodSaleModeAnnotationKey
 
 	errList := make([]error, 0, 1)
 	errList = append(errList, o.qosOptions.ApplyTo(c.QoSConfiguration))

--- a/cmd/base/options/generic_test.go
+++ b/cmd/base/options/generic_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+)
+
+func TestGenericOptionsApplyTo(t *testing.T) {
+	t.Parallel()
+
+	options := NewGenericOptions()
+	options.PodSaleModeAnnotationKey = "bytedance.quota.salemode"
+
+	conf := generic.NewGenericConfiguration()
+	err := options.ApplyTo(conf)
+
+	require.NoError(t, err)
+	require.Equal(t, "bytedance.quota.salemode", conf.PodSaleModeAnnotationKey)
+}
+
+func TestNewGenericOptionsUsesDefaultSaleModeAnnotationKey(t *testing.T) {
+	t.Parallel()
+
+	options := NewGenericOptions()
+
+	require.Equal(t, "katalyst.kubewharf.io/sale_mode", options.PodSaleModeAnnotationKey)
+}

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/cpu_pressure_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/cpu_pressure_eviction.go
@@ -25,30 +25,36 @@ import (
 )
 
 const (
-	defaultEnableLoadEviction              = false
-	defaultLoadUpperBoundRatio             = 1.8
-	defaultLoadLowerBoundRatio             = 1.0
-	defaultLoadThresholdMetPercentage      = 0.8
-	defaultLoadMetricSize                  = 10
-	defaultLoadEvictionCoolDownTime        = 300 * time.Second
-	defaultEnableSuppressionEviction       = false
-	defaultMaxSuppressionToleranceRate     = 5
-	defaultMinSuppressionToleranceDuration = 300 * time.Second
-	defaultGracePeriod                     = -1
+	defaultEnableLoadEviction                    = false
+	defaultLoadUpperBoundRatio                   = 1.8
+	defaultLoadLowerBoundRatio                   = 1.0
+	defaultLoadThresholdMetPercentage            = 0.8
+	defaultLoadMetricSize                        = 10
+	defaultLoadEvictionCoolDownTime              = 300 * time.Second
+	defaultEnableSuppressionEviction             = false
+	defaultMaxSuppressionToleranceRate           = 5
+	defaultMinSuppressionToleranceDuration       = 300 * time.Second
+	defaultEnablePIDOveruseEviction              = false
+	defaultPIDOveruseThreshold             int64 = 0
+	defaultGracePeriod                           = -1
 )
 
 // CPUPressureEvictionOptions is the options of cpu pressure eviction
 type CPUPressureEvictionOptions struct {
-	EnableLoadEviction                bool
-	LoadUpperBoundRatio               float64
-	LoadLowerBoundRatio               float64
-	LoadThresholdMetPercentage        float64
-	LoadMetricRingSize                int
-	LoadEvictionCoolDownTime          time.Duration
-	EnableSuppressionEviction         bool
-	MaxSuppressionToleranceRate       float64
-	MinSuppressionToleranceDuration   time.Duration
-	GracePeriod                       int64
+	EnableLoadEviction              bool
+	LoadUpperBoundRatio             float64
+	LoadLowerBoundRatio             float64
+	LoadThresholdMetPercentage      float64
+	LoadMetricRingSize              int
+	LoadEvictionCoolDownTime        time.Duration
+	EnableSuppressionEviction       bool
+	MaxSuppressionToleranceRate     float64
+	MinSuppressionToleranceDuration time.Duration
+	EnablePIDOveruseEviction        bool
+	PIDOveruseThreshold             int64
+	PIDOveruseGracePeriod           int64
+	GracePeriod                     int64
+
 	NumaCPUPressureEvictionOptions    NumaCPUPressureEvictionOptions
 	NumaSysCPUPressureEvictionOptions NumaSysCPUPressureEvictionOptions
 }
@@ -65,6 +71,9 @@ func NewCPUPressureEvictionOptions() *CPUPressureEvictionOptions {
 		EnableSuppressionEviction:         defaultEnableSuppressionEviction,
 		MaxSuppressionToleranceRate:       defaultMaxSuppressionToleranceRate,
 		MinSuppressionToleranceDuration:   defaultMinSuppressionToleranceDuration,
+		EnablePIDOveruseEviction:          defaultEnablePIDOveruseEviction,
+		PIDOveruseThreshold:               defaultPIDOveruseThreshold,
+		PIDOveruseGracePeriod:             defaultGracePeriod,
 		GracePeriod:                       defaultGracePeriod,
 		NumaCPUPressureEvictionOptions:    NewNumaCPUPressureEvictionOptions(),
 		NumaSysCPUPressureEvictionOptions: NewNumaSysCPUPressureEvictionOptions(),
@@ -97,6 +106,12 @@ func (o *CPUPressureEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"the maximum cpu suppression tolerance rate that can be set by the pod")
 	fs.DurationVar(&o.MinSuppressionToleranceDuration, "eviction-suppression-min-tolerance-duration", o.MinSuppressionToleranceDuration,
 		"the minimum duration a pod can tolerate cpu suppression")
+	fs.BoolVar(&o.EnablePIDOveruseEviction, "eviction-pid-overuse-enable", o.EnablePIDOveruseEviction,
+		"set true to enable pod-level pid overuse eviction")
+	fs.Int64Var(&o.PIDOveruseThreshold, "eviction-pid-overuse-threshold", o.PIDOveruseThreshold,
+		"the pod-level pid threshold aggregated from pod spec containers")
+	fs.Int64Var(&o.PIDOveruseGracePeriod, "eviction-pid-overuse-grace-period", o.PIDOveruseGracePeriod,
+		"the grace period of pod-level pid overuse eviction")
 	fs.Int64Var(&o.GracePeriod, "eviction-cpu-grace-period", o.GracePeriod,
 		"the ratio between the times metric value over the bound value and the metric ring size is greater than this percentage "+
 			", the eviction or node taint will be triggered")
@@ -114,6 +129,9 @@ func (o *CPUPressureEvictionOptions) ApplyTo(c *eviction.CPUPressureEvictionConf
 	c.EnableSuppressionEviction = o.EnableSuppressionEviction
 	c.MaxSuppressionToleranceRate = o.MaxSuppressionToleranceRate
 	c.MinSuppressionToleranceDuration = o.MinSuppressionToleranceDuration
+	c.EnablePIDOveruseEviction = o.EnablePIDOveruseEviction
+	c.PIDOveruseThreshold = o.PIDOveruseThreshold
+	c.PIDOveruseGracePeriod = o.PIDOveruseGracePeriod
 	c.GracePeriod = o.GracePeriod
 
 	if err := o.NumaCPUPressureEvictionOptions.ApplyTo(&c.NumaCPUPressureEvictionConfiguration); err != nil {

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/cpu_pressure_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/cpu_pressure_eviction.go
@@ -17,8 +17,10 @@ limitations under the License.
 package eviction
 
 import (
+	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/labels"
 	cliflag "k8s.io/component-base/cli/flag"
 
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
@@ -41,19 +43,21 @@ const (
 
 // CPUPressureEvictionOptions is the options of cpu pressure eviction
 type CPUPressureEvictionOptions struct {
-	EnableLoadEviction              bool
-	LoadUpperBoundRatio             float64
-	LoadLowerBoundRatio             float64
-	LoadThresholdMetPercentage      float64
-	LoadMetricRingSize              int
-	LoadEvictionCoolDownTime        time.Duration
-	EnableSuppressionEviction       bool
-	MaxSuppressionToleranceRate     float64
-	MinSuppressionToleranceDuration time.Duration
-	EnablePIDOveruseEviction        bool
-	PIDOveruseThreshold             int64
-	PIDOveruseGracePeriod           int64
-	GracePeriod                     int64
+	EnableLoadEviction                       bool
+	LoadUpperBoundRatio                      float64
+	LoadLowerBoundRatio                      float64
+	LoadThresholdMetPercentage               float64
+	LoadMetricRingSize                       int
+	LoadEvictionCoolDownTime                 time.Duration
+	EnableSuppressionEviction                bool
+	MaxSuppressionToleranceRate              float64
+	MinSuppressionToleranceDuration          time.Duration
+	EnablePIDOveruseEviction                 bool
+	PIDOveruseThreshold                      int64
+	PIDOveruseGracePeriod                    int64
+	PIDOveruseCandidatePodLabelSelector      string
+	PIDOveruseCandidatePodAnnotationSelector string
+	GracePeriod                              int64
 
 	NumaCPUPressureEvictionOptions    NumaCPUPressureEvictionOptions
 	NumaSysCPUPressureEvictionOptions NumaSysCPUPressureEvictionOptions
@@ -112,6 +116,10 @@ func (o *CPUPressureEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"the pod-level pid threshold aggregated from pod spec containers")
 	fs.Int64Var(&o.PIDOveruseGracePeriod, "eviction-pid-overuse-grace-period", o.PIDOveruseGracePeriod,
 		"the grace period of pod-level pid overuse eviction")
+	fs.StringVar(&o.PIDOveruseCandidatePodLabelSelector, "eviction-pid-overuse-candidate-pod-label-selector", o.PIDOveruseCandidatePodLabelSelector,
+		"the label selector used to filter pid overuse candidate pods")
+	fs.StringVar(&o.PIDOveruseCandidatePodAnnotationSelector, "eviction-pid-overuse-candidate-pod-annotation-selector", o.PIDOveruseCandidatePodAnnotationSelector,
+		"the annotation selector used to filter pid overuse candidate pods")
 	fs.Int64Var(&o.GracePeriod, "eviction-cpu-grace-period", o.GracePeriod,
 		"the ratio between the times metric value over the bound value and the metric ring size is greater than this percentage "+
 			", the eviction or node taint will be triggered")
@@ -132,6 +140,18 @@ func (o *CPUPressureEvictionOptions) ApplyTo(c *eviction.CPUPressureEvictionConf
 	c.EnablePIDOveruseEviction = o.EnablePIDOveruseEviction
 	c.PIDOveruseThreshold = o.PIDOveruseThreshold
 	c.PIDOveruseGracePeriod = o.PIDOveruseGracePeriod
+	if o.PIDOveruseCandidatePodLabelSelector != "" {
+		if _, err := labels.Parse(o.PIDOveruseCandidatePodLabelSelector); err != nil {
+			return fmt.Errorf("parse pid overuse candidate pod label selector %q failed: %w", o.PIDOveruseCandidatePodLabelSelector, err)
+		}
+	}
+	if o.PIDOveruseCandidatePodAnnotationSelector != "" {
+		if _, err := labels.Parse(o.PIDOveruseCandidatePodAnnotationSelector); err != nil {
+			return fmt.Errorf("parse pid overuse candidate pod annotation selector %q failed: %w", o.PIDOveruseCandidatePodAnnotationSelector, err)
+		}
+	}
+	c.PIDOveruseCandidatePodLabelSelector = o.PIDOveruseCandidatePodLabelSelector
+	c.PIDOveruseCandidatePodAnnotationSelector = o.PIDOveruseCandidatePodAnnotationSelector
 	c.GracePeriod = o.GracePeriod
 
 	if err := o.NumaCPUPressureEvictionOptions.ApplyTo(&c.NumaCPUPressureEvictionConfiguration); err != nil {

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/cpu_pressure_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/cpu_pressure_eviction.go
@@ -25,18 +25,18 @@ import (
 )
 
 const (
-	defaultEnableLoadEviction                    = false
-	defaultLoadUpperBoundRatio                   = 1.8
-	defaultLoadLowerBoundRatio                   = 1.0
-	defaultLoadThresholdMetPercentage            = 0.8
-	defaultLoadMetricSize                        = 10
-	defaultLoadEvictionCoolDownTime              = 300 * time.Second
-	defaultEnableSuppressionEviction             = false
-	defaultMaxSuppressionToleranceRate           = 5
-	defaultMinSuppressionToleranceDuration       = 300 * time.Second
-	defaultEnablePIDOveruseEviction              = false
-	defaultPIDOveruseThreshold             int64 = 0
-	defaultGracePeriod                           = -1
+	defaultEnableLoadEviction              = false
+	defaultLoadUpperBoundRatio             = 1.8
+	defaultLoadLowerBoundRatio             = 1.0
+	defaultLoadThresholdMetPercentage      = 0.8
+	defaultLoadMetricSize                  = 10
+	defaultLoadEvictionCoolDownTime        = 300 * time.Second
+	defaultEnableSuppressionEviction       = false
+	defaultMaxSuppressionToleranceRate     = 5
+	defaultMinSuppressionToleranceDuration = 300 * time.Second
+	defaultEnablePIDOveruseEviction        = false
+	defaultPIDOveruseThreshold             = 4000
+	defaultGracePeriod                     = -1
 )
 
 // CPUPressureEvictionOptions is the options of cpu pressure eviction

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/network_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/network_eviction.go
@@ -25,14 +25,24 @@ import (
 )
 
 type NetworkEvictionOptions struct {
-	EnableNICHealthEviction       bool
-	NICUnhealthyToleranceDuration time.Duration
-	GracePeriod                   int64
+	EnableNICHealthEviction            bool
+	NICUnhealthyToleranceDuration      time.Duration
+	GracePeriod                        int64
+	EnableNICBandwidthEviction         bool
+	NICBandwidthUtilizationThreshold   float64
+	NICBandwidthContinuousMetThreshold int
+	NICBandwidthRingSize               int
+	NICBandwidthRingMetThreshold       int
+	NICBandwidthGracePeriod            int64
 }
 
 func NewNetworkEvictionOptions() *NetworkEvictionOptions {
 	return &NetworkEvictionOptions{
-		NICUnhealthyToleranceDuration: 5 * time.Minute,
+		NICUnhealthyToleranceDuration:      5 * time.Minute,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
 	}
 }
 
@@ -41,13 +51,25 @@ func (o *NetworkEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 
 	fs.BoolVar(&o.EnableNICHealthEviction, "eviction-network-nic-health-enable", o.EnableNICHealthEviction, "enable nic health eviction")
 	fs.DurationVar(&o.NICUnhealthyToleranceDuration, "eviction-network-nic-unhealthy-tolerance-duration", o.NICUnhealthyToleranceDuration, "nic unhealthy tolerance duration")
-	fs.Int64Var(&o.GracePeriod, "eviction-network-grace-period", o.GracePeriod, "the grace period of pod deletion")
+	fs.Int64Var(&o.GracePeriod, "eviction-network-grace-period", o.GracePeriod, "the grace period of nic health eviction")
+	fs.BoolVar(&o.EnableNICBandwidthEviction, "eviction-network-nic-bandwidth-enable", o.EnableNICBandwidthEviction, "enable nic bandwidth eviction")
+	fs.Float64Var(&o.NICBandwidthUtilizationThreshold, "eviction-network-nic-bandwidth-utilization-threshold", o.NICBandwidthUtilizationThreshold, "nic bandwidth utilization threshold")
+	fs.IntVar(&o.NICBandwidthContinuousMetThreshold, "eviction-network-nic-bandwidth-continuous-met-threshold", o.NICBandwidthContinuousMetThreshold, "continuous met threshold for nic bandwidth eviction")
+	fs.IntVar(&o.NICBandwidthRingSize, "eviction-network-nic-bandwidth-ring-size", o.NICBandwidthRingSize, "ring size for nic bandwidth eviction")
+	fs.IntVar(&o.NICBandwidthRingMetThreshold, "eviction-network-nic-bandwidth-ring-met-threshold", o.NICBandwidthRingMetThreshold, "ring met threshold for nic bandwidth eviction")
+	fs.Int64Var(&o.NICBandwidthGracePeriod, "eviction-network-nic-bandwidth-grace-period", o.NICBandwidthGracePeriod, "the grace period of nic bandwidth eviction")
 }
 
 func (o *NetworkEvictionOptions) ApplyTo(c *eviction.NetworkEvictionConfiguration) error {
 	c.EnableNICHealthEviction = o.EnableNICHealthEviction
 	c.NICUnhealthyToleranceDuration = o.NICUnhealthyToleranceDuration
 	c.GracePeriod = o.GracePeriod
+	c.EnableNICBandwidthEviction = o.EnableNICBandwidthEviction
+	c.NICBandwidthUtilizationThreshold = o.NICBandwidthUtilizationThreshold
+	c.NICBandwidthContinuousMetThreshold = o.NICBandwidthContinuousMetThreshold
+	c.NICBandwidthRingSize = o.NICBandwidthRingSize
+	c.NICBandwidthRingMetThreshold = o.NICBandwidthRingMetThreshold
+	c.NICBandwidthGracePeriod = o.NICBandwidthGracePeriod
 
 	return nil
 }

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/network_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/network_eviction.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eviction
 
 import (
+	"fmt"
 	"time"
 
 	cliflag "k8s.io/component-base/cli/flag"
@@ -66,8 +67,14 @@ func (o *NetworkEvictionOptions) ApplyTo(c *eviction.NetworkEvictionConfiguratio
 	c.GracePeriod = o.GracePeriod
 	c.EnableNICBandwidthEviction = o.EnableNICBandwidthEviction
 	c.NICBandwidthUtilizationThreshold = o.NICBandwidthUtilizationThreshold
+	if o.NICBandwidthContinuousMetThreshold <= 0 || o.NICBandwidthContinuousMetThreshold > o.NICBandwidthRingSize {
+		return fmt.Errorf("continuous met threshold must be greater than 0 and less than or equal to ring size")
+	}
 	c.NICBandwidthContinuousMetThreshold = o.NICBandwidthContinuousMetThreshold
 	c.NICBandwidthRingSize = o.NICBandwidthRingSize
+	if o.NICBandwidthRingMetThreshold <= 0 || o.NICBandwidthRingMetThreshold > o.NICBandwidthRingSize {
+		return fmt.Errorf("ring met threshold must be greater than 0 and less than or equal to ring size")
+	}
 	c.NICBandwidthRingMetThreshold = o.NICBandwidthRingMetThreshold
 	c.NICBandwidthGracePeriod = o.NICBandwidthGracePeriod
 

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 )
 
 replace (
-	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260701085848-61a746dcb43f
+	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260707035838-71cca3705406
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 )
 
 replace (
+	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260615130141-02f9044eba10
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 )
 
 replace (
-	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260615130141-02f9044eba10
+	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260630110739-c039f8919985
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.mod
+++ b/go.mod
@@ -176,7 +176,7 @@ require (
 )
 
 replace (
-	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260630110739-c039f8919985
+	github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260701085848-61a746dcb43f
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/junyu-peng/katalyst-api v0.0.0-20260615130141-02f9044eba10 h1:4yhg4V8VPoi/mOTNMOof+uq+G3tMw+ddChnpMRddyk0=
-github.com/junyu-peng/katalyst-api v0.0.0-20260615130141-02f9044eba10/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
+github.com/junyu-peng/katalyst-api v0.0.0-20260630110739-c039f8919985 h1:FLHKVkx69izh6gf+jCG3NqxSGVpKkUQBd/gmZ177Yu0=
+github.com/junyu-peng/katalyst-api v0.0.0-20260630110739-c039f8919985/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/junyu-peng/katalyst-api v0.0.0-20260701085848-61a746dcb43f h1:aAp4kMJAcl9QLasyRcELYHfdNScbadERUOYKzsDvkcY=
-github.com/junyu-peng/katalyst-api v0.0.0-20260701085848-61a746dcb43f/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
+github.com/junyu-peng/katalyst-api v0.0.0-20260707035838-71cca3705406 h1:4i4la+gdJCr5QH3T+5m1zWPXlU3JedB2Jzwce25J+a0=
+github.com/junyu-peng/katalyst-api v0.0.0-20260707035838-71cca3705406/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/junyu-peng/katalyst-api v0.0.0-20260615130141-02f9044eba10 h1:4yhg4V8VPoi/mOTNMOof+uq+G3tMw+ddChnpMRddyk0=
+github.com/junyu-peng/katalyst-api v0.0.0-20260615130141-02f9044eba10/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -574,8 +576,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b h1:PHTBNy7sb0srh4dcD3TjjX0OV+IFr9d3A8EftLfcBbg=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/junyu-peng/katalyst-api v0.0.0-20260630110739-c039f8919985 h1:FLHKVkx69izh6gf+jCG3NqxSGVpKkUQBd/gmZ177Yu0=
-github.com/junyu-peng/katalyst-api v0.0.0-20260630110739-c039f8919985/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
+github.com/junyu-peng/katalyst-api v0.0.0-20260701085848-61a746dcb43f h1:aAp4kMJAcl9QLasyRcELYHfdNScbadERUOYKzsDvkcY=
+github.com/junyu-peng/katalyst-api v0.0.0-20260701085848-61a746dcb43f/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -154,6 +154,7 @@ func NewInnerEvictionPluginInitializers() map[string]plugin.InitFunc {
 	innerEvictionPluginInitializers[network.EvictionPluginNameNetwork] = network.NewNICEvictionPlugin
 	innerEvictionPluginInitializers[rootfs.EvictionPluginNamePodRootfsOveruse] = rootfs.NewPodRootfsOveruseEvictionPlugin
 	innerEvictionPluginInitializers[cpu.EvictionPluginNameSystemCPUPressure] = cpu.NewCPUSystemPressureEvictionPlugin
+	innerEvictionPluginInitializers[cpu.EvictionPluginNamePIDOveruse] = cpu.NewPIDOveruseEvictionPlugin
 	return innerEvictionPluginInitializers
 }
 

--- a/pkg/agent/evictionmanager/plugin/cpu/pid_overuse.go
+++ b/pkg/agent/evictionmanager/plugin/cpu/pid_overuse.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/events"
 
 	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
@@ -108,8 +109,13 @@ func (p *PIDOveruseEvictionPlugin) GetEvictPods(_ context.Context, request *plug
 		return &pluginapi.GetEvictPodsResponse{}, nil
 	}
 
-	usageList := make(podPIDUsageList, 0, len(request.ActivePods))
-	for _, pod := range request.ActivePods {
+	candidatePods, err := p.filterCandidatePods(request.ActivePods, dynamicConfig.PIDOveruseCandidatePodLabelSelector, dynamicConfig.PIDOveruseCandidatePodAnnotationSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	usageList := make(podPIDUsageList, 0, len(candidatePods))
+	for _, pod := range candidatePods {
 		usage, err := p.getPodPIDUsage(pod)
 		if err != nil {
 			general.Warningf("failed to get pod pid usage for %s/%s: %v", pod.Namespace, pod.Name, err)
@@ -146,6 +152,47 @@ func (p *PIDOveruseEvictionPlugin) GetEvictPods(_ context.Context, request *plug
 	}
 
 	return &pluginapi.GetEvictPodsResponse{EvictPods: result}, nil
+}
+
+func (p *PIDOveruseEvictionPlugin) filterCandidatePods(activePods []*v1.Pod, labelSelectorRaw, annotationSelectorRaw string) ([]*v1.Pod, error) {
+	labelSelector, hasLabelSelector, err := parsePIDOveruseSelector(labelSelectorRaw, "label")
+	if err != nil {
+		return nil, err
+	}
+	annotationSelector, hasAnnotationSelector, err := parsePIDOveruseSelector(annotationSelectorRaw, "annotation")
+	if err != nil {
+		return nil, err
+	}
+	if !hasLabelSelector && !hasAnnotationSelector {
+		return activePods, nil
+	}
+
+	candidatePods := make([]*v1.Pod, 0, len(activePods))
+	for _, pod := range activePods {
+		if pod == nil {
+			continue
+		}
+		if hasLabelSelector && !labelSelector.Matches(labels.Set(pod.Labels)) {
+			continue
+		}
+		if hasAnnotationSelector && !annotationSelector.Matches(labels.Set(pod.Annotations)) {
+			continue
+		}
+		candidatePods = append(candidatePods, pod)
+	}
+	return candidatePods, nil
+}
+
+func parsePIDOveruseSelector(selectorRaw, selectorType string) (labels.Selector, bool, error) {
+	if selectorRaw == "" {
+		return nil, false, nil
+	}
+
+	selector, err := labels.Parse(selectorRaw)
+	if err != nil {
+		return nil, false, fmt.Errorf("parse pid overuse candidate pod %s selector %q failed: %w", selectorType, selectorRaw, err)
+	}
+	return selector, true, nil
 }
 
 func (p *PIDOveruseEvictionPlugin) getPodPIDUsage(pod *v1.Pod) (podPIDUsage, error) {

--- a/pkg/agent/evictionmanager/plugin/cpu/pid_overuse.go
+++ b/pkg/agent/evictionmanager/plugin/cpu/pid_overuse.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/events"
+
+	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/agent/evictionmanager/plugin"
+	"github.com/kubewharf/katalyst-core/pkg/client"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/helper"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/process"
+)
+
+const EvictionPluginNamePIDOveruse = "pid-overuse-eviction-plugin"
+
+type PIDOveruseEvictionPlugin struct {
+	*process.StopControl
+
+	pluginName    string
+	dynamicConfig *dynamic.DynamicAgentConfiguration
+	metaServer    *metaserver.MetaServer
+	emitter       metrics.MetricEmitter
+}
+
+type podPIDUsage struct {
+	pod             *v1.Pod
+	total           int64
+	runnable        int64
+	uninterruptible int64
+	ioWait          int64
+	sleeping        int64
+}
+
+type podPIDUsageList []podPIDUsage
+
+func (l podPIDUsageList) Len() int      { return len(l) }
+func (l podPIDUsageList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l podPIDUsageList) Less(i, j int) bool {
+	return l[i].total > l[j].total
+}
+
+func NewPIDOveruseEvictionPlugin(_ *client.GenericClientSet, _ events.EventRecorder,
+	metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter, conf *config.Configuration,
+) plugin.EvictionPlugin {
+	return &PIDOveruseEvictionPlugin{
+		StopControl:   process.NewStopControl(time.Time{}),
+		pluginName:    EvictionPluginNamePIDOveruse,
+		dynamicConfig: conf.DynamicAgentConfiguration,
+		metaServer:    metaServer,
+		emitter:       emitter,
+	}
+}
+
+func (p *PIDOveruseEvictionPlugin) Name() string {
+	if p == nil {
+		return ""
+	}
+
+	return p.pluginName
+}
+
+func (p *PIDOveruseEvictionPlugin) Start() {}
+
+func (p *PIDOveruseEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
+	return &pluginapi.ThresholdMetResponse{
+		MetType: pluginapi.ThresholdMetType_NOT_MET,
+	}, nil
+}
+
+func (p *PIDOveruseEvictionPlugin) GetTopEvictionPods(_ context.Context, _ *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error) {
+	return &pluginapi.GetTopEvictionPodsResponse{}, nil
+}
+
+func (p *PIDOveruseEvictionPlugin) GetEvictPods(_ context.Context, request *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error) {
+	if request == nil {
+		return nil, fmt.Errorf("GetEvictPods got nil request")
+	}
+
+	dynamicConfig := p.dynamicConfig.GetDynamicConfiguration().CPUPressureEvictionConfiguration
+	if dynamicConfig == nil || !dynamicConfig.EnablePIDOveruseEviction || dynamicConfig.PIDOveruseThreshold <= 0 {
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	usageList := make(podPIDUsageList, 0, len(request.ActivePods))
+	for _, pod := range request.ActivePods {
+		usage, err := p.getPodPIDUsage(pod)
+		if err != nil {
+			general.Warningf("failed to get pod pid usage for %s/%s: %v", pod.Namespace, pod.Name, err)
+			continue
+		}
+
+		if usage.total > dynamicConfig.PIDOveruseThreshold {
+			usageList = append(usageList, usage)
+		}
+	}
+
+	if len(usageList) == 0 {
+		return &pluginapi.GetEvictPodsResponse{}, nil
+	}
+
+	sort.Sort(usageList)
+	result := make([]*pluginapi.EvictPod, 0, len(usageList))
+	deletionOptions := &pluginapi.DeletionOptions{
+		GracePeriodSeconds: dynamicConfig.PIDOveruseGracePeriod,
+	}
+
+	for _, item := range usageList {
+		evictPod := &pluginapi.EvictPod{
+			Pod:                item.pod,
+			ForceEvict:         true,
+			EvictionPluginName: p.pluginName,
+			Reason: fmt.Sprintf("pid overuse threshold met, total: %d, threshold: %d, runnable: %d, uninterruptible: %d, iowait: %d, sleeping: %d",
+				item.total, dynamicConfig.PIDOveruseThreshold, item.runnable, item.uninterruptible, item.ioWait, item.sleeping),
+		}
+		if deletionOptions.GracePeriodSeconds > 0 {
+			evictPod.DeletionOptions = deletionOptions
+		}
+		result = append(result, evictPod)
+	}
+
+	return &pluginapi.GetEvictPodsResponse{EvictPods: result}, nil
+}
+
+func (p *PIDOveruseEvictionPlugin) getPodPIDUsage(pod *v1.Pod) (podPIDUsage, error) {
+	runnable, err := helper.GetPodMetric(p.metaServer.MetricsFetcher, p.emitter, pod, consts.MetricCPUNrRunnableContainer, -1)
+	if err != nil {
+		return podPIDUsage{}, err
+	}
+	uninterruptible, err := helper.GetPodMetric(p.metaServer.MetricsFetcher, p.emitter, pod, consts.MetricCPUNrUninterruptibleContainer, -1)
+	if err != nil {
+		return podPIDUsage{}, err
+	}
+	ioWait, err := helper.GetPodMetric(p.metaServer.MetricsFetcher, p.emitter, pod, consts.MetricCPUNrIOWaitContainer, -1)
+	if err != nil {
+		return podPIDUsage{}, err
+	}
+	sleeping, err := helper.GetPodMetric(p.metaServer.MetricsFetcher, p.emitter, pod, consts.MetricCPUNrSleepingContainer, -1)
+	if err != nil {
+		return podPIDUsage{}, err
+	}
+
+	return podPIDUsage{
+		pod:             pod,
+		total:           int64(runnable + uninterruptible + ioWait + sleeping),
+		runnable:        int64(runnable),
+		uninterruptible: int64(uninterruptible),
+		ioWait:          int64(ioWait),
+		sleeping:        int64(sleeping),
+	}, nil
+}

--- a/pkg/agent/evictionmanager/plugin/cpu/pid_overuse_test.go
+++ b/pkg/agent/evictionmanager/plugin/cpu/pid_overuse_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpu
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config"
+	"github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+)
+
+func TestPIDOveruseEvictionPluginGetEvictPods(t *testing.T) {
+	t.Parallel()
+
+	emitter := metrics.DummyMetrics{}
+	fakeFetcher := metric.NewFakeMetricsFetcher(emitter).(*metric.FakeMetricsFetcher)
+	now := metav1.Now().Time
+
+	setPIDMetrics := func(podUID, containerName string, runnable, uninterruptible, ioWait, sleeping float64) {
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrRunnableContainer, utilmetric.MetricData{Value: runnable, Time: &now})
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrUninterruptibleContainer, utilmetric.MetricData{Value: uninterruptible, Time: &now})
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrIOWaitContainer, utilmetric.MetricData{Value: ioWait, Time: &now})
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrSleepingContainer, utilmetric.MetricData{Value: sleeping, Time: &now})
+	}
+
+	setPIDMetrics("pod-1", "main", 20, 10, 5, 5)
+	setPIDMetrics("pod-2", "main", 25, 10, 10, 15)
+	setPIDMetrics("pod-2", "sidecar", 10, 5, 5, 5)
+	setPIDMetrics("pod-3", "main", 35, 10, 5, 11)
+
+	metaServer := &metaserver.MetaServer{
+		MetaAgent: &agent.MetaAgent{
+			MetricsFetcher: fakeFetcher,
+		},
+	}
+
+	conf := config.NewConfiguration()
+	conf.GetDynamicConfiguration().CPUPressureEvictionConfiguration.EnablePIDOveruseEviction = true
+	conf.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseThreshold = 60
+	conf.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseGracePeriod = 12
+
+	plugin := NewPIDOveruseEvictionPlugin(nil, nil, metaServer, emitter, conf).(*PIDOveruseEvictionPlugin)
+	resp, err := plugin.GetEvictPods(context.Background(), &pluginapi.GetEvictPodsRequest{
+		ActivePods: []*v1.Pod{
+			newPIDTestPod("pod-1", "main"),
+			newPIDTestPod("pod-2", "main", "sidecar"),
+			newPIDTestPod("pod-3", "main"),
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.EvictPods, 2)
+	require.Equal(t, "pod-2", string(resp.EvictPods[0].Pod.UID))
+	require.Equal(t, "pod-3", string(resp.EvictPods[1].Pod.UID))
+	require.NotNil(t, resp.EvictPods[0].DeletionOptions)
+	require.EqualValues(t, 12, resp.EvictPods[0].DeletionOptions.GracePeriodSeconds)
+	require.True(t, resp.EvictPods[0].ForceEvict)
+	require.Equal(t, EvictionPluginNamePIDOveruse, resp.EvictPods[0].EvictionPluginName)
+}
+
+func newPIDTestPod(uid string, containerNames ...string) *v1.Pod {
+	containers := make([]v1.Container, 0, len(containerNames))
+	for _, name := range containerNames {
+		containers = append(containers, v1.Container{Name: name})
+	}
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID(uid),
+			Name: uid,
+		},
+		Spec: v1.PodSpec{
+			Containers: containers,
+		},
+	}
+}

--- a/pkg/agent/evictionmanager/plugin/cpu/pid_overuse_test.go
+++ b/pkg/agent/evictionmanager/plugin/cpu/pid_overuse_test.go
@@ -83,7 +83,101 @@ func TestPIDOveruseEvictionPluginGetEvictPods(t *testing.T) {
 	require.Equal(t, EvictionPluginNamePIDOveruse, resp.EvictPods[0].EvictionPluginName)
 }
 
+func TestPIDOveruseEvictionPluginGetEvictPodsFiltersCandidatePodsBySelectors(t *testing.T) {
+	t.Parallel()
+
+	emitter := metrics.DummyMetrics{}
+	fakeFetcher := metric.NewFakeMetricsFetcher(emitter).(*metric.FakeMetricsFetcher)
+	now := metav1.Now().Time
+
+	setPIDMetrics := func(podUID, containerName string, runnable, uninterruptible, ioWait, sleeping float64) {
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrRunnableContainer, utilmetric.MetricData{Value: runnable, Time: &now})
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrUninterruptibleContainer, utilmetric.MetricData{Value: uninterruptible, Time: &now})
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrIOWaitContainer, utilmetric.MetricData{Value: ioWait, Time: &now})
+		fakeFetcher.SetContainerMetric(podUID, containerName, consts.MetricCPUNrSleepingContainer, utilmetric.MetricData{Value: sleeping, Time: &now})
+	}
+
+	setPIDMetrics("pod-1", "main", 20, 10, 5, 5)
+	setPIDMetrics("pod-2", "main", 25, 10, 10, 15)
+	setPIDMetrics("pod-2", "sidecar", 10, 5, 5, 5)
+	setPIDMetrics("pod-3", "main", 35, 10, 5, 11)
+
+	metaServer := &metaserver.MetaServer{
+		MetaAgent: &agent.MetaAgent{
+			MetricsFetcher: fakeFetcher,
+		},
+	}
+
+	newPlugin := func() *PIDOveruseEvictionPlugin {
+		conf := config.NewConfiguration()
+		conf.GetDynamicConfiguration().CPUPressureEvictionConfiguration.EnablePIDOveruseEviction = true
+		conf.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseThreshold = 60
+		return NewPIDOveruseEvictionPlugin(nil, nil, metaServer, emitter, conf).(*PIDOveruseEvictionPlugin)
+	}
+
+	request := &pluginapi.GetEvictPodsRequest{
+		ActivePods: []*v1.Pod{
+			newPIDTestPodWithMetadata("pod-1", map[string]string{"tier": "gold"}, map[string]string{"salemode": "spot"}, "main"),
+			newPIDTestPodWithMetadata("pod-2", map[string]string{"tier": "gold"}, map[string]string{"salemode": "reserved"}, "main", "sidecar"),
+			newPIDTestPodWithMetadata("pod-3", map[string]string{"tier": "silver"}, map[string]string{"salemode": "reserved"}, "main"),
+		},
+	}
+
+	t.Run("label selector only", func(t *testing.T) {
+		t.Parallel()
+
+		plugin := newPlugin()
+		plugin.dynamicConfig.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseCandidatePodLabelSelector = "tier=silver"
+
+		resp, err := plugin.GetEvictPods(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, resp.EvictPods, 1)
+		require.Equal(t, "pod-3", string(resp.EvictPods[0].Pod.UID))
+	})
+
+	t.Run("annotation selector only", func(t *testing.T) {
+		t.Parallel()
+
+		plugin := newPlugin()
+		plugin.dynamicConfig.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseCandidatePodAnnotationSelector = "salemode=reserved"
+
+		resp, err := plugin.GetEvictPods(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, resp.EvictPods, 2)
+		require.Equal(t, "pod-2", string(resp.EvictPods[0].Pod.UID))
+		require.Equal(t, "pod-3", string(resp.EvictPods[1].Pod.UID))
+	})
+
+	t.Run("label and annotation selectors are combined with and", func(t *testing.T) {
+		t.Parallel()
+
+		plugin := newPlugin()
+		plugin.dynamicConfig.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseCandidatePodLabelSelector = "tier=gold"
+		plugin.dynamicConfig.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseCandidatePodAnnotationSelector = "salemode=reserved"
+
+		resp, err := plugin.GetEvictPods(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, resp.EvictPods, 1)
+		require.Equal(t, "pod-2", string(resp.EvictPods[0].Pod.UID))
+	})
+
+	t.Run("invalid annotation selector returns error", func(t *testing.T) {
+		t.Parallel()
+
+		plugin := newPlugin()
+		plugin.dynamicConfig.GetDynamicConfiguration().CPUPressureEvictionConfiguration.PIDOveruseCandidatePodAnnotationSelector = "salemode in"
+
+		resp, err := plugin.GetEvictPods(context.Background(), request)
+		require.Error(t, err)
+		require.Nil(t, resp)
+	})
+}
+
 func newPIDTestPod(uid string, containerNames ...string) *v1.Pod {
+	return newPIDTestPodWithMetadata(uid, nil, nil, containerNames...)
+}
+
+func newPIDTestPodWithMetadata(uid string, labels, annotations map[string]string, containerNames ...string) *v1.Pod {
 	containers := make([]v1.Container, 0, len(containerNames))
 	for _, name := range containerNames {
 		containers = append(containers, v1.Container{Name: name})
@@ -91,8 +185,10 @@ func newPIDTestPod(uid string, containerNames ...string) *v1.Pod {
 
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			UID:  types.UID(uid),
-			Name: uid,
+			UID:         types.UID(uid),
+			Name:        uid,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: v1.PodSpec{
 			Containers: containers,

--- a/pkg/agent/evictionmanager/plugin/network/bandwidth_helpers.go
+++ b/pkg/agent/evictionmanager/plugin/network/bandwidth_helpers.go
@@ -25,15 +25,17 @@ import (
 
 	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 	coreconsts "github.com/kubewharf/katalyst-core/pkg/consts"
-	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
 )
 
 const (
 	bandwidthScopePrefix            = "bandwidth"
 	bandwidthDirectionRX            = "rx"
 	bandwidthDirectionTX            = "tx"
-	bandwidthPressureStateRetention = time.Minute
+	bandwidthPressureStateRetention = 5 * time.Minute
 	bitsPerByte                     = 8
 	bpsPerMbps                      = 1000 * 1000
 )
@@ -56,9 +58,9 @@ type bandwidthPressureEvaluation struct {
 	currentHits     int
 }
 
-// bandwidthPressureState stores bandwidth samples for one (netns, nic, direction).
-// Threshold hits are calculated with the current dynamic threshold when evaluated.
-type bandwidthPressureState struct {
+// bandwidthState stores healthy NIC capacity and the sampled bandwidth history
+// for one (netns, nic, direction). Threshold hits are calculated when evaluated.
+type bandwidthState struct {
 	ring        []bandwidthSample
 	nextIndex   int
 	sampleCount int
@@ -67,47 +69,30 @@ type bandwidthPressureState struct {
 // BandwidthMetricQuerier isolates metric access from eviction decisions.
 // It returns runtime usage only; CNR remains the capacity source.
 type BandwidthMetricQuerier interface {
-	GetBandwidthMetric(scope bandwidthScope) (float64, bool)
+	GetBandwidthMetric(scope bandwidthScope) (utilmetric.MetricData, error)
 	GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool)
 }
 
-// metaServerBandwidthMetricQuerier reads instantaneous usage only; NIC capacity
+// bandwidthMetricQuerier reads instantaneous usage only; NIC capacity
 // comes from CNR so bandwidth eviction shares the same source as allocation.
-type metaServerBandwidthMetricQuerier struct {
-	metaServer *metaserver.MetaServer
+type bandwidthMetricQuerier struct {
+	metrictypes.MetricsFetcher
 }
 
-func newMetaServerBandwidthMetricQuerier(metaServer *metaserver.MetaServer) BandwidthMetricQuerier {
-	if metaServer == nil || metaServer.MetricsFetcher == nil {
-		return nil
-	}
-
-	return &metaServerBandwidthMetricQuerier{metaServer: metaServer}
+func newBandwidthMetricQuerier(metaServer metrictypes.MetricsFetcher) BandwidthMetricQuerier {
+	return &bandwidthMetricQuerier{metaServer}
 }
 
-func (m *metaServerBandwidthMetricQuerier) GetBandwidthMetric(scope bandwidthScope) (float64, bool) {
-	if m == nil || m.metaServer == nil || m.metaServer.MetricsFetcher == nil {
-		return 0, false
-	}
-
+func (m *bandwidthMetricQuerier) GetBandwidthMetric(scope bandwidthScope) (utilmetric.MetricData, error) {
 	metricName := coreconsts.MetricNetReceiveBPS
 	if scope.direction == bandwidthDirectionTX {
 		metricName = coreconsts.MetricNetTransmitBPS
 	}
 
-	bps, err := m.metaServer.MetricsFetcher.GetNSNetworkMetric(scope.netns, scope.nic, metricName)
-	if err != nil {
-		return 0, false
-	}
-
-	return bps.Value, true
+	return m.GetNSNetworkMetric(scope.netns, scope.nic, metricName)
 }
 
-func (m *metaServerBandwidthMetricQuerier) GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool) {
-	if m == nil || m.metaServer == nil || m.metaServer.MetricsFetcher == nil || pod == nil {
-		return 0, false
-	}
-
+func (m *bandwidthMetricQuerier) GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool) {
 	metricName := coreconsts.MetricNetTcpRecvBPSContainer
 	if direction == bandwidthDirectionTX {
 		metricName = coreconsts.MetricNetTcpSendBPSContainer
@@ -116,8 +101,9 @@ func (m *metaServerBandwidthMetricQuerier) GetPodDirectionUsage(pod *v1.Pod, dir
 	total := 0.0
 	found := false
 	for _, container := range pod.Spec.Containers {
-		metric, err := m.metaServer.MetricsFetcher.GetContainerMetric(string(pod.UID), container.Name, metricName)
+		metric, err := m.MetricsFetcher.GetContainerMetric(string(pod.UID), container.Name, metricName)
 		if err != nil {
+			general.Errorf("failed to get container metric %s for pod %s: %v", metricName, pod.Name, err)
 			continue
 		}
 		total += metric.Value
@@ -170,15 +156,15 @@ func getPodBandwidthScope(pod *v1.Pod, target bandwidthScope) (bandwidthScope, b
 	return bandwidthScope{}, false
 }
 
-func (s *bandwidthPressureState) observe(bps, capacityMbps float64, now time.Time) {
-	if s == nil || len(s.ring) == 0 {
+func (s *bandwidthState) observe(sample *bandwidthSample) {
+	if sample == nil {
 		return
 	}
 
 	s.ring[s.nextIndex] = bandwidthSample{
-		bps:          bps,
-		capacityMbps: capacityMbps,
-		observedAt:   now,
+		bps:          sample.bps,
+		capacityMbps: sample.capacityMbps,
+		observedAt:   sample.observedAt,
 	}
 	s.nextIndex = (s.nextIndex + 1) % len(s.ring)
 	if s.sampleCount < len(s.ring) {
@@ -186,7 +172,7 @@ func (s *bandwidthPressureState) observe(bps, capacityMbps float64, now time.Tim
 	}
 }
 
-func (s *bandwidthPressureState) expired(now time.Time, retention time.Duration) bool {
+func (s *bandwidthState) expired(retention time.Duration) bool {
 	if s == nil {
 		return true
 	}
@@ -197,10 +183,10 @@ func (s *bandwidthPressureState) expired(now time.Time, retention time.Duration)
 	if !ok || latestSample.observedAt.IsZero() {
 		return true
 	}
-	return now.Sub(latestSample.observedAt) > retention
+	return time.Now().Sub(latestSample.observedAt) > retention
 }
 
-func (s *bandwidthPressureState) evaluate(threshold float64) bandwidthPressureEvaluation {
+func (s *bandwidthState) evaluate(threshold float64) bandwidthPressureEvaluation {
 	if s == nil || len(s.ring) == 0 || s.sampleCount == 0 {
 		return bandwidthPressureEvaluation{}
 	}
@@ -234,22 +220,23 @@ func (s *bandwidthPressureState) evaluate(threshold float64) bandwidthPressureEv
 	return evaluation
 }
 
-func (s *bandwidthPressureState) latestSample() (bandwidthSample, bool) {
+func (s *bandwidthState) met(utilizationThreshold float64, continuousThreshold, ringMetThreshold int) (bandwidthPressureEvaluation, bool) {
+	evaluation := s.evaluate(utilizationThreshold)
+	if continuousThreshold > 0 && evaluation.consecutiveHits >= continuousThreshold {
+		return evaluation, true
+	}
+	if ringMetThreshold > 0 && evaluation.currentHits >= ringMetThreshold {
+		return evaluation, true
+	}
+	return evaluation, false
+}
+
+func (s *bandwidthState) latestSample() (bandwidthSample, bool) {
 	if s == nil || len(s.ring) == 0 || s.sampleCount == 0 {
 		return bandwidthSample{}, false
 	}
 	index := (s.nextIndex - 1 + len(s.ring)) % len(s.ring)
 	return s.ring[index], true
-}
-
-func (e bandwidthPressureEvaluation) met(continuousThreshold, ringMetThreshold int) bool {
-	if continuousThreshold > 0 && e.consecutiveHits >= continuousThreshold {
-		return true
-	}
-	if ringMetThreshold > 0 && e.currentHits >= ringMetThreshold {
-		return true
-	}
-	return false
 }
 
 func isBandwidthPressureMoreSevere(scope bandwidthScope, evaluation bandwidthPressureEvaluation, bestScope bandwidthScope, bestEvaluation bandwidthPressureEvaluation) bool {

--- a/pkg/agent/evictionmanager/plugin/network/bandwidth_helpers.go
+++ b/pkg/agent/evictionmanager/plugin/network/bandwidth_helpers.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	coreconsts "github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+const (
+	bandwidthScopePrefix            = "bandwidth"
+	bandwidthDirectionRX            = "rx"
+	bandwidthDirectionTX            = "tx"
+	bandwidthPressureStateRetention = time.Minute
+	bitsPerByte                     = 8
+	bpsPerMbps                      = 1000 * 1000
+)
+
+type bandwidthScope struct {
+	netns     string
+	nic       string
+	direction string
+}
+
+type bandwidthSample struct {
+	bps          float64
+	capacityMbps float64
+	observedAt   time.Time
+}
+
+type bandwidthPressureEvaluation struct {
+	lastUtilization float64
+	consecutiveHits int
+	currentHits     int
+}
+
+// bandwidthPressureState stores bandwidth samples for one (netns, nic, direction).
+// Threshold hits are calculated with the current dynamic threshold when evaluated.
+type bandwidthPressureState struct {
+	ring        []bandwidthSample
+	nextIndex   int
+	sampleCount int
+}
+
+// BandwidthMetricQuerier isolates metric access from eviction decisions.
+// It returns runtime usage only; CNR remains the capacity source.
+type BandwidthMetricQuerier interface {
+	GetBandwidthMetric(scope bandwidthScope) (float64, bool)
+	GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool)
+}
+
+// metaServerBandwidthMetricQuerier reads instantaneous usage only; NIC capacity
+// comes from CNR so bandwidth eviction shares the same source as allocation.
+type metaServerBandwidthMetricQuerier struct {
+	metaServer *metaserver.MetaServer
+}
+
+func newMetaServerBandwidthMetricQuerier(metaServer *metaserver.MetaServer) BandwidthMetricQuerier {
+	if metaServer == nil || metaServer.MetricsFetcher == nil {
+		return nil
+	}
+
+	return &metaServerBandwidthMetricQuerier{metaServer: metaServer}
+}
+
+func (m *metaServerBandwidthMetricQuerier) GetBandwidthMetric(scope bandwidthScope) (float64, bool) {
+	if m == nil || m.metaServer == nil || m.metaServer.MetricsFetcher == nil {
+		return 0, false
+	}
+
+	metricName := coreconsts.MetricNetReceiveBPS
+	if scope.direction == bandwidthDirectionTX {
+		metricName = coreconsts.MetricNetTransmitBPS
+	}
+
+	bps, err := m.metaServer.MetricsFetcher.GetNSNetworkMetric(scope.netns, scope.nic, metricName)
+	if err != nil {
+		return 0, false
+	}
+
+	return bps.Value, true
+}
+
+func (m *metaServerBandwidthMetricQuerier) GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool) {
+	if m == nil || m.metaServer == nil || m.metaServer.MetricsFetcher == nil || pod == nil {
+		return 0, false
+	}
+
+	metricName := coreconsts.MetricNetTcpRecvBPSContainer
+	if direction == bandwidthDirectionTX {
+		metricName = coreconsts.MetricNetTcpSendBPSContainer
+	}
+
+	total := 0.0
+	found := false
+	for _, container := range pod.Spec.Containers {
+		metric, err := m.metaServer.MetricsFetcher.GetContainerMetric(string(pod.UID), container.Name, metricName)
+		if err != nil {
+			continue
+		}
+		total += metric.Value
+		found = true
+	}
+
+	return total, found
+}
+
+func formatBandwidthScope(scope bandwidthScope) string {
+	return fmt.Sprintf("%s/%s/%s/%s", bandwidthScopePrefix, scope.netns, scope.nic, scope.direction)
+}
+
+func parseBandwidthScope(raw string) (bandwidthScope, error) {
+	parts := strings.Split(raw, "/")
+	if len(parts) != 4 || parts[0] != bandwidthScopePrefix {
+		return bandwidthScope{}, fmt.Errorf("invalid bandwidth scope %q", raw)
+	}
+	if parts[2] == "" {
+		return bandwidthScope{}, fmt.Errorf("invalid bandwidth scope %q", raw)
+	}
+	if parts[3] != bandwidthDirectionRX && parts[3] != bandwidthDirectionTX {
+		return bandwidthScope{}, fmt.Errorf("invalid bandwidth direction %q", parts[3])
+	}
+
+	return bandwidthScope{
+		netns:     parts[1],
+		nic:       parts[2],
+		direction: parts[3],
+	}, nil
+}
+
+func convertMbpsToBytesPerSecond(mbps float64) float64 {
+	return mbps * bpsPerMbps / bitsPerByte
+}
+
+func getPodBandwidthScope(pod *v1.Pod, target bandwidthScope) (bandwidthScope, bool) {
+	if pod.Annotations != nil {
+		if identifier := pod.Annotations[apiconsts.PodAnnotationNICSelectionResultKey]; identifier != "" {
+			netns, nic, ok := machine.ParseNICIdentifier(identifier)
+			if !ok {
+				return bandwidthScope{}, false
+			}
+			return bandwidthScope{netns: netns, nic: nic}, true
+		}
+	}
+	if target.netns == machine.DefaultNICNamespace {
+		return bandwidthScope{netns: machine.DefaultNICNamespace, nic: target.nic}, true
+	}
+	return bandwidthScope{}, false
+}
+
+func (s *bandwidthPressureState) observe(bps, capacityMbps float64, now time.Time) {
+	if s == nil || len(s.ring) == 0 {
+		return
+	}
+
+	s.ring[s.nextIndex] = bandwidthSample{
+		bps:          bps,
+		capacityMbps: capacityMbps,
+		observedAt:   now,
+	}
+	s.nextIndex = (s.nextIndex + 1) % len(s.ring)
+	if s.sampleCount < len(s.ring) {
+		s.sampleCount++
+	}
+}
+
+func (s *bandwidthPressureState) expired(now time.Time, retention time.Duration) bool {
+	if s == nil {
+		return true
+	}
+	if retention <= 0 {
+		return false
+	}
+	latestSample, ok := s.latestSample()
+	if !ok || latestSample.observedAt.IsZero() {
+		return true
+	}
+	return now.Sub(latestSample.observedAt) > retention
+}
+
+func (s *bandwidthPressureState) evaluate(threshold float64) bandwidthPressureEvaluation {
+	if s == nil || len(s.ring) == 0 || s.sampleCount == 0 {
+		return bandwidthPressureEvaluation{}
+	}
+
+	evaluation := bandwidthPressureEvaluation{}
+	if latestSample, ok := s.latestSample(); ok {
+		latestCapacityBPS := convertMbpsToBytesPerSecond(latestSample.capacityMbps)
+		if latestCapacityBPS > 0 {
+			evaluation.lastUtilization = latestSample.bps / latestCapacityBPS
+		}
+	}
+	for i := 0; i < s.sampleCount; i++ {
+		sample := s.ring[i]
+		if sample.observedAt.IsZero() {
+			continue
+		}
+		capacityBPS := convertMbpsToBytesPerSecond(sample.capacityMbps)
+		if capacityBPS > 0 && sample.bps/capacityBPS >= threshold {
+			evaluation.currentHits++
+		}
+	}
+	for i := 0; i < s.sampleCount; i++ {
+		index := (s.nextIndex - 1 - i + len(s.ring)) % len(s.ring)
+		sample := s.ring[index]
+		capacityBPS := convertMbpsToBytesPerSecond(sample.capacityMbps)
+		if sample.observedAt.IsZero() || capacityBPS <= 0 || sample.bps/capacityBPS < threshold {
+			break
+		}
+		evaluation.consecutiveHits++
+	}
+	return evaluation
+}
+
+func (s *bandwidthPressureState) latestSample() (bandwidthSample, bool) {
+	if s == nil || len(s.ring) == 0 || s.sampleCount == 0 {
+		return bandwidthSample{}, false
+	}
+	index := (s.nextIndex - 1 + len(s.ring)) % len(s.ring)
+	return s.ring[index], true
+}
+
+func (e bandwidthPressureEvaluation) met(continuousThreshold, ringMetThreshold int) bool {
+	if continuousThreshold > 0 && e.consecutiveHits >= continuousThreshold {
+		return true
+	}
+	if ringMetThreshold > 0 && e.currentHits >= ringMetThreshold {
+		return true
+	}
+	return false
+}
+
+func isBandwidthPressureMoreSevere(scope bandwidthScope, evaluation bandwidthPressureEvaluation, bestScope bandwidthScope, bestEvaluation bandwidthPressureEvaluation) bool {
+	if evaluation.lastUtilization != bestEvaluation.lastUtilization {
+		return evaluation.lastUtilization > bestEvaluation.lastUtilization
+	}
+	if evaluation.currentHits != bestEvaluation.currentHits {
+		return evaluation.currentHits > bestEvaluation.currentHits
+	}
+	if evaluation.consecutiveHits != bestEvaluation.consecutiveHits {
+		return evaluation.consecutiveHits > bestEvaluation.consecutiveHits
+	}
+	if scope.direction != bestScope.direction {
+		return scope.direction == bandwidthDirectionRX
+	}
+	return formatBandwidthScope(scope) < formatBandwidthScope(bestScope)
+}

--- a/pkg/agent/evictionmanager/plugin/network/network.go
+++ b/pkg/agent/evictionmanager/plugin/network/network.go
@@ -64,16 +64,15 @@ type nicEvictionPlugin struct {
 	mutex sync.RWMutex
 	// unhealthyNICState is a map from NIC name to the state of the NIC
 	unhealthyNICState map[string]*unhealthyNICState
-	// healthyNICState caches CNR NIC bandwidth capacity by eviction scope.
-	healthyNICState map[bandwidthScope]float64
+	// healthyNICState caches healthy NIC capacity and sampled bandwidth history by formatted eviction scope.
+	healthyNICState map[string]*bandwidthState
 
 	emitter                  metrics.MetricEmitter
 	pluginName               string
 	metaServer               *metaserver.MetaServer
 	dynamicConfig            *dynamic.DynamicAgentConfiguration
 	podSaleModeAnnotationKey string
-	bandwidthPressureState   map[bandwidthScope]*bandwidthPressureState
-	metricQuerier            BandwidthMetricQuerier
+	bandwidthMetricQuerier   BandwidthMetricQuerier
 }
 
 func NewNICEvictionPlugin(_ *client.GenericClientSet, _ events.EventRecorder,
@@ -82,14 +81,13 @@ func NewNICEvictionPlugin(_ *client.GenericClientSet, _ events.EventRecorder,
 	return &nicEvictionPlugin{
 		StopControl:              process.NewStopControl(time.Time{}),
 		unhealthyNICState:        make(map[string]*unhealthyNICState),
-		healthyNICState:          make(map[bandwidthScope]float64),
+		healthyNICState:          make(map[string]*bandwidthState),
 		emitter:                  emitter,
 		pluginName:               EvictionPluginNameNetwork,
 		metaServer:               metaServer,
 		dynamicConfig:            conf.DynamicAgentConfiguration,
 		podSaleModeAnnotationKey: conf.GenericConfiguration.PodSaleModeAnnotationKey,
-		bandwidthPressureState:   make(map[bandwidthScope]*bandwidthPressureState),
-		metricQuerier:            newMetaServerBandwidthMetricQuerier(metaServer),
+		bandwidthMetricQuerier:   newBandwidthMetricQuerier(metaServer.MetricsFetcher),
 	}
 }
 
@@ -129,77 +127,73 @@ func (n *nicEvictionPlugin) syncNICState(ctx context.Context) {
 	}
 
 	healthyNICZone, unhealthyNICZone := getNICZones(getCNR.Status.TopologyZone)
-	now := time.Now()
-
-	n.syncHealthyNICState(healthyNICZone, now)
-	n.syncUnHealthyNICState(unhealthyNICZone, now)
+	n.syncHealthyNICState(healthyNICZone)
+	n.syncUnHealthyNICState(unhealthyNICZone)
 }
 
-func (n *nicEvictionPlugin) syncHealthyNICState(healthyNICZone map[string]float64, now time.Time) {
-	healthyNICState := make(map[bandwidthScope]float64, len(healthyNICZone)*2)
+func (n *nicEvictionPlugin) syncHealthyNICState(healthyNICZone map[string]float64) {
+	if n == nil || n.dynamicConfig == nil {
+		return
+	}
+	conf := n.dynamicConfig.GetDynamicConfiguration()
+	if conf == nil || conf.NetworkEvictionConfiguration == nil {
+		return
+	}
+	evictionConfig := conf.NetworkEvictionConfiguration
+
+	activeBandwidthScopeSamples := make(map[string]*bandwidthSample, len(healthyNICZone)*2)
 	for identifier, capacity := range healthyNICZone {
 		netns, nic, ok := machine.ParseNICIdentifier(identifier)
 		if !ok {
 			continue
 		}
 		for _, direction := range []string{bandwidthDirectionRX, bandwidthDirectionTX} {
-			healthyNICState[bandwidthScope{
+			scope := bandwidthScope{
 				netns:     netns,
 				nic:       nic,
 				direction: direction,
-			}] = capacity
-		}
-	}
+			}
+			scopeKey := formatBandwidthScope(scope)
+			activeBandwidthScopeSamples[scopeKey] = nil
 
-	conf := (*eviction.NetworkEvictionConfiguration)(nil)
-	if n != nil && n.dynamicConfig != nil {
-		conf = n.dynamicConfig.GetDynamicConfiguration().NetworkEvictionConfiguration
-	}
-	if n != nil && n.metricQuerier == nil {
-		n.metricQuerier = newMetaServerBandwidthMetricQuerier(n.metaServer)
-	}
-
-	type bandwidthObservation struct {
-		scope        bandwidthScope
-		bps          float64
-		capacityMbps float64
-	}
-	observations := make([]bandwidthObservation, 0, len(healthyNICState))
-	if conf != nil && conf.EnableNICBandwidthEviction && n != nil && n.metricQuerier != nil {
-		for scope, capacity := range healthyNICState {
-			bps, ok := n.metricQuerier.GetBandwidthMetric(scope)
-			if !ok || capacity <= 0 {
+			metricData, err := n.bandwidthMetricQuerier.GetBandwidthMetric(scope)
+			if err != nil {
+				general.Errorf("failed to get bandwidth metric for scope %s: %v", scopeKey, err)
 				continue
 			}
-			observations = append(observations, bandwidthObservation{
-				scope:        scope,
-				bps:          bps,
+
+			if metricData.Time == nil || metricData.Value <= 0 {
+				general.Warningf("invalid bandwidth metric for scope %s: %v", scopeKey, metricData)
+				continue
+			}
+
+			activeBandwidthScopeSamples[scopeKey] = &bandwidthSample{
 				capacityMbps: capacity,
-			})
+				bps:          metricData.Value,
+				observedAt:   *metricData.Time,
+			}
 		}
 	}
 
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	n.healthyNICState = healthyNICState
-	n.pruneStaleBandwidthStates(healthyNICState, now, bandwidthPressureStateRetention)
-	if conf == nil || !conf.EnableNICBandwidthEviction {
-		return
-	}
-	for _, observation := range observations {
-		state := n.getOrCreateBandwidthState(observation.scope, conf.NICBandwidthRingSize, now, bandwidthPressureStateRetention)
-		state.observe(observation.bps, observation.capacityMbps, now)
+	n.pruneStaleBandwidthStates(activeBandwidthScopeSamples, bandwidthPressureStateRetention)
+	ringSize := evictionConfig.NICBandwidthRingSize
+	for scope, sample := range activeBandwidthScopeSamples {
+		state := n.getOrCreateHealthyNICState(scope, ringSize)
+		state.observe(sample)
 	}
 }
 
-func (n *nicEvictionPlugin) syncUnHealthyNICState(unhealthyNICZone map[string]v1alpha1.TopologyZone, now time.Time) {
+func (n *nicEvictionPlugin) syncUnHealthyNICState(unhealthyNICZone map[string]v1alpha1.TopologyZone) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
 	if n.unhealthyNICState == nil {
 		n.unhealthyNICState = make(map[string]*unhealthyNICState)
 	}
+	now := time.Now()
 	for nic := range unhealthyNICZone {
 		if _, ok := n.unhealthyNICState[nic]; !ok {
 			n.unhealthyNICState[nic] = &unhealthyNICState{
@@ -222,13 +216,20 @@ func (n *nicEvictionPlugin) syncUnHealthyNICState(unhealthyNICZone map[string]v1
 	}
 }
 
-func (n *nicEvictionPlugin) getHealthyNICState() map[bandwidthScope]float64 {
+func (n *nicEvictionPlugin) getHealthyNICState() map[string]*bandwidthState {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
-	result := make(map[bandwidthScope]float64, len(n.healthyNICState))
-	for scope, capacity := range n.healthyNICState {
-		result[scope] = capacity
+	result := make(map[string]*bandwidthState, len(n.healthyNICState))
+	for scopeKey, state := range n.healthyNICState {
+		if state == nil {
+			continue
+		}
+		cloned := *state
+		if state.ring != nil {
+			cloned.ring = append([]bandwidthSample(nil), state.ring...)
+		}
+		result[scopeKey] = &cloned
 	}
 	return result
 }
@@ -239,7 +240,13 @@ func (n *nicEvictionPlugin) getUnhealthyNICState() map[string]*unhealthyNICState
 
 	result := make(map[string]*unhealthyNICState, len(n.unhealthyNICState))
 	for nic, state := range n.unhealthyNICState {
-		result[nic] = state
+		if state == nil {
+			continue
+		}
+		result[nic] = &unhealthyNICState{
+			lastUnhealthyTime: state.lastUnhealthyTime,
+			nicZone:           *state.nicZone.DeepCopy(),
+		}
 	}
 	return result
 }
@@ -261,21 +268,23 @@ func (n *nicEvictionPlugin) ThresholdMet(_ context.Context, req *pluginapi.GetTh
 	var bestResp *pluginapi.ThresholdMetResponse
 	var bestScope bandwidthScope
 	var bestEvaluation bandwidthPressureEvaluation
-	now := time.Now()
 	bandwidthScopes := n.getHealthyNICState()
 
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
-
-	n.pruneStaleBandwidthStates(bandwidthScopes, now, bandwidthPressureStateRetention)
-
-	for scope := range bandwidthScopes {
-		state, ok := n.bandwidthPressureState[scope]
-		if !ok {
+	for scopeKey, state := range bandwidthScopes {
+		if state == nil {
 			continue
 		}
-		evaluation := state.evaluate(conf.NICBandwidthUtilizationThreshold)
-		if !evaluation.met(conf.NICBandwidthContinuousMetThreshold, conf.NICBandwidthRingMetThreshold) {
+		scope, err := parseBandwidthScope(scopeKey)
+		if err != nil {
+			general.Warningf("skip invalid healthy NIC scope key %q: %v", scopeKey, err)
+			continue
+		}
+		evaluation, met := state.met(
+			conf.NICBandwidthUtilizationThreshold,
+			conf.NICBandwidthContinuousMetThreshold,
+			conf.NICBandwidthRingMetThreshold,
+		)
+		if !met {
 			continue
 		}
 
@@ -287,6 +296,8 @@ func (n *nicEvictionPlugin) ThresholdMet(_ context.Context, req *pluginapi.GetTh
 			EvictionScope:     formatBandwidthScope(scope),
 		}
 		if bestResp == nil || isBandwidthPressureMoreSevere(scope, evaluation, bestScope, bestEvaluation) {
+			general.Infof("update best bandwidth eviction scope to %s with utilization %.4f, current hits %d, consecutive hits %d",
+				resp.EvictionScope, evaluation.lastUtilization, evaluation.currentHits, evaluation.consecutiveHits)
 			bestResp = resp
 			bestScope = scope
 			bestEvaluation = evaluation
@@ -317,14 +328,8 @@ func (n *nicEvictionPlugin) GetTopEvictionPods(_ context.Context, req *pluginapi
 	if conf == nil || !conf.EnableNICBandwidthEviction {
 		return &pluginapi.GetTopEvictionPodsResponse{}, nil
 	}
-	if n.metricQuerier == nil {
-		n.metricQuerier = newMetaServerBandwidthMetricQuerier(n.metaServer)
-	}
-	if n.metricQuerier == nil {
-		return &pluginapi.GetTopEvictionPodsResponse{}, nil
-	}
 
-	// Pod usage is currently TCP-only because UDP container BPS is not exposed yet.
+	// currently we only take TCP into account.
 	candidatePods := make([]*v1.Pod, 0, len(req.ActivePods))
 	usageSnapshot := make(map[string]float64, len(req.ActivePods))
 	for _, pod := range req.ActivePods {
@@ -336,7 +341,7 @@ func (n *nicEvictionPlugin) GetTopEvictionPods(_ context.Context, req *pluginapi
 		if !ok || podScope.netns != scope.netns || podScope.nic != scope.nic {
 			continue
 		}
-		usage, ok := n.metricQuerier.GetPodDirectionUsage(pod, scope.direction)
+		usage, ok := n.bandwidthMetricQuerier.GetPodDirectionUsage(pod, scope.direction)
 		if !ok {
 			continue
 		}
@@ -346,7 +351,7 @@ func (n *nicEvictionPlugin) GetTopEvictionPods(_ context.Context, req *pluginapi
 		usageSnapshot[podKey] = usage
 	}
 
-	if len(candidatePods) == 0 {
+	if len(candidatePods) <= 1 {
 		return &pluginapi.GetTopEvictionPodsResponse{}, nil
 	}
 
@@ -375,34 +380,41 @@ func (n *nicEvictionPlugin) GetTopEvictionPods(_ context.Context, req *pluginapi
 	return resp, nil
 }
 
-func (n *nicEvictionPlugin) pruneStaleBandwidthStates(activeScopes map[bandwidthScope]float64, now time.Time, retention time.Duration) {
-	if n == nil || n.bandwidthPressureState == nil {
+func (n *nicEvictionPlugin) pruneStaleBandwidthStates(activeScopes map[string]*bandwidthSample, retention time.Duration) {
+	if n == nil || n.healthyNICState == nil {
 		return
 	}
-	for scope, state := range n.bandwidthPressureState {
-		if _, ok := activeScopes[scope]; !ok {
-			delete(n.bandwidthPressureState, scope)
+	for scopeKey, state := range n.healthyNICState {
+		if _, ok := activeScopes[scopeKey]; !ok {
+			delete(n.healthyNICState, scopeKey)
 			continue
 		}
-		if !state.expired(now, retention) {
+		if !state.expired(retention) {
 			continue
 		}
-		delete(n.bandwidthPressureState, scope)
+		delete(n.healthyNICState, scopeKey)
 	}
 }
 
-func (n *nicEvictionPlugin) getOrCreateBandwidthState(scope bandwidthScope, ringSize int, now time.Time, retention time.Duration) *bandwidthPressureState {
+func (n *nicEvictionPlugin) getOrCreateHealthyNICState(scopeKey string, ringSize int) *bandwidthState {
 	if ringSize <= 0 {
 		ringSize = 1
 	}
-	if n.bandwidthPressureState == nil {
-		n.bandwidthPressureState = make(map[bandwidthScope]*bandwidthPressureState)
+	if n.healthyNICState == nil {
+		n.healthyNICState = make(map[string]*bandwidthState)
 	}
 
-	state, ok := n.bandwidthPressureState[scope]
-	if !ok || len(state.ring) != ringSize || state.expired(now, retention) {
-		state = &bandwidthPressureState{ring: make([]bandwidthSample, ringSize)}
-		n.bandwidthPressureState[scope] = state
+	state, ok := n.healthyNICState[scopeKey]
+	if !ok {
+		state = &bandwidthState{ring: make([]bandwidthSample, ringSize)}
+		n.healthyNICState[scopeKey] = state
+		return state
+	}
+
+	if len(state.ring) != ringSize {
+		state.ring = make([]bandwidthSample, ringSize)
+		state.nextIndex = 0
+		state.sampleCount = 0
 	}
 	return state
 }

--- a/pkg/agent/evictionmanager/plugin/network/network.go
+++ b/pkg/agent/evictionmanager/plugin/network/network.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 	"github.com/kubewharf/katalyst-core/pkg/util/native"
 	"github.com/kubewharf/katalyst-core/pkg/util/process"
 )
@@ -63,23 +64,32 @@ type nicEvictionPlugin struct {
 	mutex sync.RWMutex
 	// unhealthyNICState is a map from NIC name to the state of the NIC
 	unhealthyNICState map[string]*unhealthyNICState
+	// healthyNICState caches CNR NIC bandwidth capacity by eviction scope.
+	healthyNICState map[bandwidthScope]float64
 
-	emitter       metrics.MetricEmitter
-	pluginName    string
-	metaServer    *metaserver.MetaServer
-	dynamicConfig *dynamic.DynamicAgentConfiguration
+	emitter                  metrics.MetricEmitter
+	pluginName               string
+	metaServer               *metaserver.MetaServer
+	dynamicConfig            *dynamic.DynamicAgentConfiguration
+	podSaleModeAnnotationKey string
+	bandwidthPressureState   map[bandwidthScope]*bandwidthPressureState
+	metricQuerier            BandwidthMetricQuerier
 }
 
 func NewNICEvictionPlugin(_ *client.GenericClientSet, _ events.EventRecorder,
 	metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter, conf *config.Configuration,
 ) plugin.EvictionPlugin {
 	return &nicEvictionPlugin{
-		StopControl:       process.NewStopControl(time.Time{}),
-		unhealthyNICState: make(map[string]*unhealthyNICState),
-		emitter:           emitter,
-		pluginName:        EvictionPluginNameNetwork,
-		metaServer:        metaServer,
-		dynamicConfig:     conf.DynamicAgentConfiguration,
+		StopControl:              process.NewStopControl(time.Time{}),
+		unhealthyNICState:        make(map[string]*unhealthyNICState),
+		healthyNICState:          make(map[bandwidthScope]float64),
+		emitter:                  emitter,
+		pluginName:               EvictionPluginNameNetwork,
+		metaServer:               metaServer,
+		dynamicConfig:            conf.DynamicAgentConfiguration,
+		podSaleModeAnnotationKey: conf.GenericConfiguration.PodSaleModeAnnotationKey,
+		bandwidthPressureState:   make(map[bandwidthScope]*bandwidthPressureState),
+		metricQuerier:            newMetaServerBandwidthMetricQuerier(metaServer),
 	}
 }
 
@@ -93,19 +103,311 @@ func (n *nicEvictionPlugin) Name() string {
 
 func (n *nicEvictionPlugin) Start() {
 	general.RegisterHeartbeatCheck(EvictionPluginNameNetwork, healthCheckTimeout, general.HealthzCheckStateNotReady, healthCheckTimeout)
-	go wait.UntilWithContext(context.TODO(), n.syncUnhealthyNICState, time.Second*10)
+	go wait.UntilWithContext(context.TODO(), n.syncNICState, time.Second*10)
 }
 
-func (n *nicEvictionPlugin) ThresholdMet(_ context.Context, _ *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
-	return &pluginapi.ThresholdMetResponse{
-		MetType: pluginapi.ThresholdMetType_NOT_MET,
-	}, nil
+// Shared NIC state lifecycle.
+func (n *nicEvictionPlugin) syncNICState(ctx context.Context) {
+	var err error
+	defer func() {
+		_ = general.UpdateHealthzStateByError(EvictionPluginNameNetwork, err)
+	}()
+
+	if n == nil || n.metaServer == nil {
+		err = fmt.Errorf("nil network eviction plugin or metaserver")
+		return
+	}
+
+	getCNR, err := n.metaServer.GetCNR(ctx)
+	if err != nil {
+		klog.Errorf("Failed to get CNR: %v", err)
+		return
+	}
+	if getCNR == nil {
+		err = fmt.Errorf("nil CNR")
+		return
+	}
+
+	healthyNICZone, unhealthyNICZone := getNICZones(getCNR.Status.TopologyZone)
+	now := time.Now()
+
+	n.syncHealthyNICState(healthyNICZone, now)
+	n.syncUnHealthyNICState(unhealthyNICZone, now)
 }
 
-func (n *nicEvictionPlugin) GetTopEvictionPods(_ context.Context, _ *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error) {
-	return &pluginapi.GetTopEvictionPodsResponse{}, nil
+func (n *nicEvictionPlugin) syncHealthyNICState(healthyNICZone map[string]float64, now time.Time) {
+	healthyNICState := make(map[bandwidthScope]float64, len(healthyNICZone)*2)
+	for identifier, capacity := range healthyNICZone {
+		netns, nic, ok := machine.ParseNICIdentifier(identifier)
+		if !ok {
+			continue
+		}
+		for _, direction := range []string{bandwidthDirectionRX, bandwidthDirectionTX} {
+			healthyNICState[bandwidthScope{
+				netns:     netns,
+				nic:       nic,
+				direction: direction,
+			}] = capacity
+		}
+	}
+
+	conf := (*eviction.NetworkEvictionConfiguration)(nil)
+	if n != nil && n.dynamicConfig != nil {
+		conf = n.dynamicConfig.GetDynamicConfiguration().NetworkEvictionConfiguration
+	}
+	if n != nil && n.metricQuerier == nil {
+		n.metricQuerier = newMetaServerBandwidthMetricQuerier(n.metaServer)
+	}
+
+	type bandwidthObservation struct {
+		scope        bandwidthScope
+		bps          float64
+		capacityMbps float64
+	}
+	observations := make([]bandwidthObservation, 0, len(healthyNICState))
+	if conf != nil && conf.EnableNICBandwidthEviction && n != nil && n.metricQuerier != nil {
+		for scope, capacity := range healthyNICState {
+			bps, ok := n.metricQuerier.GetBandwidthMetric(scope)
+			if !ok || capacity <= 0 {
+				continue
+			}
+			observations = append(observations, bandwidthObservation{
+				scope:        scope,
+				bps:          bps,
+				capacityMbps: capacity,
+			})
+		}
+	}
+
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	n.healthyNICState = healthyNICState
+	n.pruneStaleBandwidthStates(healthyNICState, now, bandwidthPressureStateRetention)
+	if conf == nil || !conf.EnableNICBandwidthEviction {
+		return
+	}
+	for _, observation := range observations {
+		state := n.getOrCreateBandwidthState(observation.scope, conf.NICBandwidthRingSize, now, bandwidthPressureStateRetention)
+		state.observe(observation.bps, observation.capacityMbps, now)
+	}
 }
 
+func (n *nicEvictionPlugin) syncUnHealthyNICState(unhealthyNICZone map[string]v1alpha1.TopologyZone, now time.Time) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	if n.unhealthyNICState == nil {
+		n.unhealthyNICState = make(map[string]*unhealthyNICState)
+	}
+	for nic := range unhealthyNICZone {
+		if _, ok := n.unhealthyNICState[nic]; !ok {
+			n.unhealthyNICState[nic] = &unhealthyNICState{
+				lastUnhealthyTime: now,
+				nicZone:           unhealthyNICZone[nic],
+			}
+		} else {
+			n.unhealthyNICState[nic].nicZone = unhealthyNICZone[nic]
+		}
+		if n.emitter != nil {
+			_ = n.emitter.StoreInt64(metricsNameNetworkEvictionUnhealthyNIC, 1, metrics.MetricTypeNameRaw,
+				metrics.MetricTag{Key: "nic", Val: nic})
+		}
+	}
+
+	for nic := range n.unhealthyNICState {
+		if _, ok := unhealthyNICZone[nic]; !ok {
+			delete(n.unhealthyNICState, nic)
+		}
+	}
+}
+
+func (n *nicEvictionPlugin) getHealthyNICState() map[bandwidthScope]float64 {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+
+	result := make(map[bandwidthScope]float64, len(n.healthyNICState))
+	for scope, capacity := range n.healthyNICState {
+		result[scope] = capacity
+	}
+	return result
+}
+
+func (n *nicEvictionPlugin) getUnhealthyNICState() map[string]*unhealthyNICState {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+
+	result := make(map[string]*unhealthyNICState, len(n.unhealthyNICState))
+	for nic, state := range n.unhealthyNICState {
+		result[nic] = state
+	}
+	return result
+}
+
+// Bandwidth eviction flow.
+func (n *nicEvictionPlugin) ThresholdMet(_ context.Context, req *pluginapi.GetThresholdMetRequest) (*pluginapi.ThresholdMetResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetThresholdMet got nil request")
+	}
+	if n == nil || n.dynamicConfig == nil {
+		return &pluginapi.ThresholdMetResponse{MetType: pluginapi.ThresholdMetType_NOT_MET}, nil
+	}
+
+	conf := n.dynamicConfig.GetDynamicConfiguration().NetworkEvictionConfiguration
+	if conf == nil || !conf.EnableNICBandwidthEviction {
+		return &pluginapi.ThresholdMetResponse{MetType: pluginapi.ThresholdMetType_NOT_MET}, nil
+	}
+
+	var bestResp *pluginapi.ThresholdMetResponse
+	var bestScope bandwidthScope
+	var bestEvaluation bandwidthPressureEvaluation
+	now := time.Now()
+	bandwidthScopes := n.getHealthyNICState()
+
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	n.pruneStaleBandwidthStates(bandwidthScopes, now, bandwidthPressureStateRetention)
+
+	for scope := range bandwidthScopes {
+		state, ok := n.bandwidthPressureState[scope]
+		if !ok {
+			continue
+		}
+		evaluation := state.evaluate(conf.NICBandwidthUtilizationThreshold)
+		if !evaluation.met(conf.NICBandwidthContinuousMetThreshold, conf.NICBandwidthRingMetThreshold) {
+			continue
+		}
+
+		resp := &pluginapi.ThresholdMetResponse{
+			ThresholdValue:    conf.NICBandwidthUtilizationThreshold,
+			ObservedValue:     evaluation.lastUtilization,
+			ThresholdOperator: pluginapi.ThresholdOperator_GREATER_THAN,
+			MetType:           pluginapi.ThresholdMetType_HARD_MET,
+			EvictionScope:     formatBandwidthScope(scope),
+		}
+		if bestResp == nil || isBandwidthPressureMoreSevere(scope, evaluation, bestScope, bestEvaluation) {
+			bestResp = resp
+			bestScope = scope
+			bestEvaluation = evaluation
+		}
+	}
+
+	if bestResp == nil {
+		return &pluginapi.ThresholdMetResponse{MetType: pluginapi.ThresholdMetType_NOT_MET}, nil
+	}
+	return bestResp, nil
+}
+
+func (n *nicEvictionPlugin) GetTopEvictionPods(_ context.Context, req *pluginapi.GetTopEvictionPodsRequest) (*pluginapi.GetTopEvictionPodsResponse, error) {
+	if req == nil {
+		return nil, fmt.Errorf("GetTopEvictionPods got nil request")
+	}
+	if n == nil || n.dynamicConfig == nil || len(req.ActivePods) == 0 || req.TopN == 0 {
+		return &pluginapi.GetTopEvictionPodsResponse{}, nil
+	}
+
+	scope, err := parseBandwidthScope(req.EvictionScope)
+	if err != nil {
+		klog.Warningf("skip invalid bandwidth eviction scope %q: %v", req.EvictionScope, err)
+		return &pluginapi.GetTopEvictionPodsResponse{}, nil
+	}
+
+	conf := n.dynamicConfig.GetDynamicConfiguration().NetworkEvictionConfiguration
+	if conf == nil || !conf.EnableNICBandwidthEviction {
+		return &pluginapi.GetTopEvictionPodsResponse{}, nil
+	}
+	if n.metricQuerier == nil {
+		n.metricQuerier = newMetaServerBandwidthMetricQuerier(n.metaServer)
+	}
+	if n.metricQuerier == nil {
+		return &pluginapi.GetTopEvictionPodsResponse{}, nil
+	}
+
+	// Pod usage is currently TCP-only because UDP container BPS is not exposed yet.
+	candidatePods := make([]*v1.Pod, 0, len(req.ActivePods))
+	usageSnapshot := make(map[string]float64, len(req.ActivePods))
+	for _, pod := range req.ActivePods {
+		if pod == nil || !native.PodIsActive(pod) {
+			continue
+		}
+
+		podScope, ok := getPodBandwidthScope(pod, scope)
+		if !ok || podScope.netns != scope.netns || podScope.nic != scope.nic {
+			continue
+		}
+		usage, ok := n.metricQuerier.GetPodDirectionUsage(pod, scope.direction)
+		if !ok {
+			continue
+		}
+
+		podKey := native.GenerateUniqObjectUIDKey(pod)
+		candidatePods = append(candidatePods, pod)
+		usageSnapshot[podKey] = usage
+	}
+
+	if len(candidatePods) == 0 {
+		return &pluginapi.GetTopEvictionPodsResponse{}, nil
+	}
+
+	general.NewMultiSorter(
+		native.PodSaleModeCmpFunc(n.podSaleModeAnnotationKey),
+		func(i1, i2 interface{}) int {
+			leftUsage := usageSnapshot[native.GenerateUniqObjectUIDKey(i1.(*v1.Pod))]
+			rightUsage := usageSnapshot[native.GenerateUniqObjectUIDKey(i2.(*v1.Pod))]
+			return general.CmpFloat64(leftUsage, rightUsage)
+		},
+		native.PodUniqKeyCmpFunc,
+	).Sort(native.NewPodSourceImpList(candidatePods))
+
+	topN := general.MinUInt64(req.TopN, uint64(len(candidatePods)))
+	targets := make([]*v1.Pod, 0, int(topN))
+	for i := uint64(0); i < topN; i++ {
+		targets = append(targets, candidatePods[i])
+	}
+
+	resp := &pluginapi.GetTopEvictionPodsResponse{TargetPods: targets}
+	if conf.NICBandwidthGracePeriod > 0 {
+		resp.DeletionOptions = &pluginapi.DeletionOptions{
+			GracePeriodSeconds: conf.NICBandwidthGracePeriod,
+		}
+	}
+	return resp, nil
+}
+
+func (n *nicEvictionPlugin) pruneStaleBandwidthStates(activeScopes map[bandwidthScope]float64, now time.Time, retention time.Duration) {
+	if n == nil || n.bandwidthPressureState == nil {
+		return
+	}
+	for scope, state := range n.bandwidthPressureState {
+		if _, ok := activeScopes[scope]; !ok {
+			delete(n.bandwidthPressureState, scope)
+			continue
+		}
+		if !state.expired(now, retention) {
+			continue
+		}
+		delete(n.bandwidthPressureState, scope)
+	}
+}
+
+func (n *nicEvictionPlugin) getOrCreateBandwidthState(scope bandwidthScope, ringSize int, now time.Time, retention time.Duration) *bandwidthPressureState {
+	if ringSize <= 0 {
+		ringSize = 1
+	}
+	if n.bandwidthPressureState == nil {
+		n.bandwidthPressureState = make(map[bandwidthScope]*bandwidthPressureState)
+	}
+
+	state, ok := n.bandwidthPressureState[scope]
+	if !ok || len(state.ring) != ringSize || state.expired(now, retention) {
+		state = &bandwidthPressureState{ring: make([]bandwidthSample, ringSize)}
+		n.bandwidthPressureState[scope] = state
+	}
+	return state
+}
+
+// NIC health eviction flow.
 func (n *nicEvictionPlugin) GetEvictPods(ctx context.Context, request *pluginapi.GetEvictPodsRequest) (*pluginapi.GetEvictPodsResponse, error) {
 	dynamicConfig := n.dynamicConfig.GetDynamicConfiguration()
 	if !dynamicConfig.EnableNICHealthEviction {
@@ -132,7 +434,8 @@ func (n *nicEvictionPlugin) GetEvictPods(ctx context.Context, request *pluginapi
 	}, nil
 }
 
-func getUnhealthyNICZone(topologyZone []*v1alpha1.TopologyZone) map[string]v1alpha1.TopologyZone {
+func getNICZones(topologyZone []*v1alpha1.TopologyZone) (map[string]float64, map[string]v1alpha1.TopologyZone) {
+	healthy := make(map[string]float64)
 	unhealthy := make(map[string]v1alpha1.TopologyZone)
 	for _, zone := range topologyZone {
 		if zone == nil || zone.Type != v1alpha1.TopologyTypeSocket {
@@ -152,11 +455,13 @@ func getUnhealthyNICZone(topologyZone []*v1alpha1.TopologyZone) map[string]v1alp
 			bw, ok := (*nicZone.Resources.Allocatable)[apiconsts.ResourceNetBandwidth]
 			if !ok || bw.IsZero() {
 				unhealthy[nicZone.Name] = *nicZone
+				continue
 			}
+			healthy[nicZone.Name] = float64(bw.Value())
 		}
 	}
 
-	return unhealthy
+	return healthy, unhealthy
 }
 
 func (n *nicEvictionPlugin) getUnhealthyNICAllocationPods(
@@ -263,47 +568,4 @@ func (n *nicEvictionPlugin) getUnhealthyNICAllocationUIDsFromTopologyZone(
 	}
 
 	return zonePods
-}
-
-func (n *nicEvictionPlugin) syncUnhealthyNICState(ctx context.Context) {
-	var err error
-	defer func() {
-		_ = general.UpdateHealthzStateByError(EvictionPluginNameNetwork, err)
-	}()
-
-	getCNR, err := n.metaServer.GetCNR(ctx)
-	if err != nil {
-		klog.Errorf("Failed to get CNR: %v", err)
-		return
-	}
-
-	unHealthyNICZone := getUnhealthyNICZone(getCNR.Status.TopologyZone)
-
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
-
-	for nic := range unHealthyNICZone {
-		if _, ok := n.unhealthyNICState[nic]; !ok {
-			n.unhealthyNICState[nic] = &unhealthyNICState{
-				lastUnhealthyTime: time.Now(),
-				nicZone:           unHealthyNICZone[nic],
-			}
-		} else {
-			n.unhealthyNICState[nic].nicZone = unHealthyNICZone[nic]
-		}
-		_ = n.emitter.StoreInt64(metricsNameNetworkEvictionUnhealthyNIC, 1, metrics.MetricTypeNameRaw,
-			metrics.MetricTag{Key: "nic", Val: nic})
-	}
-
-	for nic := range n.unhealthyNICState {
-		if _, ok := unHealthyNICZone[nic]; !ok {
-			delete(n.unhealthyNICState, nic)
-		}
-	}
-}
-
-func (n *nicEvictionPlugin) getUnhealthyNICState() map[string]*unhealthyNICState {
-	n.mutex.RLock()
-	defer n.mutex.RUnlock()
-	return n.unhealthyNICState
 }

--- a/pkg/agent/evictionmanager/plugin/network/network_test.go
+++ b/pkg/agent/evictionmanager/plugin/network/network_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,22 +30,35 @@ import (
 	"github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
+	coreconsts "github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/cnr"
+	metametric "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	utilmetric "github.com/kubewharf/katalyst-core/pkg/util/metric"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
-func TestSyncUnhealthyNICState(t *testing.T) {
+const (
+	bandwidthTestLowBPS      = 1000 * 1000
+	bandwidthTestMediumBPS   = 6 * 1000 * 1000
+	bandwidthTestPressureBPS = 10 * 1000 * 1000
+)
+
+func TestSyncNICState(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name              string
 		cnr               *v1alpha1.CustomNodeResource
+		expectedHealthy   map[bandwidthScope]float64
 		expectedNICStates map[string]*unhealthyNICState
 	}{{
-		name: "add new unhealthy nic",
+		name: "sync healthy and unhealthy nics",
 		cnr: &v1alpha1.CustomNodeResource{
 			Status: v1alpha1.CustomNodeResourceStatus{
 				TopologyZone: []*v1alpha1.TopologyZone{{
@@ -57,9 +71,21 @@ func TestSyncUnhealthyNICState(t *testing.T) {
 								apiconsts.ResourceNetBandwidth: resource.MustParse("0"),
 							},
 						},
+					}, {
+						Name: "eth1",
+						Type: v1alpha1.TopologyTypeNIC,
+						Resources: v1alpha1.Resources{
+							Allocatable: &v1.ResourceList{
+								apiconsts.ResourceNetBandwidth: resource.MustParse("100"),
+							},
+						},
 					}},
 				}},
 			},
+		},
+		expectedHealthy: map[bandwidthScope]float64{
+			{netns: machine.DefaultNICNamespace, nic: "eth1", direction: bandwidthDirectionRX}: 100,
+			{netns: machine.DefaultNICNamespace, nic: "eth1", direction: bandwidthDirectionTX}: 100,
 		},
 		expectedNICStates: map[string]*unhealthyNICState{
 			"eth0": {nicZone: v1alpha1.TopologyZone{Name: "eth0"}},
@@ -71,6 +97,7 @@ func TestSyncUnhealthyNICState(t *testing.T) {
 				TopologyZone: []*v1alpha1.TopologyZone{},
 			},
 		},
+		expectedHealthy:   map[bandwidthScope]float64{},
 		expectedNICStates: map[string]*unhealthyNICState{},
 	}, {
 		name: "update nic zone allocation",
@@ -109,6 +136,7 @@ func TestSyncUnhealthyNICState(t *testing.T) {
 			t.Parallel()
 			plugin := &nicEvictionPlugin{
 				unhealthyNICState: make(map[string]*unhealthyNICState),
+				healthyNICState:   make(map[bandwidthScope]float64),
 				metaServer: &metaserver.MetaServer{
 					MetaAgent: &agent.MetaAgent{
 						CNRFetcher: &cnr.CNRFetcherStub{CNR: tt.cnr},
@@ -117,7 +145,14 @@ func TestSyncUnhealthyNICState(t *testing.T) {
 				emitter: metrics.DummyMetrics{},
 			}
 
-			plugin.syncUnhealthyNICState(context.TODO())
+			plugin.syncNICState(context.TODO())
+
+			require.Len(t, plugin.healthyNICState, len(tt.expectedHealthy))
+			for scope, expectedCapacity := range tt.expectedHealthy {
+				actualCapacity, exists := plugin.healthyNICState[scope]
+				require.True(t, exists, "expected healthy NIC scope %v not found", scope)
+				require.Equal(t, expectedCapacity, actualCapacity)
+			}
 
 			// Verify NIC states count
 			if len(plugin.unhealthyNICState) != len(tt.expectedNICStates) {
@@ -314,5 +349,1412 @@ func TestGetEvictPods(t *testing.T) {
 				t.Errorf("Expected %d evicted pods, got %d", tt.expectedEvicts, len(response.EvictPods))
 			}
 		})
+	}
+}
+
+func TestNICBandwidthEvictionThresholdMetFeatureDisabled(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: false,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+}
+
+func TestNICBandwidthEvictionThresholdMetContinuous(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+		NICBandwidthGracePeriod:            12,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	for i := 0; i < 2; i++ {
+		plugin.syncNICState(context.Background())
+		resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+			ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+		})
+		require.NoError(t, err)
+		require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+	}
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Zero(t, resp.GracePeriodSeconds)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetChecksHealthyNICWithoutPods(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetParsesScopeFromHealthyNICStateKey(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, nil, newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": nil,
+	}, "100"))
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetChoosesMoreSevereDirection(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+		NICBandwidthGracePeriod:            9,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+			"bandwidth/ns1/eth0/tx": {bps: bandwidthTestPressureBPS + 1000*1000, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/tx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetIgnoresMissingSpeed(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 0},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetMissingDirectionalMetric(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetPerNetNSIsolation(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "")
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "")
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestMediumBPS, speed: 100},
+			"bandwidth/ns2/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{
+		newBandwidthTestNIC("ns1", "eth0"),
+		newBandwidthTestNIC("ns2", "eth0"),
+	}, newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": {native.GenerateUniqObjectUIDKey(pod1)},
+		"ns2-eth0": {native.GenerateUniqObjectUIDKey(pod2)},
+	}, "100"))
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod1, pod2},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns2/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetUsesProductionMetricIdentifier(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	metricsFetcher := metametric.NewFakeMetricsFetcher(metrics.DummyMetrics{}).(*metametric.FakeMetricsFetcher)
+	metricsFetcher.SetNSNetworkMetric("ns1", "eth0", coreconsts.MetricNetReceiveBPS, utilmetric.MetricData{Value: bandwidthTestPressureBPS, Time: &now})
+
+	plugin := newBandwidthInjectedTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, metricsFetcher, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetUsesCNRCapacity(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	pod := newNetworkTestPod("default", "pod1", "uid1", "")
+	metricsFetcher := metametric.NewFakeMetricsFetcher(metrics.DummyMetrics{}).(*metametric.FakeMetricsFetcher)
+	metricsFetcher.SetNSNetworkMetric("ns1", "eth0", coreconsts.MetricNetReceiveBPS, utilmetric.MetricData{Value: bandwidthTestPressureBPS, Time: &now})
+
+	plugin := newBandwidthInjectedTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, metricsFetcher, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": {native.GenerateUniqObjectUIDKey(pod)},
+	}, "100"))
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetConvertsCNRMbpsToBytesPerSecond(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	pod := newNetworkTestPod("default", "pod1", "uid1", "")
+	metricsFetcher := metametric.NewFakeMetricsFetcher(metrics.DummyMetrics{}).(*metametric.FakeMetricsFetcher)
+	metricsFetcher.SetNSNetworkMetric("ns1", "eth0", coreconsts.MetricNetReceiveBPS, utilmetric.MetricData{Value: bandwidthTestLowBPS, Time: &now})
+
+	plugin := newBandwidthInjectedTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, metricsFetcher, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": {native.GenerateUniqObjectUIDKey(pod)},
+	}, "100"))
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+}
+
+func TestNICBandwidthEvictionThresholdMetSkipsUnhealthyCNRNIC(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	pod := newNetworkTestPod("default", "pod1", "uid1", "")
+	metricsFetcher := metametric.NewFakeMetricsFetcher(metrics.DummyMetrics{}).(*metametric.FakeMetricsFetcher)
+	metricsFetcher.SetNSNetworkMetric("ns1", "eth0", coreconsts.MetricNetReceiveBPS, utilmetric.MetricData{Value: bandwidthTestPressureBPS, Time: &now})
+
+	plugin := newBandwidthInjectedTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, metricsFetcher, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": {native.GenerateUniqObjectUIDKey(pod)},
+	}, "0"))
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+}
+
+func TestNICBandwidthEvictionThresholdMetLatestFourOfSixSamples(t *testing.T) {
+	t.Parallel()
+
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestLowBPS, speed: 100},
+		},
+	}
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 5,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	samples := []float64{bandwidthTestPressureBPS, bandwidthTestLowBPS, bandwidthTestPressureBPS, bandwidthTestLowBPS, bandwidthTestPressureBPS, bandwidthTestPressureBPS}
+	for i, sample := range samples {
+		querier.deviceMetrics["bandwidth/ns1/eth0/rx"] = fakeNICMetric{bps: sample, speed: 100}
+		plugin.syncNICState(context.Background())
+		resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+			ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+		})
+		require.NoError(t, err)
+		if i < len(samples)-1 {
+			require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+			continue
+		}
+		require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+		require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+	}
+}
+
+func TestNICBandwidthEvictionThresholdMetRecalculatesHistoryAfterThresholdChange(t *testing.T) {
+	t.Parallel()
+
+	conf := &eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}
+	plugin := newBandwidthTestPlugin(conf, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: 9 * 1000 * 1000, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	for i := 0; i < 2; i++ {
+		plugin.syncNICState(context.Background())
+		resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+		require.NoError(t, err)
+		require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+	}
+
+	conf.NICBandwidthUtilizationThreshold = 0.7
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", resp.EvictionScope)
+}
+
+func TestNICBandwidthEvictionThresholdMetUsesSampledCapacityAfterCapacityChange(t *testing.T) {
+	t.Parallel()
+
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": nil,
+	}, "200"))
+
+	for i := 0; i < 2; i++ {
+		plugin.syncNICState(context.Background())
+		resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+		require.NoError(t, err)
+		require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+	}
+
+	plugin.metaServer.MetaAgent.CNRFetcher.(*cnr.CNRFetcherStub).CNR = newBandwidthTestCNRWithCapacity(map[string][]string{
+		"ns1-eth0": nil,
+	}, "100")
+	plugin.syncNICState(context.Background())
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+}
+
+func TestNICBandwidthEvictionThresholdMetKeepsHistoryWithoutActivePods(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	for i := 0; i < 2; i++ {
+		plugin.syncNICState(context.Background())
+		resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+			ActivePods: []*v1.Pod{pod1},
+		})
+		require.NoError(t, err)
+		require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+	}
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	plugin.syncNICState(context.Background())
+	resp, err = plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod2},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	state := plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}]
+	require.NotNil(t, state)
+	evaluation := state.evaluate(0.75)
+	require.Equal(t, 4, evaluation.consecutiveHits)
+}
+
+func TestNICBandwidthEvictionThresholdMetKeepsHistoryAfterPodSwitch(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	for i := 0; i < 2; i++ {
+		plugin.syncNICState(context.Background())
+		resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+			ActivePods: []*v1.Pod{pod1},
+		})
+		require.NoError(t, err)
+		require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+	}
+
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod2},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	state := plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}]
+	require.NotNil(t, state)
+	evaluation := state.evaluate(0.75)
+	require.Equal(t, 3, evaluation.consecutiveHits)
+}
+
+func TestNICBandwidthEvictionThresholdMetResetsExpiredState(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+	oldObservedAt := time.Now().Add(-10 * time.Minute)
+	plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}] = &bandwidthPressureState{
+		ring: []bandwidthSample{
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
+			{},
+			{},
+		},
+		nextIndex:   4,
+		sampleCount: 4,
+	}
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
+	state := plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}]
+	require.NotNil(t, state)
+	evaluation := state.evaluate(0.75)
+	require.Equal(t, 1, evaluation.currentHits)
+	require.Equal(t, 1, evaluation.consecutiveHits)
+}
+
+func TestNICBandwidthEvictionThresholdMetPrunesStaleState(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+	plugin.bandwidthPressureState[bandwidthScope{netns: "stale", nic: "eth0", direction: bandwidthDirectionRX}] = &bandwidthPressureState{
+		ring: []bandwidthSample{{
+			bps:          bandwidthTestPressureBPS,
+			capacityMbps: 100,
+			observedAt:   time.Now().Add(-10 * time.Minute),
+		}, {}, {}, {}, {}, {}},
+		sampleCount: 1,
+	}
+
+	plugin.syncNICState(context.Background())
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.NotContains(t, plugin.bandwidthPressureState, bandwidthScope{netns: "stale", nic: "eth0", direction: bandwidthDirectionRX})
+}
+
+func TestNICBandwidthEvictionThresholdMetUsesMetricsCollectedBySyncNICState(t *testing.T) {
+	t.Parallel()
+
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+			"bandwidth/ns1/eth0/tx": {bps: 0, speed: 100},
+		},
+	}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+	querier.bandwidthMetricCallCount = 0
+	plugin.bandwidthPressureState = map[bandwidthScope]*bandwidthPressureState{}
+
+	plugin.syncNICState(context.Background())
+	require.Equal(t, 2, querier.bandwidthMetricCallCount)
+
+	scope := bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}
+	state := plugin.bandwidthPressureState[scope]
+	require.NotNil(t, state)
+	require.Equal(t, 1, state.sampleCount)
+
+	querier.deviceMetrics["bandwidth/ns1/eth0/rx"] = fakeNICMetric{bps: 0, speed: 100}
+	beforeThresholdCall := querier.bandwidthMetricCallCount
+
+	resp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
+	require.Equal(t, beforeThresholdCall, querier.bandwidthMetricCallCount)
+}
+
+func TestNICHealthEvictionGetEvictPodsDoesNotTouchBandwidthMetrics(t *testing.T) {
+	t.Parallel()
+
+	pod := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	pod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod.UID): {
+				"c1": {bandwidthDirectionRX: 90},
+			},
+		},
+	}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICHealthEviction:            false,
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+		NICBandwidthGracePeriod:            11,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	getEvictResp, err := plugin.GetEvictPods(context.Background(), &pluginapi.GetEvictPodsRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Empty(t, getEvictResp.EvictPods)
+	require.Zero(t, querier.bandwidthMetricCallCount)
+	require.Empty(t, querier.directionUsageCalls)
+}
+
+func TestNICBandwidthEvictionCoexistenceHealthMissBandwidthHit(t *testing.T) {
+	t.Parallel()
+
+	pod := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	pod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod.UID): {
+				"c1": {bandwidthDirectionRX: 90},
+			},
+		},
+	}
+
+	requests := v1.ResourceList{
+		apiconsts.ResourceNetBandwidth: resource.MustParse("10G"),
+	}
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICHealthEviction:            true,
+		EnableNICBandwidthEviction:         true,
+		NICUnhealthyToleranceDuration:      time.Minute,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+		NICBandwidthGracePeriod:            11,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+	plugin.unhealthyNICState = map[string]*unhealthyNICState{
+		"eth0": {
+			lastUnhealthyTime: time.Now(),
+			nicZone: v1alpha1.TopologyZone{
+				Name: "eth0",
+				Type: v1alpha1.TopologyTypeNIC,
+				Allocations: []*v1alpha1.Allocation{{
+					Consumer: native.GenerateUniqObjectUIDKey(pod),
+					Requests: &requests,
+				}},
+			},
+		},
+	}
+
+	getEvictResp, err := plugin.GetEvictPods(context.Background(), &pluginapi.GetEvictPodsRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Empty(t, getEvictResp.EvictPods)
+	require.Zero(t, querier.bandwidthMetricCallCount)
+	require.Empty(t, querier.directionUsageCalls)
+
+	plugin.syncNICState(context.Background())
+	thresholdResp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, thresholdResp.MetType)
+	require.Equal(t, "bandwidth/ns1/eth0/rx", thresholdResp.EvictionScope)
+	require.Zero(t, thresholdResp.GracePeriodSeconds)
+
+	topResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod},
+		TopN:          1,
+		EvictionScope: thresholdResp.EvictionScope,
+	})
+	require.NoError(t, err)
+	require.Len(t, topResp.TargetPods, 1)
+	require.Equal(t, "pod1", topResp.TargetPods[0].Name)
+	require.NotNil(t, topResp.DeletionOptions)
+	require.EqualValues(t, 11, topResp.DeletionOptions.GracePeriodSeconds)
+}
+
+func TestNICBandwidthEvictionCoexistenceDefaultNetNSScope(t *testing.T) {
+	t.Parallel()
+
+	pod := newNetworkTestPod("default", "pod1", "uid1", "eth0")
+	pod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth//eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
+		},
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod.UID): {
+				"c1": {bandwidthDirectionRX: 90},
+			},
+		},
+	}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 1,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+		NICBandwidthGracePeriod:            3,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC(machine.DefaultNICNamespace, "eth0")}, nil)
+
+	plugin.syncNICState(context.Background())
+	thresholdResp, err := plugin.ThresholdMet(context.Background(), &pluginapi.GetThresholdMetRequest{
+		ActivePods: []*v1.Pod{pod},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, thresholdResp.MetType)
+	require.Equal(t, "bandwidth//eth0/rx", thresholdResp.EvictionScope)
+
+	topResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod},
+		TopN:          1,
+		EvictionScope: thresholdResp.EvictionScope,
+	})
+	require.NoError(t, err)
+	require.Len(t, topResp.TargetPods, 1)
+	require.Equal(t, "pod1", topResp.TargetPods[0].Name)
+	require.NotNil(t, topResp.DeletionOptions)
+	require.EqualValues(t, 3, topResp.DeletionOptions.GracePeriodSeconds)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsAggregatesByPod(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	pod1.Spec.Containers = []v1.Container{{Name: "c1"}, {Name: "c2"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod3 := newNetworkTestPod("default", "pod3", "uid3", "ns1-eth0")
+	pod3.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+		NICBandwidthGracePeriod:    7,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod1.UID): {
+				"c1": {bandwidthDirectionRX: 70, bandwidthDirectionTX: 10},
+				"c2": {bandwidthDirectionRX: 50, bandwidthDirectionTX: 15},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 100, bandwidthDirectionTX: 80},
+			},
+			string(pod3.UID): {
+				"c1": {bandwidthDirectionRX: 40, bandwidthDirectionTX: 120},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod1, pod2, pod3},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	require.Equal(t, "pod1", resp.TargetPods[0].Name)
+	require.Equal(t, "pod2", resp.TargetPods[1].Name)
+	require.NotNil(t, resp.DeletionOptions)
+	require.EqualValues(t, 7, resp.DeletionOptions.GracePeriodSeconds)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsAssignsPodWithoutAnnotationToDefaultNS(t *testing.T) {
+	t.Parallel()
+
+	defaultPod := newNetworkTestPod("default", "default-pod", "uid1", "")
+	defaultPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	nsPod := newNetworkTestPod("default", "ns-pod", "uid2", "ns1-eth0")
+	nsPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(defaultPod.UID): {
+				"c1": {bandwidthDirectionRX: 120},
+			},
+			string(nsPod.UID): {
+				"c1": {bandwidthDirectionRX: 200},
+			},
+		},
+	}, []machine.InterfaceInfo{
+		newBandwidthTestNIC(machine.DefaultNICNamespace, "eth0"),
+		newBandwidthTestNIC("ns1", "eth0"),
+	}, nil)
+
+	defaultResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{defaultPod, nsPod},
+		TopN:          2,
+		EvictionScope: "bandwidth//eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, defaultResp.TargetPods, 1)
+	require.Equal(t, "default-pod", defaultResp.TargetPods[0].Name)
+
+	nsResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{defaultPod, nsPod},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, nsResp.TargetPods, 1)
+	require.Equal(t, "ns-pod", nsResp.TargetPods[0].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsSortsBySaleModeBeforeUsage(t *testing.T) {
+	t.Parallel()
+
+	spotPod := newNetworkTestPod("default", "spot-pod", "uid1", "ns1-eth0")
+	spotPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	spotPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeSpot
+	scheduledPod := newNetworkTestPod("default", "scheduled-pod", "uid2", "ns1-eth0")
+	scheduledPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	scheduledPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeScheduled
+	reservedPod := newNetworkTestPod("default", "reserved-pod", "uid3", "ns1-eth0")
+	reservedPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	reservedPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeReserved
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(spotPod.UID): {
+				"c1": {bandwidthDirectionRX: 50},
+			},
+			string(scheduledPod.UID): {
+				"c1": {bandwidthDirectionRX: 500},
+			},
+			string(reservedPod.UID): {
+				"c1": {bandwidthDirectionRX: 1000},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{reservedPod, scheduledPod, spotPod},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	require.Equal(t, "spot-pod", resp.TargetPods[0].Name)
+	require.Equal(t, "scheduled-pod", resp.TargetPods[1].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsPrefersScheduledOverReserved(t *testing.T) {
+	t.Parallel()
+
+	scheduledPod := newNetworkTestPod("default", "scheduled-pod", "uid1", "ns1-eth0")
+	scheduledPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	scheduledPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeScheduled
+	reservedPod := newNetworkTestPod("default", "reserved-pod", "uid2", "ns1-eth0")
+	reservedPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	reservedPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeReserved
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(scheduledPod.UID): {
+				"c1": {bandwidthDirectionRX: 80},
+			},
+			string(reservedPod.UID): {
+				"c1": {bandwidthDirectionRX: 800},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{reservedPod, scheduledPod},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	require.Equal(t, "scheduled-pod", resp.TargetPods[0].Name)
+	require.Equal(t, "reserved-pod", resp.TargetPods[1].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsTreatsMissingAndInvalidSaleModeAsDefault(t *testing.T) {
+	t.Parallel()
+
+	missingPod := newNetworkTestPod("default", "missing-pod", "uid1", "ns1-eth0")
+	missingPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	invalidPod := newNetworkTestPod("default", "invalid-pod", "uid2", "ns1-eth0")
+	invalidPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	invalidPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = "wrong-value"
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(missingPod.UID): {
+				"c1": {bandwidthDirectionRX: 120},
+			},
+			string(invalidPod.UID): {
+				"c1": {bandwidthDirectionRX: 200},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{missingPod, invalidPod},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	require.Equal(t, "invalid-pod", resp.TargetPods[0].Name)
+	require.Equal(t, "missing-pod", resp.TargetPods[1].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsUsesConfigurableSaleModeAnnotationKey(t *testing.T) {
+	t.Parallel()
+
+	bytedPod := newNetworkTestPod("default", "byted-pod", "uid1", "ns1-eth0")
+	bytedPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	bytedPod.Annotations["bytedance.quota.salemode"] = apiconsts.PodSaleModeSpot
+	apiPod := newNetworkTestPod("default", "api-pod", "uid2", "ns1-eth0")
+	apiPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	apiPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeSpot
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(bytedPod.UID): {
+				"c1": {bandwidthDirectionRX: 80},
+			},
+			string(apiPod.UID): {
+				"c1": {bandwidthDirectionRX: 200},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+	plugin.podSaleModeAnnotationKey = "bytedance.quota.salemode"
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{apiPod, bytedPod},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	require.Equal(t, "byted-pod", resp.TargetPods[0].Name)
+	require.Equal(t, "api-pod", resp.TargetPods[1].Name)
+}
+
+func TestNewNICEvictionPluginUsesConfiguredSaleModeAnnotationKey(t *testing.T) {
+	t.Parallel()
+
+	conf := config.NewConfiguration()
+	conf.GenericConfiguration.PodSaleModeAnnotationKey = "bytedance.quota.salemode"
+
+	plugin := NewNICEvictionPlugin(nil, nil, nil, metrics.DummyMetrics{}, conf)
+	nicPlugin, ok := plugin.(*nicEvictionPlugin)
+	require.True(t, ok)
+	require.Equal(t, "bytedance.quota.salemode", nicPlugin.podSaleModeAnnotationKey)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsNilRequest(t *testing.T) {
+	t.Parallel()
+
+	resp, err := (&nicEvictionPlugin{}).GetTopEvictionPods(context.Background(), nil)
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsAggregatesByPodTX(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	pod1.Spec.Containers = []v1.Container{{Name: "c1"}, {Name: "c2"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod1.UID): {
+				"c1": {bandwidthDirectionRX: 120, bandwidthDirectionTX: 20},
+				"c2": {bandwidthDirectionRX: 10, bandwidthDirectionTX: 35},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 5, bandwidthDirectionTX: 50},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod1, pod2},
+		TopN:          1,
+		EvictionScope: "bandwidth/ns1/eth0/tx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 1)
+	require.Equal(t, "pod1", resp.TargetPods[0].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsTieUsesNativePodUniqKeyOrdering(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newNetworkTestPod("default-a", "pod-a", "uid-z", "ns1-eth0")
+	pod1.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod2 := newNetworkTestPod("default-b", "pod-b", "uid-a", "ns1-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod1.UID): {
+				"c1": {bandwidthDirectionRX: 60},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 60},
+			},
+		},
+	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod1, pod2},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	expectedFirst, expectedSecond := pod1, pod2
+	if native.PodUniqKeyCmpFunc(pod2, pod1) < 0 {
+		expectedFirst, expectedSecond = pod2, pod1
+	}
+	require.Equal(t, native.GenerateUniqObjectNameKey(expectedFirst), native.GenerateUniqObjectNameKey(resp.TargetPods[0]))
+	require.Equal(t, native.GenerateUniqObjectNameKey(expectedSecond), native.GenerateUniqObjectNameKey(resp.TargetPods[1]))
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsReadsDirectionUsageOnce(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	pod1.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod3 := newNetworkTestPod("default", "pod3", "uid3", "ns1-eth0")
+	pod3.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	querier := &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod1.UID): {"c1": {bandwidthDirectionRX: 100}},
+			string(pod2.UID): {"c1": {bandwidthDirectionRX: 80}},
+			string(pod3.UID): {"c1": {bandwidthDirectionRX: 60}},
+		},
+	}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod1, pod2, pod3},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 2)
+	require.Equal(t, "pod1", resp.TargetPods[0].Name)
+	require.Equal(t, "pod2", resp.TargetPods[1].Name)
+	require.Equal(t, 1, querier.directionUsageCalls[string(pod1.UID)][bandwidthDirectionRX])
+	require.Equal(t, 1, querier.directionUsageCalls[string(pod2.UID)][bandwidthDirectionRX])
+	require.Equal(t, 1, querier.directionUsageCalls[string(pod3.UID)][bandwidthDirectionRX])
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsSkipsPodWhenUsageReadFails(t *testing.T) {
+	t.Parallel()
+
+	stablePod := newNetworkTestPod("default", "stable-pod", "uid1", "ns1-eth0")
+	stablePod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	flakyPod := newNetworkTestPod("default", "flaky-pod", "uid2", "ns1-eth0")
+	flakyPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	querier := &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(stablePod.UID): {"c1": {bandwidthDirectionRX: 80}},
+			string(flakyPod.UID):  {"c1": {bandwidthDirectionRX: 120}},
+		},
+		failDirectionUsageAfter: map[string]map[string]int{
+			string(flakyPod.UID): {bandwidthDirectionRX: 0},
+		},
+	}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{stablePod, flakyPod},
+		TopN:          2,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 1)
+	require.Equal(t, "stable-pod", resp.TargetPods[0].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsInvalidScope(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")},
+		TopN:          1,
+		EvictionScope: "bandwidth/ns1/eth0",
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.TargetPods)
+	require.Nil(t, resp.DeletionOptions)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsBondPath(t *testing.T) {
+	t.Parallel()
+
+	bondPod := newNetworkTestPod("default", "bond-pod", "uid1", "ns1-bond0")
+	bondPod.Spec.Containers = []v1.Container{{Name: "c1"}, {Name: "c2"}}
+	otherPod := newNetworkTestPod("default", "other-pod", "uid2", "ns1-eth0")
+	otherPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(bondPod.UID): {
+				"c1": {bandwidthDirectionRX: 40},
+				"c2": {bandwidthDirectionRX: 50},
+			},
+			string(otherPod.UID): {
+				"c1": {bandwidthDirectionRX: 100},
+			},
+		},
+	}, []machine.InterfaceInfo{
+		newBandwidthTestNIC("ns1", "bond0"),
+		newBandwidthTestNIC("ns1", "eth0"),
+	}, newBandwidthTestCNR(map[string][]string{
+		"ns1-bond0": nil,
+	}))
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{bondPod, otherPod},
+		TopN:          1,
+		EvictionScope: "bandwidth/ns1/bond0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 1)
+	require.Equal(t, "bond-pod", resp.TargetPods[0].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsMultiNetNSIsolation(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
+	pod1.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns2-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+	}, &fakeBandwidthMetricQuerier{
+		containerDirectionUsage: map[string]map[string]map[string]float64{
+			string(pod1.UID): {
+				"c1": {bandwidthDirectionRX: 200},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 80},
+			},
+		},
+	}, []machine.InterfaceInfo{
+		newBandwidthTestNIC("ns1", "eth0"),
+		newBandwidthTestNIC("ns2", "eth0"),
+	}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{pod1, pod2},
+		TopN:          1,
+		EvictionScope: "bandwidth/ns2/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TargetPods, 1)
+	require.Equal(t, "pod2", resp.TargetPods[0].Name)
+}
+
+func TestNICBandwidthEvictionGetTopEvictionPodsEmptyCandidates(t *testing.T) {
+	t.Parallel()
+
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction: true,
+		NICBandwidthGracePeriod:    5,
+	}, &fakeBandwidthMetricQuerier{}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+
+	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
+		ActivePods:    []*v1.Pod{newNetworkTestPod("default", "pod1", "uid1", "ns2-eth0")},
+		TopN:          1,
+		EvictionScope: "bandwidth/ns1/eth0/rx",
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.TargetPods)
+	require.Nil(t, resp.DeletionOptions)
+}
+
+type fakeNICMetric struct {
+	bps   float64
+	speed float64
+}
+
+type fakeBandwidthMetricQuerier struct {
+	deviceMetrics            map[string]fakeNICMetric
+	containerDirectionUsage  map[string]map[string]map[string]float64
+	bandwidthMetricCallCount int
+	directionUsageCalls      map[string]map[string]int
+	failDirectionUsageAfter  map[string]map[string]int
+}
+
+func (f *fakeBandwidthMetricQuerier) GetBandwidthMetric(scope bandwidthScope) (float64, bool) {
+	if f == nil {
+		return 0, false
+	}
+	f.bandwidthMetricCallCount++
+
+	metric, ok := f.deviceMetrics[formatBandwidthScope(scope)]
+	if !ok {
+		return 0, false
+	}
+
+	return metric.bps, true
+}
+
+func (f *fakeBandwidthMetricQuerier) GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool) {
+	if f == nil || pod == nil {
+		return 0, false
+	}
+	if f.directionUsageCalls == nil {
+		f.directionUsageCalls = make(map[string]map[string]int)
+	}
+	if f.directionUsageCalls[string(pod.UID)] == nil {
+		f.directionUsageCalls[string(pod.UID)] = make(map[string]int)
+	}
+	f.directionUsageCalls[string(pod.UID)][direction]++
+	if f.failDirectionUsageAfter != nil {
+		if directions, ok := f.failDirectionUsageAfter[string(pod.UID)]; ok {
+			if failAfter, ok := directions[direction]; ok && f.directionUsageCalls[string(pod.UID)][direction] > failAfter {
+				return 0, false
+			}
+		}
+	}
+
+	containers, ok := f.containerDirectionUsage[string(pod.UID)]
+	if !ok {
+		return 0, false
+	}
+
+	total := 0.0
+	found := false
+	for _, container := range pod.Spec.Containers {
+		usageByDirection, ok := containers[container.Name]
+		if !ok {
+			continue
+		}
+		usage, ok := usageByDirection[direction]
+		if !ok {
+			continue
+		}
+		total += usage
+		found = true
+	}
+
+	return total, found
+}
+
+func newBandwidthTestPlugin(conf *eviction.NetworkEvictionConfiguration, metricQuerier BandwidthMetricQuerier, interfaces []machine.InterfaceInfo, cnrObj *v1alpha1.CustomNodeResource) *nicEvictionPlugin {
+	return newBandwidthTestPluginWithMetaServer(conf, metricQuerier, nil, interfaces, cnrObj)
+}
+
+func newBandwidthInjectedTestPlugin(conf *eviction.NetworkEvictionConfiguration, metricsFetcher *metametric.FakeMetricsFetcher, interfaces []machine.InterfaceInfo, cnrObj *v1alpha1.CustomNodeResource) *nicEvictionPlugin {
+	return newBandwidthTestPluginWithMetaServer(conf, nil, metricsFetcher, interfaces, cnrObj)
+}
+
+func newBandwidthTestPluginWithMetaServer(conf *eviction.NetworkEvictionConfiguration, metricQuerier BandwidthMetricQuerier, metricsFetcher *metametric.FakeMetricsFetcher, interfaces []machine.InterfaceInfo, cnrObj *v1alpha1.CustomNodeResource) *nicEvictionPlugin {
+	dynamicConfig := dynamic.NewDynamicAgentConfiguration()
+	dynamicConfig.GetDynamicConfiguration().NetworkEvictionConfiguration = conf
+	if cnrObj == nil {
+		cnrObj = newBandwidthTestCNRFromInterfaces(interfaces, "100")
+	}
+
+	plugin := &nicEvictionPlugin{
+		dynamicConfig:            dynamicConfig,
+		unhealthyNICState:        make(map[string]*unhealthyNICState),
+		healthyNICState:          make(map[bandwidthScope]float64),
+		emitter:                  metrics.DummyMetrics{},
+		podSaleModeAnnotationKey: apiconsts.PodAnnotationSaleModeKey,
+		bandwidthPressureState:   map[bandwidthScope]*bandwidthPressureState{},
+		metricQuerier:            metricQuerier,
+		metaServer: &metaserver.MetaServer{MetaAgent: &agent.MetaAgent{
+			MetricsFetcher: metricsFetcher,
+			KatalystMachineInfo: &machine.KatalystMachineInfo{
+				ExtraNetworkInfo: &machine.ExtraNetworkInfo{Interface: interfaces},
+			},
+			CNRFetcher: &cnr.CNRFetcherStub{CNR: cnrObj},
+		}},
+	}
+	plugin.syncNICState(context.Background())
+	plugin.bandwidthPressureState = map[bandwidthScope]*bandwidthPressureState{}
+	if fakeQuerier, ok := metricQuerier.(*fakeBandwidthMetricQuerier); ok {
+		fakeQuerier.bandwidthMetricCallCount = 0
+	}
+	return plugin
+}
+
+func newBandwidthTestCNRFromInterfaces(interfaces []machine.InterfaceInfo, capacity string) *v1alpha1.CustomNodeResource {
+	allocations := make(map[string][]string, len(interfaces))
+	for _, iface := range interfaces {
+		allocations[machine.FormatNICIdentifier(iface.NSName, iface.Name)] = nil
+	}
+	return newBandwidthTestCNRWithCapacity(allocations, capacity)
+}
+
+func newBandwidthTestNIC(netns, nic string) machine.InterfaceInfo {
+	return machine.InterfaceInfo{
+		NetNSInfo: machine.NetNSInfo{NSName: netns},
+		Name:      nic,
+	}
+}
+
+func newBandwidthTestCNR(allocations map[string][]string) *v1alpha1.CustomNodeResource {
+	return newBandwidthTestCNRWithCapacity(allocations, "10G")
+}
+
+func newBandwidthTestCNRWithCapacity(allocations map[string][]string, capacity string) *v1alpha1.CustomNodeResource {
+	children := make([]*v1alpha1.TopologyZone, 0, len(allocations))
+	for identifier, consumers := range allocations {
+		zoneAllocations := make([]*v1alpha1.Allocation, 0, len(consumers))
+		for _, consumer := range consumers {
+			requests := v1.ResourceList{apiconsts.ResourceNetBandwidth: resource.MustParse("10G")}
+			zoneAllocations = append(zoneAllocations, &v1alpha1.Allocation{Consumer: consumer, Requests: &requests})
+		}
+		allocatable := v1.ResourceList{apiconsts.ResourceNetBandwidth: resource.MustParse(capacity)}
+		children = append(children, &v1alpha1.TopologyZone{
+			Name:        identifier,
+			Type:        v1alpha1.TopologyTypeNIC,
+			Resources:   v1alpha1.Resources{Allocatable: &allocatable},
+			Allocations: zoneAllocations,
+		})
+	}
+
+	return &v1alpha1.CustomNodeResource{Status: v1alpha1.CustomNodeResourceStatus{TopologyZone: []*v1alpha1.TopologyZone{{
+		Type:     v1alpha1.TopologyTypeSocket,
+		Children: children,
+	}}}}
+}
+
+func newNetworkTestPod(namespace, name, uid, nicIdentifier string) *v1.Pod {
+	annotations := map[string]string{}
+	if nicIdentifier != "" {
+		annotations[apiconsts.PodAnnotationNICSelectionResultKey] = nicIdentifier
+	}
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			UID:         types.UID(uid),
+			Annotations: annotations,
+		},
+		Status: v1.PodStatus{Phase: v1.PodRunning},
 	}
 }

--- a/pkg/agent/evictionmanager/plugin/network/network_test.go
+++ b/pkg/agent/evictionmanager/plugin/network/network_test.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 	pluginapi "github.com/kubewharf/katalyst-api/pkg/protocol/evictionplugin/v1alpha1"
-	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
 	coreconsts "github.com/kubewharf/katalyst-core/pkg/consts"
@@ -55,7 +55,7 @@ func TestSyncNICState(t *testing.T) {
 	tests := []struct {
 		name              string
 		cnr               *v1alpha1.CustomNodeResource
-		expectedHealthy   map[bandwidthScope]float64
+		expectedHealthy   map[string]float64
 		expectedNICStates map[string]*unhealthyNICState
 	}{{
 		name: "sync healthy and unhealthy nics",
@@ -83,9 +83,9 @@ func TestSyncNICState(t *testing.T) {
 				}},
 			},
 		},
-		expectedHealthy: map[bandwidthScope]float64{
-			{netns: machine.DefaultNICNamespace, nic: "eth1", direction: bandwidthDirectionRX}: 100,
-			{netns: machine.DefaultNICNamespace, nic: "eth1", direction: bandwidthDirectionTX}: 100,
+		expectedHealthy: map[string]float64{
+			formatBandwidthScope(bandwidthScope{netns: machine.DefaultNICNamespace, nic: "eth1", direction: bandwidthDirectionRX}): 100,
+			formatBandwidthScope(bandwidthScope{netns: machine.DefaultNICNamespace, nic: "eth1", direction: bandwidthDirectionTX}): 100,
 		},
 		expectedNICStates: map[string]*unhealthyNICState{
 			"eth0": {nicZone: v1alpha1.TopologyZone{Name: "eth0"}},
@@ -97,7 +97,7 @@ func TestSyncNICState(t *testing.T) {
 				TopologyZone: []*v1alpha1.TopologyZone{},
 			},
 		},
-		expectedHealthy:   map[bandwidthScope]float64{},
+		expectedHealthy:   map[string]float64{},
 		expectedNICStates: map[string]*unhealthyNICState{},
 	}, {
 		name: "update nic zone allocation",
@@ -134,9 +134,25 @@ func TestSyncNICState(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			dynamicConfig := dynamic.NewDynamicAgentConfiguration()
+			dynamicConfig.GetDynamicConfiguration().NetworkEvictionConfiguration = &eviction.NetworkEvictionConfiguration{
+				EnableNICBandwidthEviction: true,
+				NICBandwidthRingSize:       1,
+			}
+			deviceMetrics := make(map[string]fakeNICMetric, len(tt.expectedHealthy))
+			for scope, expectedCapacity := range tt.expectedHealthy {
+				deviceMetrics[scope] = fakeNICMetric{
+					bps:   convertMbpsToBytesPerSecond(expectedCapacity),
+					speed: expectedCapacity,
+				}
+			}
 			plugin := &nicEvictionPlugin{
 				unhealthyNICState: make(map[string]*unhealthyNICState),
-				healthyNICState:   make(map[bandwidthScope]float64),
+				healthyNICState:   make(map[string]*bandwidthState),
+				dynamicConfig:     dynamicConfig,
+				bandwidthMetricQuerier: &fakeBandwidthMetricQuerier{
+					deviceMetrics: deviceMetrics,
+				},
 				metaServer: &metaserver.MetaServer{
 					MetaAgent: &agent.MetaAgent{
 						CNRFetcher: &cnr.CNRFetcherStub{CNR: tt.cnr},
@@ -149,9 +165,12 @@ func TestSyncNICState(t *testing.T) {
 
 			require.Len(t, plugin.healthyNICState, len(tt.expectedHealthy))
 			for scope, expectedCapacity := range tt.expectedHealthy {
-				actualCapacity, exists := plugin.healthyNICState[scope]
+				actualState, exists := plugin.healthyNICState[scope]
 				require.True(t, exists, "expected healthy NIC scope %v not found", scope)
-				require.Equal(t, expectedCapacity, actualCapacity)
+				require.NotNil(t, actualState)
+				latest, ok := actualState.latestSample()
+				require.True(t, ok)
+				require.Equal(t, expectedCapacity, latest.capacityMbps)
 			}
 
 			// Verify NIC states count
@@ -477,6 +496,26 @@ func TestNICBandwidthEvictionThresholdMetChoosesMoreSevereDirection(t *testing.T
 	require.Equal(t, "bandwidth/ns1/eth0/tx", resp.EvictionScope)
 }
 
+func TestBandwidthStateMet(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	state := &bandwidthState{
+		ring: []bandwidthSample{
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: now.Add(-2 * time.Second)},
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: now.Add(-1 * time.Second)},
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: now},
+		},
+		nextIndex:   0,
+		sampleCount: 3,
+	}
+
+	evaluation, met := state.met(0.75, 3, 4)
+	require.True(t, met)
+	require.Equal(t, 3, evaluation.currentHits)
+	require.Equal(t, 3, evaluation.consecutiveHits)
+}
+
 func TestNICBandwidthEvictionThresholdMetIgnoresMissingSpeed(t *testing.T) {
 	t.Parallel()
 
@@ -798,7 +837,7 @@ func TestNICBandwidthEvictionThresholdMetKeepsHistoryWithoutActivePods(t *testin
 	})
 	require.NoError(t, err)
 	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
-	state := plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}]
+	state := plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX})]
 	require.NotNil(t, state)
 	evaluation := state.evaluate(0.75)
 	require.Equal(t, 4, evaluation.consecutiveHits)
@@ -836,7 +875,7 @@ func TestNICBandwidthEvictionThresholdMetKeepsHistoryAfterPodSwitch(t *testing.T
 	})
 	require.NoError(t, err)
 	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
-	state := plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}]
+	state := plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX})]
 	require.NotNil(t, state)
 	evaluation := state.evaluate(0.75)
 	require.Equal(t, 3, evaluation.consecutiveHits)
@@ -857,7 +896,7 @@ func TestNICBandwidthEvictionThresholdMetResetsExpiredState(t *testing.T) {
 		},
 	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
 	oldObservedAt := time.Now().Add(-10 * time.Minute)
-	plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}] = &bandwidthPressureState{
+	plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX})] = &bandwidthState{
 		ring: []bandwidthSample{
 			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
 			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
@@ -876,11 +915,49 @@ func TestNICBandwidthEvictionThresholdMetResetsExpiredState(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, pluginapi.ThresholdMetType_NOT_MET, resp.MetType)
-	state := plugin.bandwidthPressureState[bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}]
+	state := plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX})]
 	require.NotNil(t, state)
 	evaluation := state.evaluate(0.75)
 	require.Equal(t, 1, evaluation.currentHits)
 	require.Equal(t, 1, evaluation.consecutiveHits)
+}
+
+func TestNICBandwidthEvictionThresholdMetKeepsHistoryWhenMetricTimeWithinRetention(t *testing.T) {
+	t.Parallel()
+
+	oldObservedAt := time.Now().Add(-4 * time.Minute)
+	currentMetricTime := time.Now().Add(-1 * time.Minute)
+	querier := &fakeBandwidthMetricQuerier{
+		deviceMetrics: map[string]fakeNICMetric{
+			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100, observedAt: currentMetricTime},
+		},
+	}
+	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
+		EnableNICBandwidthEviction:         true,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
+	plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX})] = &bandwidthState{
+		ring: []bandwidthSample{
+			{bps: bandwidthTestPressureBPS, capacityMbps: 100, observedAt: oldObservedAt},
+			{},
+			{},
+			{},
+			{},
+			{},
+		},
+		nextIndex:   1,
+		sampleCount: 1,
+	}
+
+	plugin.syncNICState(context.Background())
+	state := plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX})]
+	require.NotNil(t, state)
+	evaluation := state.evaluate(0.75)
+	require.Equal(t, 2, evaluation.currentHits)
+	require.Equal(t, 2, evaluation.consecutiveHits)
 }
 
 func TestNICBandwidthEvictionThresholdMetPrunesStaleState(t *testing.T) {
@@ -897,11 +974,12 @@ func TestNICBandwidthEvictionThresholdMetPrunesStaleState(t *testing.T) {
 			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
 		},
 	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
-	plugin.bandwidthPressureState[bandwidthScope{netns: "stale", nic: "eth0", direction: bandwidthDirectionRX}] = &bandwidthPressureState{
+	staleMetricTime := time.Now().Add(-10 * time.Minute)
+	plugin.healthyNICState[formatBandwidthScope(bandwidthScope{netns: "stale", nic: "eth0", direction: bandwidthDirectionRX})] = &bandwidthState{
 		ring: []bandwidthSample{{
 			bps:          bandwidthTestPressureBPS,
 			capacityMbps: 100,
-			observedAt:   time.Now().Add(-10 * time.Minute),
+			observedAt:   staleMetricTime,
 		}, {}, {}, {}, {}, {}},
 		sampleCount: 1,
 	}
@@ -912,7 +990,7 @@ func TestNICBandwidthEvictionThresholdMetPrunesStaleState(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, pluginapi.ThresholdMetType_HARD_MET, resp.MetType)
-	require.NotContains(t, plugin.bandwidthPressureState, bandwidthScope{netns: "stale", nic: "eth0", direction: bandwidthDirectionRX})
+	require.NotContains(t, plugin.healthyNICState, formatBandwidthScope(bandwidthScope{netns: "stale", nic: "eth0", direction: bandwidthDirectionRX}))
 }
 
 func TestNICBandwidthEvictionThresholdMetUsesMetricsCollectedBySyncNICState(t *testing.T) {
@@ -933,15 +1011,18 @@ func TestNICBandwidthEvictionThresholdMetUsesMetricsCollectedBySyncNICState(t *t
 		NICBandwidthRingMetThreshold:       4,
 	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
 	querier.bandwidthMetricCallCount = 0
-	plugin.bandwidthPressureState = map[bandwidthScope]*bandwidthPressureState{}
+	plugin.healthyNICState = map[string]*bandwidthState{}
 
 	plugin.syncNICState(context.Background())
 	require.Equal(t, 2, querier.bandwidthMetricCallCount)
 
 	scope := bandwidthScope{netns: "ns1", nic: "eth0", direction: bandwidthDirectionRX}
-	state := plugin.bandwidthPressureState[scope]
+	state := plugin.healthyNICState[formatBandwidthScope(scope)]
 	require.NotNil(t, state)
 	require.Equal(t, 1, state.sampleCount)
+	latest, ok := state.latestSample()
+	require.True(t, ok)
+	require.Equal(t, querier.deviceMetrics[formatBandwidthScope(scope)].observedAt, latest.observedAt)
 
 	querier.deviceMetrics["bandwidth/ns1/eth0/rx"] = fakeNICMetric{bps: 0, speed: 100}
 	beforeThresholdCall := querier.bandwidthMetricCallCount
@@ -957,6 +1038,8 @@ func TestNICHealthEvictionGetEvictPodsDoesNotTouchBandwidthMetrics(t *testing.T)
 
 	pod := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
 	pod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
 	querier := &fakeBandwidthMetricQuerier{
 		deviceMetrics: map[string]fakeNICMetric{
 			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
@@ -964,6 +1047,9 @@ func TestNICHealthEvictionGetEvictPodsDoesNotTouchBandwidthMetrics(t *testing.T)
 		containerDirectionUsage: map[string]map[string]map[string]float64{
 			string(pod.UID): {
 				"c1": {bandwidthDirectionRX: 90},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 60},
 			},
 		},
 	}
@@ -992,6 +1078,8 @@ func TestNICBandwidthEvictionCoexistenceHealthMissBandwidthHit(t *testing.T) {
 
 	pod := newNetworkTestPod("default", "pod1", "uid1", "ns1-eth0")
 	pod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns1-eth0")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
 	querier := &fakeBandwidthMetricQuerier{
 		deviceMetrics: map[string]fakeNICMetric{
 			"bandwidth/ns1/eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
@@ -999,6 +1087,9 @@ func TestNICBandwidthEvictionCoexistenceHealthMissBandwidthHit(t *testing.T) {
 		containerDirectionUsage: map[string]map[string]map[string]float64{
 			string(pod.UID): {
 				"c1": {bandwidthDirectionRX: 90},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 60},
 			},
 		},
 	}
@@ -1048,7 +1139,7 @@ func TestNICBandwidthEvictionCoexistenceHealthMissBandwidthHit(t *testing.T) {
 	require.Zero(t, thresholdResp.GracePeriodSeconds)
 
 	topResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{pod},
+		ActivePods:    []*v1.Pod{pod, pod2},
 		TopN:          1,
 		EvictionScope: thresholdResp.EvictionScope,
 	})
@@ -1064,6 +1155,8 @@ func TestNICBandwidthEvictionCoexistenceDefaultNetNSScope(t *testing.T) {
 
 	pod := newNetworkTestPod("default", "pod1", "uid1", "eth0")
 	pod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod2 := newNetworkTestPod("default", "pod2", "uid2", "")
+	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
 	querier := &fakeBandwidthMetricQuerier{
 		deviceMetrics: map[string]fakeNICMetric{
 			"bandwidth//eth0/rx": {bps: bandwidthTestPressureBPS, speed: 100},
@@ -1071,6 +1164,9 @@ func TestNICBandwidthEvictionCoexistenceDefaultNetNSScope(t *testing.T) {
 		containerDirectionUsage: map[string]map[string]map[string]float64{
 			string(pod.UID): {
 				"c1": {bandwidthDirectionRX: 90},
+			},
+			string(pod2.UID): {
+				"c1": {bandwidthDirectionRX: 40},
 			},
 		},
 	}
@@ -1093,7 +1189,7 @@ func TestNICBandwidthEvictionCoexistenceDefaultNetNSScope(t *testing.T) {
 	require.Equal(t, "bandwidth//eth0/rx", thresholdResp.EvictionScope)
 
 	topResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{pod},
+		ActivePods:    []*v1.Pod{pod, pod2},
 		TopN:          1,
 		EvictionScope: thresholdResp.EvictionScope,
 	})
@@ -1150,8 +1246,12 @@ func TestNICBandwidthEvictionGetTopEvictionPodsAssignsPodWithoutAnnotationToDefa
 
 	defaultPod := newNetworkTestPod("default", "default-pod", "uid1", "")
 	defaultPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	defaultPod2 := newNetworkTestPod("default", "default-pod-2", "uid3", "")
+	defaultPod2.Spec.Containers = []v1.Container{{Name: "c1"}}
 	nsPod := newNetworkTestPod("default", "ns-pod", "uid2", "ns1-eth0")
 	nsPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	nsPod2 := newNetworkTestPod("default", "ns-pod-2", "uid4", "ns1-eth0")
+	nsPod2.Spec.Containers = []v1.Container{{Name: "c1"}}
 
 	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
 		EnableNICBandwidthEviction: true,
@@ -1160,8 +1260,14 @@ func TestNICBandwidthEvictionGetTopEvictionPodsAssignsPodWithoutAnnotationToDefa
 			string(defaultPod.UID): {
 				"c1": {bandwidthDirectionRX: 120},
 			},
+			string(defaultPod2.UID): {
+				"c1": {bandwidthDirectionRX: 60},
+			},
 			string(nsPod.UID): {
 				"c1": {bandwidthDirectionRX: 200},
+			},
+			string(nsPod2.UID): {
+				"c1": {bandwidthDirectionRX: 80},
 			},
 		},
 	}, []machine.InterfaceInfo{
@@ -1170,22 +1276,24 @@ func TestNICBandwidthEvictionGetTopEvictionPodsAssignsPodWithoutAnnotationToDefa
 	}, nil)
 
 	defaultResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{defaultPod, nsPod},
+		ActivePods:    []*v1.Pod{defaultPod, defaultPod2, nsPod, nsPod2},
 		TopN:          2,
 		EvictionScope: "bandwidth//eth0/rx",
 	})
 	require.NoError(t, err)
-	require.Len(t, defaultResp.TargetPods, 1)
+	require.Len(t, defaultResp.TargetPods, 2)
 	require.Equal(t, "default-pod", defaultResp.TargetPods[0].Name)
+	require.Equal(t, "default-pod-2", defaultResp.TargetPods[1].Name)
 
 	nsResp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{defaultPod, nsPod},
+		ActivePods:    []*v1.Pod{defaultPod, defaultPod2, nsPod, nsPod2},
 		TopN:          2,
 		EvictionScope: "bandwidth/ns1/eth0/rx",
 	})
 	require.NoError(t, err)
-	require.Len(t, nsResp.TargetPods, 1)
+	require.Len(t, nsResp.TargetPods, 2)
 	require.Equal(t, "ns-pod", nsResp.TargetPods[0].Name)
+	require.Equal(t, "ns-pod-2", nsResp.TargetPods[1].Name)
 }
 
 func TestNICBandwidthEvictionGetTopEvictionPodsSortsBySaleModeBeforeUsage(t *testing.T) {
@@ -1300,7 +1408,7 @@ func TestNICBandwidthEvictionGetTopEvictionPodsUsesConfigurableSaleModeAnnotatio
 
 	bytedPod := newNetworkTestPod("default", "byted-pod", "uid1", "ns1-eth0")
 	bytedPod.Spec.Containers = []v1.Container{{Name: "c1"}}
-	bytedPod.Annotations["bytedance.quota.salemode"] = apiconsts.PodSaleModeSpot
+	bytedPod.Annotations["salemode"] = apiconsts.PodSaleModeSpot
 	apiPod := newNetworkTestPod("default", "api-pod", "uid2", "ns1-eth0")
 	apiPod.Spec.Containers = []v1.Container{{Name: "c1"}}
 	apiPod.Annotations[apiconsts.PodAnnotationSaleModeKey] = apiconsts.PodSaleModeSpot
@@ -1317,7 +1425,7 @@ func TestNICBandwidthEvictionGetTopEvictionPodsUsesConfigurableSaleModeAnnotatio
 			},
 		},
 	}, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
-	plugin.podSaleModeAnnotationKey = "bytedance.quota.salemode"
+	plugin.podSaleModeAnnotationKey = "salemode"
 
 	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
 		ActivePods:    []*v1.Pod{apiPod, bytedPod},
@@ -1328,18 +1436,6 @@ func TestNICBandwidthEvictionGetTopEvictionPodsUsesConfigurableSaleModeAnnotatio
 	require.Len(t, resp.TargetPods, 2)
 	require.Equal(t, "byted-pod", resp.TargetPods[0].Name)
 	require.Equal(t, "api-pod", resp.TargetPods[1].Name)
-}
-
-func TestNewNICEvictionPluginUsesConfiguredSaleModeAnnotationKey(t *testing.T) {
-	t.Parallel()
-
-	conf := config.NewConfiguration()
-	conf.GenericConfiguration.PodSaleModeAnnotationKey = "bytedance.quota.salemode"
-
-	plugin := NewNICEvictionPlugin(nil, nil, nil, metrics.DummyMetrics{}, conf)
-	nicPlugin, ok := plugin.(*nicEvictionPlugin)
-	require.True(t, ok)
-	require.Equal(t, "bytedance.quota.salemode", nicPlugin.podSaleModeAnnotationKey)
 }
 
 func TestNICBandwidthEvictionGetTopEvictionPodsNilRequest(t *testing.T) {
@@ -1461,11 +1557,14 @@ func TestNICBandwidthEvictionGetTopEvictionPodsSkipsPodWhenUsageReadFails(t *tes
 	stablePod.Spec.Containers = []v1.Container{{Name: "c1"}}
 	flakyPod := newNetworkTestPod("default", "flaky-pod", "uid2", "ns1-eth0")
 	flakyPod.Spec.Containers = []v1.Container{{Name: "c1"}}
+	backupPod := newNetworkTestPod("default", "backup-pod", "uid3", "ns1-eth0")
+	backupPod.Spec.Containers = []v1.Container{{Name: "c1"}}
 
 	querier := &fakeBandwidthMetricQuerier{
 		containerDirectionUsage: map[string]map[string]map[string]float64{
 			string(stablePod.UID): {"c1": {bandwidthDirectionRX: 80}},
 			string(flakyPod.UID):  {"c1": {bandwidthDirectionRX: 120}},
+			string(backupPod.UID): {"c1": {bandwidthDirectionRX: 60}},
 		},
 		failDirectionUsageAfter: map[string]map[string]int{
 			string(flakyPod.UID): {bandwidthDirectionRX: 0},
@@ -1477,13 +1576,14 @@ func TestNICBandwidthEvictionGetTopEvictionPodsSkipsPodWhenUsageReadFails(t *tes
 	}, querier, []machine.InterfaceInfo{newBandwidthTestNIC("ns1", "eth0")}, nil)
 
 	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{stablePod, flakyPod},
+		ActivePods:    []*v1.Pod{stablePod, flakyPod, backupPod},
 		TopN:          2,
 		EvictionScope: "bandwidth/ns1/eth0/rx",
 	})
 	require.NoError(t, err)
-	require.Len(t, resp.TargetPods, 1)
+	require.Len(t, resp.TargetPods, 2)
 	require.Equal(t, "stable-pod", resp.TargetPods[0].Name)
+	require.Equal(t, "backup-pod", resp.TargetPods[1].Name)
 }
 
 func TestNICBandwidthEvictionGetTopEvictionPodsInvalidScope(t *testing.T) {
@@ -1508,6 +1608,8 @@ func TestNICBandwidthEvictionGetTopEvictionPodsBondPath(t *testing.T) {
 
 	bondPod := newNetworkTestPod("default", "bond-pod", "uid1", "ns1-bond0")
 	bondPod.Spec.Containers = []v1.Container{{Name: "c1"}, {Name: "c2"}}
+	bondPod2 := newNetworkTestPod("default", "bond-pod-2", "uid3", "ns1-bond0")
+	bondPod2.Spec.Containers = []v1.Container{{Name: "c1"}}
 	otherPod := newNetworkTestPod("default", "other-pod", "uid2", "ns1-eth0")
 	otherPod.Spec.Containers = []v1.Container{{Name: "c1"}}
 
@@ -1518,6 +1620,9 @@ func TestNICBandwidthEvictionGetTopEvictionPodsBondPath(t *testing.T) {
 			string(bondPod.UID): {
 				"c1": {bandwidthDirectionRX: 40},
 				"c2": {bandwidthDirectionRX: 50},
+			},
+			string(bondPod2.UID): {
+				"c1": {bandwidthDirectionRX: 30},
 			},
 			string(otherPod.UID): {
 				"c1": {bandwidthDirectionRX: 100},
@@ -1531,7 +1636,7 @@ func TestNICBandwidthEvictionGetTopEvictionPodsBondPath(t *testing.T) {
 	}))
 
 	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{bondPod, otherPod},
+		ActivePods:    []*v1.Pod{bondPod, bondPod2, otherPod},
 		TopN:          1,
 		EvictionScope: "bandwidth/ns1/bond0/rx",
 	})
@@ -1547,6 +1652,8 @@ func TestNICBandwidthEvictionGetTopEvictionPodsMultiNetNSIsolation(t *testing.T)
 	pod1.Spec.Containers = []v1.Container{{Name: "c1"}}
 	pod2 := newNetworkTestPod("default", "pod2", "uid2", "ns2-eth0")
 	pod2.Spec.Containers = []v1.Container{{Name: "c1"}}
+	pod3 := newNetworkTestPod("default", "pod3", "uid3", "ns2-eth0")
+	pod3.Spec.Containers = []v1.Container{{Name: "c1"}}
 
 	plugin := newBandwidthTestPlugin(&eviction.NetworkEvictionConfiguration{
 		EnableNICBandwidthEviction: true,
@@ -1558,6 +1665,9 @@ func TestNICBandwidthEvictionGetTopEvictionPodsMultiNetNSIsolation(t *testing.T)
 			string(pod2.UID): {
 				"c1": {bandwidthDirectionRX: 80},
 			},
+			string(pod3.UID): {
+				"c1": {bandwidthDirectionRX: 40},
+			},
 		},
 	}, []machine.InterfaceInfo{
 		newBandwidthTestNIC("ns1", "eth0"),
@@ -1565,7 +1675,7 @@ func TestNICBandwidthEvictionGetTopEvictionPodsMultiNetNSIsolation(t *testing.T)
 	}, nil)
 
 	resp, err := plugin.GetTopEvictionPods(context.Background(), &pluginapi.GetTopEvictionPodsRequest{
-		ActivePods:    []*v1.Pod{pod1, pod2},
+		ActivePods:    []*v1.Pod{pod1, pod2, pod3},
 		TopN:          1,
 		EvictionScope: "bandwidth/ns2/eth0/rx",
 	})
@@ -1593,8 +1703,9 @@ func TestNICBandwidthEvictionGetTopEvictionPodsEmptyCandidates(t *testing.T) {
 }
 
 type fakeNICMetric struct {
-	bps   float64
-	speed float64
+	bps        float64
+	speed      float64
+	observedAt time.Time
 }
 
 type fakeBandwidthMetricQuerier struct {
@@ -1605,18 +1716,22 @@ type fakeBandwidthMetricQuerier struct {
 	failDirectionUsageAfter  map[string]map[string]int
 }
 
-func (f *fakeBandwidthMetricQuerier) GetBandwidthMetric(scope bandwidthScope) (float64, bool) {
+func (f *fakeBandwidthMetricQuerier) GetBandwidthMetric(scope bandwidthScope) (utilmetric.MetricData, error) {
 	if f == nil {
-		return 0, false
+		return utilmetric.MetricData{}, fmt.Errorf("nil fakeBandwidthMetricQuerier")
 	}
 	f.bandwidthMetricCallCount++
 
 	metric, ok := f.deviceMetrics[formatBandwidthScope(scope)]
 	if !ok {
-		return 0, false
+		return utilmetric.MetricData{}, fmt.Errorf("bandwidth metric not found for scope %s", formatBandwidthScope(scope))
 	}
 
-	return metric.bps, true
+	if metric.observedAt.IsZero() {
+		metric.observedAt = time.Now()
+		f.deviceMetrics[formatBandwidthScope(scope)] = metric
+	}
+	return utilmetric.MetricData{Value: metric.bps, Time: &metric.observedAt}, nil
 }
 
 func (f *fakeBandwidthMetricQuerier) GetPodDirectionUsage(pod *v1.Pod, direction string) (float64, bool) {
@@ -1675,25 +1790,28 @@ func newBandwidthTestPluginWithMetaServer(conf *eviction.NetworkEvictionConfigur
 	if cnrObj == nil {
 		cnrObj = newBandwidthTestCNRFromInterfaces(interfaces, "100")
 	}
+	metaServer := &metaserver.MetaServer{MetaAgent: &agent.MetaAgent{
+		MetricsFetcher: metricsFetcher,
+		KatalystMachineInfo: &machine.KatalystMachineInfo{
+			ExtraNetworkInfo: &machine.ExtraNetworkInfo{Interface: interfaces},
+		},
+		CNRFetcher: &cnr.CNRFetcherStub{CNR: cnrObj},
+	}}
+	if metricQuerier == nil {
+		metricQuerier = newBandwidthMetricQuerier(metricsFetcher)
+	}
 
 	plugin := &nicEvictionPlugin{
 		dynamicConfig:            dynamicConfig,
 		unhealthyNICState:        make(map[string]*unhealthyNICState),
-		healthyNICState:          make(map[bandwidthScope]float64),
+		healthyNICState:          make(map[string]*bandwidthState),
 		emitter:                  metrics.DummyMetrics{},
 		podSaleModeAnnotationKey: apiconsts.PodAnnotationSaleModeKey,
-		bandwidthPressureState:   map[bandwidthScope]*bandwidthPressureState{},
-		metricQuerier:            metricQuerier,
-		metaServer: &metaserver.MetaServer{MetaAgent: &agent.MetaAgent{
-			MetricsFetcher: metricsFetcher,
-			KatalystMachineInfo: &machine.KatalystMachineInfo{
-				ExtraNetworkInfo: &machine.ExtraNetworkInfo{Interface: interfaces},
-			},
-			CNRFetcher: &cnr.CNRFetcherStub{CNR: cnrObj},
-		}},
+		bandwidthMetricQuerier:   metricQuerier,
+		metaServer:               metaServer,
 	}
 	plugin.syncNICState(context.Background())
-	plugin.bandwidthPressureState = map[bandwidthScope]*bandwidthPressureState{}
+	plugin.healthyNICState = map[string]*bandwidthState{}
 	if fakeQuerier, ok := metricQuerier.(*fakeBandwidthMetricQuerier); ok {
 		fakeQuerier.bandwidthMetricCallCount = 0
 	}

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
@@ -513,7 +513,7 @@ func (p *StaticPolicy) GetTopologyAwareResources(_ context.Context,
 	identifier := allocationInfo.Identifier
 	if identifier == "" {
 		// backup to use ifName and interfaceInfo.NSName as identifier
-		identifier = getResourceIdentifier(interfaceInfo.NSName, interfaceInfo.Name)
+		identifier = machine.FormatNICIdentifier(interfaceInfo.NSName, interfaceInfo.Name)
 	}
 
 	topologyAwareQuantityList := []*pluginapi.TopologyAwareQuantity{
@@ -591,7 +591,7 @@ func (p *StaticPolicy) GetTopologyAwareAllocatableResources(_ context.Context,
 			}
 
 			var allocatable uint32
-			resourceIdentifier := getResourceIdentifier(iface.NSName, iface.Name)
+			resourceIdentifier := machine.FormatNICIdentifier(iface.NSName, iface.Name)
 			if health {
 				allocatable = general.MinUInt32(nicState.EgressState.Allocatable, nicState.IngressState.Allocatable)
 			}
@@ -835,7 +835,7 @@ func (p *StaticPolicy) Allocate(ctx context.Context,
 			commonstate.EmptyOwnerPoolName, qosLevel),
 		Egress:     uint32(reqInt),
 		Ingress:    uint32(reqInt),
-		Identifier: getResourceIdentifier(selectedNIC.NSName, selectedNIC.Name),
+		Identifier: machine.FormatNICIdentifier(selectedNIC.NSName, selectedNIC.Name),
 		NSName:     selectedNIC.NSName,
 		IfName:     selectedNIC.Name,
 		NumaNodes:  allocateNUMAs,

--- a/pkg/agent/qrm-plugins/network/staticpolicy/util.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/util.go
@@ -313,14 +313,6 @@ func getReservedBandwidth(nics []machine.InterfaceInfo, reservation uint32, poli
 	return reservedBandwidth, nil
 }
 
-func getResourceIdentifier(ifaceNS, ifaceName string) string {
-	if len(ifaceNS) > 0 {
-		return fmt.Sprintf("%s-%s", ifaceNS, ifaceName)
-	}
-
-	return ifaceName
-}
-
 func applyImplicitReq(req *pluginapi.ResourceRequest, allocationInfo *state.AllocationInfo) error {
 	if req == nil || allocationInfo == nil {
 		return fmt.Errorf("nil req or allocationInfo")

--- a/pkg/agent/qrm-plugins/network/staticpolicy/util_test.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/util_test.go
@@ -27,6 +27,7 @@ import (
 	v1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/network/state"
 	katalystconsts "github.com/kubewharf/katalyst-core/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
 // helper to extract topology allocation from annotations JSON
@@ -131,6 +132,40 @@ func TestGetNetworkTopologyAllocationsAnnotations(t *testing.T) {
 				if !reflect.DeepEqual(ta, tt.wantTopology) {
 					t.Fatalf("unexpected topology allocation. got=%v, want=%v", ta, tt.wantTopology)
 				}
+			}
+		})
+	}
+}
+
+func TestGetResourceIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		ifaceNS   string
+		ifaceName string
+		want      string
+	}{
+		{
+			name:      "default namespace keeps nic name",
+			ifaceNS:   "",
+			ifaceName: "eth0",
+			want:      "eth0",
+		},
+		{
+			name:      "named namespace prefixes nic name",
+			ifaceNS:   "ns1",
+			ifaceName: "eth0",
+			want:      "ns1-eth0",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := machine.FormatNICIdentifier(tt.ifaceNS, tt.ifaceName); got != tt.want {
+				t.Fatalf("unexpected resource identifier, got=%q want=%q", got, tt.want)
 			}
 		})
 	}

--- a/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction.go
@@ -32,6 +32,9 @@ type CPUPressureEvictionConfiguration struct {
 	EnableSuppressionEviction               bool
 	MaxSuppressionToleranceRate             float64
 	MinSuppressionToleranceDuration         time.Duration
+	EnablePIDOveruseEviction                bool
+	PIDOveruseThreshold                     int64
+	PIDOveruseGracePeriod                   int64
 	GracePeriod                             int64
 	NumaCPUPressureEvictionConfiguration    NumaCPUPressureEvictionConfiguration
 	NumaSysCPUPressureEvictionConfiguration NumaSysCPUPressureEvictionConfiguration
@@ -45,47 +48,62 @@ func NewCPUPressureEvictionConfiguration() *CPUPressureEvictionConfiguration {
 }
 
 func (c *CPUPressureEvictionConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
-	if aqc := conf.AdminQoSConfiguration; aqc != nil &&
-		aqc.Spec.Config.EvictionConfig != nil && aqc.Spec.Config.EvictionConfig.CPUPressureEvictionConfig != nil {
-		config := aqc.Spec.Config.EvictionConfig.CPUPressureEvictionConfig
-		if config.EnableLoadEviction != nil {
-			c.EnableLoadEviction = *config.EnableLoadEviction
+	if aqc := conf.AdminQoSConfiguration; aqc != nil && aqc.Spec.Config.EvictionConfig != nil {
+		evictionConfig := aqc.Spec.Config.EvictionConfig
+		if config := evictionConfig.CPUPressureEvictionConfig; config != nil {
+			if config.EnableLoadEviction != nil {
+				c.EnableLoadEviction = *config.EnableLoadEviction
+			}
+
+			if config.LoadUpperBoundRatio != nil {
+				c.LoadUpperBoundRatio = *config.LoadUpperBoundRatio
+			}
+
+			if config.LoadLowerBoundRatio != nil {
+				c.LoadLowerBoundRatio = *config.LoadLowerBoundRatio
+			}
+
+			if config.LoadThresholdMetPercentage != nil {
+				c.LoadThresholdMetPercentage = *config.LoadThresholdMetPercentage
+			}
+
+			if config.LoadMetricRingSize != nil {
+				c.LoadMetricRingSize = *config.LoadMetricRingSize
+			}
+
+			if config.LoadEvictionCoolDownTime != nil {
+				c.LoadEvictionCoolDownTime = config.LoadEvictionCoolDownTime.Duration
+			}
+
+			if config.EnableSuppressionEviction != nil {
+				c.EnableSuppressionEviction = *config.EnableSuppressionEviction
+			}
+
+			if config.MaxSuppressionToleranceRate != nil {
+				c.MaxSuppressionToleranceRate = *config.MaxSuppressionToleranceRate
+			}
+
+			if config.MinSuppressionToleranceDuration != nil {
+				c.MinSuppressionToleranceDuration = config.MinSuppressionToleranceDuration.Duration
+			}
+
+			if config.GracePeriod != nil {
+				c.GracePeriod = *config.GracePeriod
+			}
 		}
 
-		if config.LoadUpperBoundRatio != nil {
-			c.LoadUpperBoundRatio = *config.LoadUpperBoundRatio
-		}
+		if config := evictionConfig.PIDOveruseEvictionConfig; config != nil {
+			if config.EnablePIDOveruseEviction != nil {
+				c.EnablePIDOveruseEviction = *config.EnablePIDOveruseEviction
+			}
 
-		if config.LoadLowerBoundRatio != nil {
-			c.LoadLowerBoundRatio = *config.LoadLowerBoundRatio
-		}
+			if config.PIDOveruseThreshold != nil {
+				c.PIDOveruseThreshold = *config.PIDOveruseThreshold
+			}
 
-		if config.LoadThresholdMetPercentage != nil {
-			c.LoadThresholdMetPercentage = *config.LoadThresholdMetPercentage
-		}
-
-		if config.LoadMetricRingSize != nil {
-			c.LoadMetricRingSize = *config.LoadMetricRingSize
-		}
-
-		if config.LoadEvictionCoolDownTime != nil {
-			c.LoadEvictionCoolDownTime = config.LoadEvictionCoolDownTime.Duration
-		}
-
-		if config.EnableSuppressionEviction != nil {
-			c.EnableSuppressionEviction = *config.EnableSuppressionEviction
-		}
-
-		if config.MaxSuppressionToleranceRate != nil {
-			c.MaxSuppressionToleranceRate = *config.MaxSuppressionToleranceRate
-		}
-
-		if config.MinSuppressionToleranceDuration != nil {
-			c.MinSuppressionToleranceDuration = config.MinSuppressionToleranceDuration.Duration
-		}
-
-		if config.GracePeriod != nil {
-			c.GracePeriod = *config.GracePeriod
+			if config.GracePeriod != nil {
+				c.PIDOveruseGracePeriod = *config.GracePeriod
+			}
 		}
 	}
 

--- a/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction.go
@@ -23,21 +23,23 @@ import (
 )
 
 type CPUPressureEvictionConfiguration struct {
-	EnableLoadEviction                      bool
-	LoadUpperBoundRatio                     float64
-	LoadLowerBoundRatio                     float64
-	LoadThresholdMetPercentage              float64
-	LoadMetricRingSize                      int
-	LoadEvictionCoolDownTime                time.Duration
-	EnableSuppressionEviction               bool
-	MaxSuppressionToleranceRate             float64
-	MinSuppressionToleranceDuration         time.Duration
-	EnablePIDOveruseEviction                bool
-	PIDOveruseThreshold                     int64
-	PIDOveruseGracePeriod                   int64
-	GracePeriod                             int64
-	NumaCPUPressureEvictionConfiguration    NumaCPUPressureEvictionConfiguration
-	NumaSysCPUPressureEvictionConfiguration NumaSysCPUPressureEvictionConfiguration
+	EnableLoadEviction                       bool
+	LoadUpperBoundRatio                      float64
+	LoadLowerBoundRatio                      float64
+	LoadThresholdMetPercentage               float64
+	LoadMetricRingSize                       int
+	LoadEvictionCoolDownTime                 time.Duration
+	EnableSuppressionEviction                bool
+	MaxSuppressionToleranceRate              float64
+	MinSuppressionToleranceDuration          time.Duration
+	EnablePIDOveruseEviction                 bool
+	PIDOveruseThreshold                      int64
+	PIDOveruseGracePeriod                    int64
+	PIDOveruseCandidatePodLabelSelector      string
+	PIDOveruseCandidatePodAnnotationSelector string
+	GracePeriod                              int64
+	NumaCPUPressureEvictionConfiguration     NumaCPUPressureEvictionConfiguration
+	NumaSysCPUPressureEvictionConfiguration  NumaSysCPUPressureEvictionConfiguration
 }
 
 func NewCPUPressureEvictionConfiguration() *CPUPressureEvictionConfiguration {
@@ -99,6 +101,14 @@ func (c *CPUPressureEvictionConfiguration) ApplyConfiguration(conf *crd.DynamicC
 
 			if config.PIDOveruseThreshold != nil {
 				c.PIDOveruseThreshold = *config.PIDOveruseThreshold
+			}
+
+			if config.CandidatePodLabelSelector != nil {
+				c.PIDOveruseCandidatePodLabelSelector = *config.CandidatePodLabelSelector
+			}
+
+			if config.CandidatePodAnnotationSelector != nil {
+				c.PIDOveruseCandidatePodAnnotationSelector = *config.CandidatePodAnnotationSelector
 			}
 
 			if config.GracePeriod != nil {

--- a/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction_test.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction_test.go
@@ -32,6 +32,8 @@ func TestCPUPressureEvictionConfigurationApplyPIDOveruseConfiguration(t *testing
 	enablePIDOveruseEviction := true
 	pidOveruseThreshold := int64(256)
 	gracePeriod := int64(9)
+	labelSelector := "tier=gold"
+	annotationSelector := "salemode=reserved"
 
 	conf := NewCPUPressureEvictionConfiguration()
 	conf.ApplyConfiguration(&crd.DynamicConfigCRD{
@@ -43,9 +45,11 @@ func TestCPUPressureEvictionConfigurationApplyPIDOveruseConfiguration(t *testing
 							LoadEvictionCoolDownTime: &metav1.Duration{},
 						},
 						PIDOveruseEvictionConfig: &configapi.PIDOveruseEvictionConfig{
-							EnablePIDOveruseEviction: &enablePIDOveruseEviction,
-							PIDOveruseThreshold:      &pidOveruseThreshold,
-							GracePeriod:              &gracePeriod,
+							EnablePIDOveruseEviction:       &enablePIDOveruseEviction,
+							PIDOveruseThreshold:            &pidOveruseThreshold,
+							CandidatePodLabelSelector:      &labelSelector,
+							CandidatePodAnnotationSelector: &annotationSelector,
+							GracePeriod:                    &gracePeriod,
 						},
 					},
 				},
@@ -56,4 +60,6 @@ func TestCPUPressureEvictionConfigurationApplyPIDOveruseConfiguration(t *testing
 	require.True(t, conf.EnablePIDOveruseEviction)
 	require.EqualValues(t, 256, conf.PIDOveruseThreshold)
 	require.EqualValues(t, 9, conf.PIDOveruseGracePeriod)
+	require.Equal(t, labelSelector, conf.PIDOveruseCandidatePodLabelSelector)
+	require.Equal(t, annotationSelector, conf.PIDOveruseCandidatePodAnnotationSelector)
 }

--- a/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction_test.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/cpu_pressure_eviction_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configapi "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+)
+
+func TestCPUPressureEvictionConfigurationApplyPIDOveruseConfiguration(t *testing.T) {
+	t.Parallel()
+
+	enablePIDOveruseEviction := true
+	pidOveruseThreshold := int64(256)
+	gracePeriod := int64(9)
+
+	conf := NewCPUPressureEvictionConfiguration()
+	conf.ApplyConfiguration(&crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &configapi.AdminQoSConfiguration{
+			Spec: configapi.AdminQoSConfigurationSpec{
+				Config: configapi.AdminQoSConfig{
+					EvictionConfig: &configapi.EvictionConfig{
+						CPUPressureEvictionConfig: &configapi.CPUPressureEvictionConfig{
+							LoadEvictionCoolDownTime: &metav1.Duration{},
+						},
+						PIDOveruseEvictionConfig: &configapi.PIDOveruseEvictionConfig{
+							EnablePIDOveruseEviction: &enablePIDOveruseEviction,
+							PIDOveruseThreshold:      &pidOveruseThreshold,
+							GracePeriod:              &gracePeriod,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.True(t, conf.EnablePIDOveruseEviction)
+	require.EqualValues(t, 256, conf.PIDOveruseThreshold)
+	require.EqualValues(t, 9, conf.PIDOveruseGracePeriod)
+}

--- a/pkg/config/agent/dynamic/adminqos/eviction/network_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/network_eviction.go
@@ -30,26 +30,68 @@ type NetworkEvictionConfiguration struct {
 	NICUnhealthyToleranceDuration time.Duration
 	// GracePeriod is the grace period for NIC health eviction
 	GracePeriod int64
+	// EnableNICBandwidthEviction indicates whether to enable NIC bandwidth eviction.
+	EnableNICBandwidthEviction bool
+	// NICBandwidthUtilizationThreshold is the threshold for NIC bandwidth utilization.
+	NICBandwidthUtilizationThreshold float64
+	// NICBandwidthContinuousMetThreshold is the continuous hit threshold for NIC bandwidth pressure.
+	NICBandwidthContinuousMetThreshold int
+	// NICBandwidthRingSize is the ring size for NIC bandwidth pressure observations.
+	NICBandwidthRingSize int
+	// NICBandwidthRingMetThreshold is the ring hit threshold for NIC bandwidth pressure.
+	NICBandwidthRingMetThreshold int
+	// NICBandwidthGracePeriod is the grace period for NIC bandwidth eviction.
+	NICBandwidthGracePeriod int64
 }
 
 func NewNetworkEvictionConfiguration() *NetworkEvictionConfiguration {
-	return &NetworkEvictionConfiguration{}
+	return &NetworkEvictionConfiguration{
+		NICUnhealthyToleranceDuration:      5 * time.Minute,
+		NICBandwidthUtilizationThreshold:   0.75,
+		NICBandwidthContinuousMetThreshold: 3,
+		NICBandwidthRingSize:               6,
+		NICBandwidthRingMetThreshold:       4,
+	}
 }
 
 func (n *NetworkEvictionConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
-	if aqc := conf.AdminQoSConfiguration; aqc != nil && aqc.Spec.Config.EvictionConfig != nil &&
-		aqc.Spec.Config.EvictionConfig.NetworkEvictionConfig != nil {
-		config := aqc.Spec.Config.EvictionConfig.NetworkEvictionConfig
-		if config.NICUnhealthyToleranceDuration != nil {
-			n.EnableNICHealthEviction = *config.EnableNICHealthEviction
-		}
+	if aqc := conf.AdminQoSConfiguration; aqc != nil && aqc.Spec.Config.EvictionConfig != nil {
+		if config := aqc.Spec.Config.EvictionConfig.NetworkEvictionConfig; config != nil {
+			if config.EnableNICHealthEviction != nil {
+				n.EnableNICHealthEviction = *config.EnableNICHealthEviction
+			}
 
-		if config.NICUnhealthyToleranceDuration != nil {
-			n.NICUnhealthyToleranceDuration = config.NICUnhealthyToleranceDuration.Duration
-		}
+			if config.NICUnhealthyToleranceDuration != nil {
+				n.NICUnhealthyToleranceDuration = config.NICUnhealthyToleranceDuration.Duration
+			}
 
-		if config.GracePeriod != nil {
-			n.GracePeriod = *config.GracePeriod
+			if config.GracePeriod != nil {
+				n.GracePeriod = *config.GracePeriod
+			}
+
+			if config.EnableNICBandwidthEviction != nil {
+				n.EnableNICBandwidthEviction = *config.EnableNICBandwidthEviction
+			}
+
+			if config.NICBandwidthUtilizationThreshold != nil {
+				n.NICBandwidthUtilizationThreshold = *config.NICBandwidthUtilizationThreshold
+			}
+
+			if config.NICBandwidthContinuousMetThreshold != nil {
+				n.NICBandwidthContinuousMetThreshold = int(*config.NICBandwidthContinuousMetThreshold)
+			}
+
+			if config.NICBandwidthRingSize != nil {
+				n.NICBandwidthRingSize = int(*config.NICBandwidthRingSize)
+			}
+
+			if config.NICBandwidthRingMetThreshold != nil {
+				n.NICBandwidthRingMetThreshold = int(*config.NICBandwidthRingMetThreshold)
+			}
+
+			if config.NICBandwidthGracePeriod != nil {
+				n.NICBandwidthGracePeriod = *config.NICBandwidthGracePeriod
+			}
 		}
 	}
 }

--- a/pkg/config/agent/dynamic/adminqos/eviction/network_eviction_test.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/network_eviction_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	configapi "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+)
+
+func TestNetworkEvictionConfigurationApplyBandwidthConfiguration(t *testing.T) {
+	t.Parallel()
+
+	enableBandwidthEviction := true
+	utilizationThreshold := 0.75
+	continuousMetThreshold := int64(3)
+	ringSize := int64(6)
+	ringMetThreshold := int64(4)
+	gracePeriod := int64(12)
+
+	conf := NewNetworkEvictionConfiguration()
+	conf.ApplyConfiguration(&crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &configapi.AdminQoSConfiguration{
+			Spec: configapi.AdminQoSConfigurationSpec{
+				Config: configapi.AdminQoSConfig{
+					EvictionConfig: &configapi.EvictionConfig{
+						NetworkEvictionConfig: &configapi.NetworkEvictionConfig{
+							EnableNICBandwidthEviction:         &enableBandwidthEviction,
+							NICBandwidthUtilizationThreshold:   &utilizationThreshold,
+							NICBandwidthContinuousMetThreshold: &continuousMetThreshold,
+							NICBandwidthRingSize:               &ringSize,
+							NICBandwidthRingMetThreshold:       &ringMetThreshold,
+							NICBandwidthGracePeriod:            &gracePeriod,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.True(t, conf.EnableNICBandwidthEviction)
+	require.Equal(t, 0.75, conf.NICBandwidthUtilizationThreshold)
+	require.Equal(t, 3, conf.NICBandwidthContinuousMetThreshold)
+	require.Equal(t, 6, conf.NICBandwidthRingSize)
+	require.Equal(t, 4, conf.NICBandwidthRingMetThreshold)
+	require.EqualValues(t, 12, conf.NICBandwidthGracePeriod)
+}

--- a/pkg/config/generic/generic_base.go
+++ b/pkg/config/generic/generic_base.go
@@ -18,6 +18,8 @@ package generic
 
 import (
 	componentbaseconfig "k8s.io/component-base/config"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 )
 
 // GenericConfiguration stores all the generic configurations needed
@@ -32,6 +34,7 @@ type GenericConfiguration struct {
 
 	GenericEndpoint             string
 	GenericEndpointHandleChains []string
+	PodSaleModeAnnotationKey    string
 
 	*QoSConfiguration
 	*MetricsConfiguration
@@ -46,10 +49,11 @@ type GenericConfiguration struct {
 // NewGenericConfiguration creates a new generic configuration.
 func NewGenericConfiguration() *GenericConfiguration {
 	return &GenericConfiguration{
-		DryRun:               false,
-		QoSConfiguration:     NewQoSConfiguration(),
-		MetricsConfiguration: NewMetricsConfiguration(),
-		AuthConfiguration:    NewAuthConfiguration(),
-		LogConfiguration:     NewLogConfiguration(),
+		DryRun:                   false,
+		PodSaleModeAnnotationKey: apiconsts.PodAnnotationSaleModeKey,
+		QoSConfiguration:         NewQoSConfiguration(),
+		MetricsConfiguration:     NewMetricsConfiguration(),
+		AuthConfiguration:        NewAuthConfiguration(),
+		LogConfiguration:         NewLogConfiguration(),
 	}
 }

--- a/pkg/consts/metric.go
+++ b/pkg/consts/metric.go
@@ -260,6 +260,7 @@ const (
 	MetricCPUNrRunnableContainer        = "cpu.nr.runnable.container"
 	MetricCPUNrUninterruptibleContainer = "cpu.nr.uninterruptible.container"
 	MetricCPUNrIOWaitContainer          = "cpu.nr.iowait.container"
+	MetricCPUNrSleepingContainer        = "cpu.nr.sleeping.container"
 
 	MetricLoad1MinContainer  = "cpu.load.1min.container"
 	MetricLoad5MinContainer  = "cpu.load.5min.container"

--- a/pkg/metaserver/agent/metric/fake_metric.go
+++ b/pkg/metaserver/agent/metric/fake_metric.go
@@ -103,7 +103,11 @@ func (f *FakeMetricsFetcher) GetNumaMetric(numaID int, metricName string) (metri
 }
 
 func (f *FakeMetricsFetcher) GetNetworkMetric(networkName string, metricName string) (metric.MetricData, error) {
-	return f.checkMetricDataExpire(f.metricStore.GetDeviceMetric(networkName, metricName))
+	return f.checkMetricDataExpire(f.metricStore.GetNetworkMetric(networkName, metricName))
+}
+
+func (f *FakeMetricsFetcher) GetNSNetworkMetric(netns, networkName string, metricName string) (metric.MetricData, error) {
+	return f.checkMetricDataExpire(f.metricStore.GetNSNetworkMetric(netns, networkName, metricName))
 }
 
 func (f *FakeMetricsFetcher) GetDeviceMetric(deviceName string, metricName string) (metric.MetricData, error) {
@@ -155,6 +159,14 @@ func (f *FakeMetricsFetcher) SetByStringIndex(metricName string, metricMap inter
 
 func (f *FakeMetricsFetcher) SetDeviceMetric(deviceName string, metricName string, data metric.MetricData) {
 	f.metricStore.SetDeviceMetric(deviceName, metricName, data)
+}
+
+func (f *FakeMetricsFetcher) SetNetworkMetric(networkName string, metricName string, data metric.MetricData) {
+	f.metricStore.SetNetworkMetric(networkName, metricName, data)
+}
+
+func (f *FakeMetricsFetcher) SetNSNetworkMetric(netns, networkName string, metricName string, data metric.MetricData) {
+	f.metricStore.SetNSNetworkMetric(netns, networkName, metricName, data)
 }
 
 func (f *FakeMetricsFetcher) SetContainerMetric(podUID, containerName, metricName string, data metric.MetricData) {

--- a/pkg/metaserver/agent/metric/metric_impl.go
+++ b/pkg/metaserver/agent/metric/metric_impl.go
@@ -330,6 +330,10 @@ func (f *MetricsFetcherImpl) GetNetworkMetric(networkName string, metricName str
 	return f.checkMetricDataExpire(f.metricStore.GetNetworkMetric(networkName, metricName))
 }
 
+func (f *MetricsFetcherImpl) GetNSNetworkMetric(netns, networkName string, metricName string) (utilmetric.MetricData, error) {
+	return f.checkMetricDataExpire(f.metricStore.GetNSNetworkMetric(netns, networkName, metricName))
+}
+
 func (f *MetricsFetcherImpl) GetCPUMetric(coreID int, metricName string) (utilmetric.MetricData, error) {
 	return f.checkMetricDataExpire(f.metricStore.GetCPUMetric(coreID, metricName))
 }

--- a/pkg/metaserver/agent/metric/metric_test.go
+++ b/pkg/metaserver/agent/metric/metric_test.go
@@ -159,6 +159,28 @@ func Test_notifySystem(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestMetricsFetcher_GetNSNetworkMetric(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	conf := generateTestConfiguration(t)
+	f := NewMetricsFetcher(conf.BaseConfiguration, conf.MetricConfiguration,
+		metrics.DummyMetrics{}, &pod.PodFetcherStub{}, &machine.KatalystMachineInfo{}).(*MetricsFetcherImpl)
+	f.metricStore.SetNetworkMetric("eth0", "test-net-metric", metric.MetricData{Value: 1, Time: &now})
+	f.metricStore.SetNSNetworkMetric("ns1", "eth0", "test-net-metric", metric.MetricData{Value: 2, Time: &now})
+
+	data, err := f.GetNetworkMetric("eth0", "test-net-metric")
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), data.Value)
+
+	data, err = f.GetNSNetworkMetric("ns1", "eth0", "test-net-metric")
+	require.NoError(t, err)
+	assert.Equal(t, float64(2), data.Value)
+
+	_, err = f.GetNSNetworkMetric("ns2", "eth0", "test-net-metric")
+	assert.Error(t, err)
+}
+
 func TestStore_Aggregate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client.go
@@ -32,7 +32,7 @@ const (
 	CgroupPathParamKey = "cgroup_user_path"
 
 	SystemIOResource      = "system/io"
-	SystemNetResource     = "system/network"
+	SystemNetResource     = "system/network/all_netns"
 	SystemMemoryResource  = "system/memory"
 	SystemComputeResource = "system/compute"
 	SystemInfoResource    = "system/info"

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_system.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_system.go
@@ -104,7 +104,7 @@ func (c *MalachiteClient) GetSystemIOStats() (*types.SystemIoData, error) {
 	return &rsp.Data, nil
 }
 
-func (c *MalachiteClient) GetSystemNetStats() (*types.SystemNetworkData, error) {
+func (c *MalachiteClient) GetSystemNetStats() ([]types.SystemNetworkData, error) {
 	statsData, err := c.getSystemStats(Net)
 	if err != nil {
 		return nil, err
@@ -119,8 +119,18 @@ func (c *MalachiteClient) GetSystemNetStats() (*types.SystemNetworkData, error) 
 		return nil, fmt.Errorf("system network stats status is not ok, %d", rsp.Status)
 	}
 
-	c.checkSystemStatsOutOfDate("network", UpdateTimeout, rsp.Data.UpdateTime)
-	return &rsp.Data, nil
+	c.checkSystemStatsOutOfDate("network", UpdateTimeout, getLatestSystemNetworkUpdateTime(rsp.Data))
+	return rsp.Data, nil
+}
+
+func getLatestSystemNetworkUpdateTime(data []types.SystemNetworkData) int64 {
+	var updateTime int64
+	for _, item := range data {
+		if item.UpdateTime > updateTime {
+			updateTime = item.UpdateTime
+		}
+	}
+	return updateTime
 }
 
 func (c *MalachiteClient) getSystemStats(kind SystemResourceKind) ([]byte, error) {

--- a/pkg/metaserver/agent/metric/provisioner/malachite/client/client_system_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/client/client_system_test.go
@@ -81,12 +81,13 @@ var (
 
 	fakeSystemNet = &types.MalachiteSystemNetworkResponse{
 		Status: 0,
-		Data: types.SystemNetworkData{
+		Data: []types.SystemNetworkData{{
+			NetNS: "",
 			NetworkCard: []types.NetworkCard{
 				{},
 			},
 			TCP: types.TCP{},
-		},
+		}},
 	}
 )
 
@@ -228,6 +229,13 @@ func TestGetSystemNetStats(t *testing.T) {
 	})
 	_, err = malachiteClient.GetSystemComputeStats()
 	assert.NotNil(t, err)
+}
+
+func TestNewMalachiteClientUsesAllNetNSSystemNetworkResource(t *testing.T) {
+	t.Parallel()
+
+	malachiteClient := NewMalachiteClient(&pod.PodFetcherStub{}, metrics.DummyMetrics{})
+	assert.Contains(t, malachiteClient.urls[SystemNetResource], "/system/network/all_netns")
 }
 
 func TestGetSystemNonExistStats(t *testing.T) {

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -1101,6 +1101,8 @@ func (m *MalachiteMetricsProvisioner) processContainerCPUData(podUID, containerN
 			utilmetric.MetricData{Value: float64(cpu.TaskNrUninterruptible), Time: &updateTime})
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUNrIOWaitContainer,
 			utilmetric.MetricData{Value: float64(cpu.TaskNrIoWait), Time: &updateTime})
+		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUNrSleepingContainer,
+			utilmetric.MetricData{Value: float64(cpu.TaskNrSleeping), Time: &updateTime})
 
 		m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricLoad1MinContainer,
 			utilmetric.MetricData{Value: cpu.Load.One, Time: &updateTime})
@@ -1213,6 +1215,8 @@ func (m *MalachiteMetricsProvisioner) processContainerCPUData(podUID, containerN
 				utilmetric.MetricData{Value: float64(cpu.TaskNrUninterruptible), Time: &updateTime})
 			m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUNrIOWaitContainer,
 				utilmetric.MetricData{Value: float64(cpu.TaskNrIoWait), Time: &updateTime})
+			m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricCPUNrSleepingContainer,
+				utilmetric.MetricData{Value: float64(cpu.TaskNrSleeping), Time: &updateTime})
 			m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricLoad1MinContainer,
 				utilmetric.MetricData{Value: cpu.Load.One, Time: &updateTime})
 			m.metricStore.SetContainerMetric(podUID, containerName, consts.MetricLoad5MinContainer,

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -465,102 +465,108 @@ func (m *MalachiteMetricsProvisioner) processSystemIOData(systemIOData *malachit
 	}
 }
 
-func (m *MalachiteMetricsProvisioner) processSystemNetData(systemNetData *malachitetypes.SystemNetworkData) {
-	if systemNetData == nil {
+func (m *MalachiteMetricsProvisioner) processSystemNetData(systemNetData []malachitetypes.SystemNetworkData) {
+	if len(systemNetData) == 0 {
 		return
 	}
 
-	// todo, currently we only get a unified data for the whole system io data
-	updateTime := time.Unix(systemNetData.UpdateTime, 0)
-
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpDelayedAcks,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPDelayAcks), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpOverflows,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPListenOverflows), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpDrops,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPListenDrops), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpAbort,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPAbortOnMemory), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpDrop,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPReqQFullDrop), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpRetran,
-		utilmetric.MetricData{Value: systemNetData.TCP.TCPRetran, Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpRetranSegs,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPRetransSegs), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpRecvPackets,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPOutSegs), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetTcpCloseWait,
-		utilmetric.MetricData{Value: float64(systemNetData.TCP.TCPCloseWait), Time: &updateTime})
-	m.metricStore.SetNodeMetric(consts.MetricNetUpdateTime,
-		utilmetric.MetricData{Value: float64(systemNetData.UpdateTime), Time: &updateTime})
-
-	for _, device := range systemNetData.NetworkCard {
-		// for now, we will only consider standard network interface
-		// todo, may need to use configurations in the future to filter
-		if !strings.HasPrefix(device.Name, "eth") {
-			continue
+	var defaultNetData *malachitetypes.SystemNetworkData
+	for i := range systemNetData {
+		if systemNetData[i].NetNS == machine.DefaultNICNamespace {
+			defaultNetData = &systemNetData[i]
+			break
 		}
+	}
 
-		errs := []error{}
-		// setNetworkRateMetric will use metricStore.GetNetworkMetric to get previous round metric,
-		// we should call setNetworkRateMetric before calling SetNetworkMetric
-		errs = append(errs, m.setNetworkRateMetric(device.Name, consts.MetricNetTransmitBPS,
-			consts.MetricNetTransmitBytes, float64(device.TransmitBytes), &updateTime))
-		errs = append(errs, m.setNetworkRateMetric(device.Name, consts.MetricNetReceiveBPS,
-			consts.MetricNetReceiveBytes, float64(device.ReceiveBytes), &updateTime))
+	if defaultNetData == nil {
+		klog.Warningf("[malachite] skip node tcp metrics because default network namespace data is missing")
+	} else {
+		updateTime := time.Unix(defaultNetData.UpdateTime, 0)
 
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceiveBytes,
-			utilmetric.MetricData{Value: float64(device.ReceiveBytes), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceivePackets,
-			utilmetric.MetricData{Value: float64(device.ReceivePackets), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceiveErrs,
-			utilmetric.MetricData{Value: float64(device.ReceiveErrs), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceiveDrops,
-			utilmetric.MetricData{Value: float64(device.ReceiveDrop), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceiveFIFO,
-			utilmetric.MetricData{Value: float64(device.ReceiveFifo), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceiveFrame,
-			utilmetric.MetricData{Value: float64(device.ReceiveFrame), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetReceiveCompressed,
-			utilmetric.MetricData{Value: float64(device.ReceiveCompressed), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitMulticast,
-			utilmetric.MetricData{Value: float64(device.ReceiveMulticast), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitBytes,
-			utilmetric.MetricData{Value: float64(device.TransmitBytes), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitPackets,
-			utilmetric.MetricData{Value: float64(device.TransmitPackets), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitErrs,
-			utilmetric.MetricData{Value: float64(device.TransmitErrs), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitDrops,
-			utilmetric.MetricData{Value: float64(device.TransmitDrop), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitFIFO,
-			utilmetric.MetricData{Value: float64(device.TransmitFifo), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitColls,
-			utilmetric.MetricData{Value: float64(device.TransmitColls), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitCarrier,
-			utilmetric.MetricData{Value: float64(device.TransmitCarrier), Time: &updateTime})
-		m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetTransmitCompressed,
-			utilmetric.MetricData{Value: float64(device.TransmitCompressed), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpDelayedAcks,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPDelayAcks), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpOverflows,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPListenOverflows), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpDrops,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPListenDrops), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpAbort,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPAbortOnMemory), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpDrop,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPReqQFullDrop), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpRetran,
+			utilmetric.MetricData{Value: defaultNetData.TCP.TCPRetran, Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpRetranSegs,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPRetransSegs), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpRecvPackets,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPOutSegs), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetTcpCloseWait,
+			utilmetric.MetricData{Value: float64(defaultNetData.TCP.TCPCloseWait), Time: &updateTime})
+		m.metricStore.SetNodeMetric(consts.MetricNetUpdateTime,
+			utilmetric.MetricData{Value: float64(defaultNetData.UpdateTime), Time: &updateTime})
+	}
 
-		if device.Speeds != nil {
-			m.metricStore.SetNetworkMetric(device.Name, consts.MetricNetSpeed,
-				utilmetric.MetricData{Value: float64(*device.Speeds), Time: &updateTime})
-		}
+	for _, netData := range systemNetData {
+		updateTime := time.Unix(netData.UpdateTime, 0)
+		for _, device := range netData.NetworkCard {
+			if !m.shouldStoreNetworkMetricDevice(netData.NetNS, device.Name) {
+				continue
+			}
 
-		aggErrs := errors.NewAggregate(errs)
+			errs := []error{}
+			// setNetworkRateMetric will use metricStore.GetNSNetworkMetric to get previous round metric,
+			// we should call setNetworkRateMetric before calling SetNSNetworkMetric
+			errs = append(errs, m.setNetworkRateMetric(netData.NetNS, device.Name, consts.MetricNetTransmitBPS,
+				consts.MetricNetTransmitBytes, float64(device.TransmitBytes), &updateTime))
+			errs = append(errs, m.setNetworkRateMetric(netData.NetNS, device.Name, consts.MetricNetReceiveBPS,
+				consts.MetricNetReceiveBytes, float64(device.ReceiveBytes), &updateTime))
 
-		if aggErrs != nil {
-			general.Warningf("set network metrics for: %s got errors: %s", device.Name, aggErrs.Error())
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceiveBytes,
+				utilmetric.MetricData{Value: float64(device.ReceiveBytes), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceivePackets,
+				utilmetric.MetricData{Value: float64(device.ReceivePackets), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceiveErrs,
+				utilmetric.MetricData{Value: float64(device.ReceiveErrs), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceiveDrops,
+				utilmetric.MetricData{Value: float64(device.ReceiveDrop), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceiveFIFO,
+				utilmetric.MetricData{Value: float64(device.ReceiveFifo), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceiveFrame,
+				utilmetric.MetricData{Value: float64(device.ReceiveFrame), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetReceiveCompressed,
+				utilmetric.MetricData{Value: float64(device.ReceiveCompressed), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitMulticast,
+				utilmetric.MetricData{Value: float64(device.ReceiveMulticast), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitBytes,
+				utilmetric.MetricData{Value: float64(device.TransmitBytes), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitPackets,
+				utilmetric.MetricData{Value: float64(device.TransmitPackets), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitErrs,
+				utilmetric.MetricData{Value: float64(device.TransmitErrs), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitDrops,
+				utilmetric.MetricData{Value: float64(device.TransmitDrop), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitFIFO,
+				utilmetric.MetricData{Value: float64(device.TransmitFifo), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitColls,
+				utilmetric.MetricData{Value: float64(device.TransmitColls), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitCarrier,
+				utilmetric.MetricData{Value: float64(device.TransmitCarrier), Time: &updateTime})
+			m.metricStore.SetNSNetworkMetric(netData.NetNS, device.Name, consts.MetricNetTransmitCompressed,
+				utilmetric.MetricData{Value: float64(device.TransmitCompressed), Time: &updateTime})
+
+			aggErrs := errors.NewAggregate(errs)
+			if aggErrs != nil {
+				general.Warningf("set network metrics for: %s got errors: %s", machine.FormatNICIdentifier(netData.NetNS, device.Name), aggErrs.Error())
+			}
 		}
 	}
 }
 
-func (m *MalachiteMetricsProvisioner) setNetworkRateMetric(deviceName,
+func (m *MalachiteMetricsProvisioner) setNetworkRateMetric(netns, deviceName,
 	rateMetricName, valueMetricName string,
 	curValue float64,
 	curUpdateTime *time.Time,
 ) error {
-	lastMetric, err := m.metricStore.GetNetworkMetric(deviceName, valueMetricName)
+	lastMetric, err := m.metricStore.GetNSNetworkMetric(netns, deviceName, valueMetricName)
 	if err != nil {
 		return fmt.Errorf("get value metric: %s for %s failed with err: %v",
 			valueMetricName, rateMetricName, err)
@@ -580,7 +586,7 @@ func (m *MalachiteMetricsProvisioner) setNetworkRateMetric(deviceName,
 	}
 
 	if (curValue > lastValue) && (curValue != 0) && (lastValue != 0) {
-		m.metricStore.SetNetworkMetric(deviceName, rateMetricName,
+		m.metricStore.SetNSNetworkMetric(netns, deviceName, rateMetricName,
 			utilmetric.MetricData{Value: (curValue - lastValue) / timeDeltaInSec, Time: curUpdateTime})
 	} else {
 		return fmt.Errorf("invalid curValue: %.2f, lastValue: %.2f for rateMetricName: %s",
@@ -588,6 +594,32 @@ func (m *MalachiteMetricsProvisioner) setNetworkRateMetric(deviceName,
 	}
 
 	return nil
+}
+
+func isNetworkMetricDevice(deviceName string) bool {
+	if deviceName == "" {
+		return false
+	}
+
+	return strings.HasPrefix(deviceName, "eth") || strings.HasPrefix(deviceName, "bond")
+}
+
+func (m *MalachiteMetricsProvisioner) shouldStoreNetworkMetricDevice(netns, deviceName string) bool {
+	if !isNetworkMetricDevice(deviceName) {
+		return false
+	}
+	if m == nil || m.baseConf == nil || m.baseConf.MachineInfoConfiguration == nil {
+		return true
+	}
+
+	// all_netns can return many namespaces; store only those enabled by machine config.
+	if netns == machine.DefaultNICNamespace {
+		return true
+	}
+	if !m.baseConf.NetMultipleNS {
+		return false
+	}
+	return general.IsNameEnabled(netns, nil, m.baseConf.NetAllocatableNS)
 }
 
 func (m *MalachiteMetricsProvisioner) processSystemNumaData(systemMemoryData *malachitetypes.SystemMemoryData, systemComputeData *malachitetypes.SystemComputeData) {

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner.go
@@ -616,9 +616,6 @@ func (m *MalachiteMetricsProvisioner) shouldStoreNetworkMetricDevice(netns, devi
 	if netns == machine.DefaultNICNamespace {
 		return true
 	}
-	if !m.baseConf.NetMultipleNS {
-		return false
-	}
 	return general.IsNameEnabled(netns, nil, m.baseConf.NetAllocatableNS)
 }
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -295,6 +295,41 @@ func Test_getCPI(t *testing.T) {
 	assert.Equal(t, float64(1), data.Value)
 }
 
+func Test_processContainerCPUDataStoresSleepingTasks(t *testing.T) {
+	t.Parallel()
+
+	store := utilmetric.NewMetricStore()
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	assert.Nil(t, err)
+
+	implement := NewMalachiteMetricsProvisioner(&global.BaseConfiguration{
+		ReclaimRelativeRootCgroupPath: "test",
+		MalachiteConfiguration:        &global.MalachiteConfiguration{},
+	}, &metaserver.MetricConfiguration{}, metrics.DummyMetrics{}, &pod.PodFetcherStub{}, store,
+		&machine.KatalystMachineInfo{
+			CPUTopology: cpuTopology,
+		})
+
+	fakeCgroupInfoV1 := &malachitetypes.MalachiteCgroupInfo{
+		CgroupType: "V1",
+		V1: &malachitetypes.MalachiteCgroupV1Info{
+			Cpu: &malachitetypes.CPUCgDataV1{
+				TaskNrRunning:         5,
+				TaskNrUninterruptible: 4,
+				TaskNrIoWait:          3,
+				TaskNrSleeping:        2,
+				UpdateTime:            1,
+			},
+		},
+	}
+
+	implement.(*MalachiteMetricsProvisioner).processContainerCPUData("podUID", "containerName", fakeCgroupInfoV1)
+
+	data, err := store.GetContainerMetric("podUID", "containerName", consts.MetricCPUNrSleepingContainer)
+	assert.NoError(t, err)
+	assert.Equal(t, 2.0, data.Value)
+}
+
 func Test_setContainerMbmTotalMetric(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -109,14 +109,14 @@ func Test_noneExistMetricsProvisioner(t *testing.T) {
 			},
 		},
 	}
-	fakeSystemNet := &malachitetypes.SystemNetworkData{
+	fakeSystemNet := []malachitetypes.SystemNetworkData{{
 		TCP: malachitetypes.TCP{},
 		NetworkCard: []malachitetypes.NetworkCard{
 			{
 				Name: "eth0",
 			},
 		},
-	}
+	}}
 	fakeCgroupInfoV1 := &malachitetypes.MalachiteCgroupInfo{
 		CgroupType: "V1",
 		V1: &malachitetypes.MalachiteCgroupV1Info{
@@ -293,6 +293,128 @@ func Test_getCPI(t *testing.T) {
 	data, err = store.GetContainerMetric("pod2", "container1", consts.MetricCPUCPIContainer)
 	assert.NoError(t, err)
 	assert.Equal(t, float64(1), data.Value)
+}
+
+func Test_processSystemNetDataStoresNamespacedNICMetrics(t *testing.T) {
+	t.Parallel()
+
+	store := utilmetric.NewMetricStore()
+	provisioner := &MalachiteMetricsProvisioner{metricStore: store}
+	speed := uint64(100)
+
+	provisioner.processSystemNetData([]malachitetypes.SystemNetworkData{{
+		NetNS:      "ns1",
+		UpdateTime: 1,
+		NetworkCard: []malachitetypes.NetworkCard{{
+			Name:          "eth0",
+			ReceiveBytes:  100,
+			TransmitBytes: 200,
+			Speeds:        &speed,
+		}},
+	}})
+	provisioner.processSystemNetData([]malachitetypes.SystemNetworkData{{
+		NetNS:      "ns1",
+		UpdateTime: 2,
+		NetworkCard: []malachitetypes.NetworkCard{{
+			Name:          "eth0",
+			ReceiveBytes:  190,
+			TransmitBytes: 320,
+			Speeds:        &speed,
+		}},
+	}})
+
+	rx, err := store.GetNSNetworkMetric("ns1", "eth0", consts.MetricNetReceiveBPS)
+	assert.NoError(t, err)
+	assert.Equal(t, 90.0, rx.Value)
+
+	tx, err := store.GetNSNetworkMetric("ns1", "eth0", consts.MetricNetTransmitBPS)
+	assert.NoError(t, err)
+	assert.Equal(t, 120.0, tx.Value)
+
+	_, err = store.GetNSNetworkMetric("ns1", "eth0", consts.MetricNetSpeed)
+	assert.Error(t, err)
+}
+
+func Test_processSystemNetDataFiltersUnallocatableNamespaces(t *testing.T) {
+	t.Parallel()
+
+	store := utilmetric.NewMetricStore()
+	provisioner := &MalachiteMetricsProvisioner{
+		metricStore: store,
+		baseConf: &global.BaseConfiguration{
+			MachineInfoConfiguration: &global.MachineInfoConfiguration{
+				NetMultipleNS:    true,
+				NetAllocatableNS: []string{"ns1"},
+			},
+		},
+	}
+
+	provisioner.processSystemNetData([]malachitetypes.SystemNetworkData{{
+		NetNS:      "ns1",
+		UpdateTime: 1,
+		NetworkCard: []malachitetypes.NetworkCard{
+			{Name: "eth0", ReceiveBytes: 100, TransmitBytes: 100},
+		},
+	}, {
+		NetNS:      "ns2",
+		UpdateTime: 1,
+		NetworkCard: []malachitetypes.NetworkCard{
+			{Name: "eth0", ReceiveBytes: 100, TransmitBytes: 100},
+		},
+	}})
+	provisioner.processSystemNetData([]malachitetypes.SystemNetworkData{{
+		NetNS:      "ns1",
+		UpdateTime: 2,
+		NetworkCard: []malachitetypes.NetworkCard{
+			{Name: "eth0", ReceiveBytes: 190, TransmitBytes: 190},
+		},
+	}, {
+		NetNS:      "ns2",
+		UpdateTime: 2,
+		NetworkCard: []malachitetypes.NetworkCard{
+			{Name: "eth0", ReceiveBytes: 190, TransmitBytes: 190},
+		},
+	}})
+
+	_, err := store.GetNSNetworkMetric("ns1", "eth0", consts.MetricNetReceiveBPS)
+	assert.NoError(t, err)
+
+	_, err = store.GetNSNetworkMetric("ns2", "eth0", consts.MetricNetReceiveBPS)
+	assert.Error(t, err)
+}
+
+func Test_processSystemNetDataSkipsNodeTCPMetricsWithoutDefaultNamespace(t *testing.T) {
+	t.Parallel()
+
+	store := utilmetric.NewMetricStore()
+	provisioner := &MalachiteMetricsProvisioner{
+		metricStore: store,
+		baseConf: &global.BaseConfiguration{
+			MachineInfoConfiguration: &global.MachineInfoConfiguration{
+				NetMultipleNS:    true,
+				NetAllocatableNS: []string{"ns1"},
+			},
+		},
+	}
+
+	provisioner.processSystemNetData([]malachitetypes.SystemNetworkData{{
+		NetNS:      "ns1",
+		UpdateTime: 1,
+		TCP: malachitetypes.TCP{
+			TCPDelayAcks: 99,
+		},
+		NetworkCard: []malachitetypes.NetworkCard{{
+			Name:         "eth0",
+			ReceiveBytes: 100,
+		}},
+	}})
+
+	data, err := store.GetNSNetworkMetric("ns1", "eth0", consts.MetricNetReceiveBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, 100.0, data.Value)
+
+	_, err = store.GetNodeMetric(consts.MetricNetTcpDelayedAcks)
+	assert.Error(t, err)
 }
 
 func Test_processContainerCPUDataStoresSleepingTasks(t *testing.T) {

--- a/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/provisioner_test.go
@@ -343,7 +343,6 @@ func Test_processSystemNetDataFiltersUnallocatableNamespaces(t *testing.T) {
 		metricStore: store,
 		baseConf: &global.BaseConfiguration{
 			MachineInfoConfiguration: &global.MachineInfoConfiguration{
-				NetMultipleNS:    true,
 				NetAllocatableNS: []string{"ns1"},
 			},
 		},
@@ -391,7 +390,6 @@ func Test_processSystemNetDataSkipsNodeTCPMetricsWithoutDefaultNamespace(t *test
 		metricStore: store,
 		baseConf: &global.BaseConfiguration{
 			MachineInfoConfiguration: &global.MachineInfoConfiguration{
-				NetMultipleNS:    true,
 				NetAllocatableNS: []string{"ns1"},
 			},
 		},

--- a/pkg/metaserver/agent/metric/provisioner/malachite/types/system.go
+++ b/pkg/metaserver/agent/metric/provisioner/malachite/types/system.go
@@ -64,11 +64,12 @@ type ZramStat struct {
 }
 
 type MalachiteSystemNetworkResponse struct {
-	Status int               `json:"status"`
-	Data   SystemNetworkData `json:"data"`
+	Status int                 `json:"status"`
+	Data   []SystemNetworkData `json:"data"`
 }
 
 type SystemNetworkData struct {
+	NetNS       string        `json:"netns"`
 	NetworkCard []NetworkCard `json:"networkcard"`
 	TCP         TCP           `json:"tcp"`
 	UpdateTime  int64         `json:"update_time"`

--- a/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/provisioner_test.go
@@ -126,6 +126,10 @@ func TestSample(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 54.0, data.Value)
 
+	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricCPUNrSleepingContainer)
+	require.NoError(t, err)
+	require.Equal(t, 54.0, data.Value)
+
 	data, err = f.metricStore.GetContainerMetric("2126079c-8e0a-4cfe-9a0b-583199c14027", "testContainer", consts.MetricCPUUsageContainer)
 	require.NoError(t, err)
 	require.Equal(t, 0.99, data.Value)

--- a/pkg/metaserver/agent/metric/provisioner/rodan/types/consts.go
+++ b/pkg/metaserver/agent/metric/provisioner/rodan/types/consts.go
@@ -72,10 +72,11 @@ var MetricsMap = map[string]map[string]string{
 		"cgmem_total_cache": consts.MetricMemCacheContainer,
 	},
 	ContainerLoadPath: {
-		"loadavg_nrrunning": consts.MetricCPUNrRunnableContainer,
-		"loadavg_loadavg1":  consts.MetricLoad1MinContainer,
-		"loadavg_loadavg5":  consts.MetricLoad5MinContainer,
-		"loadavg_loadavg15": consts.MetricLoad15MinContainer,
+		"loadavg_nrrunning":  consts.MetricCPUNrRunnableContainer,
+		"loadavg_nrsleeping": consts.MetricCPUNrSleepingContainer,
+		"loadavg_loadavg1":   consts.MetricLoad1MinContainer,
+		"loadavg_loadavg5":   consts.MetricLoad5MinContainer,
+		"loadavg_loadavg15":  consts.MetricLoad15MinContainer,
 	},
 	ContainerNumaStatPath: {
 		"filepage": consts.MetricsMemFilePerNumaContainer,

--- a/pkg/metaserver/agent/metric/types/metric.go
+++ b/pkg/metaserver/agent/metric/types/metric.go
@@ -72,8 +72,10 @@ type MetricsReader interface {
 	GetNumaMetric(numaID int, metricName string) (metric.MetricData, error)
 	// GetDeviceMetric get metric of device.
 	GetDeviceMetric(deviceName string, metricName string) (metric.MetricData, error)
-	// GetDeviceMetric get metric of network.
+	// GetNetworkMetric get metric of network in the default namespace.
 	GetNetworkMetric(networkName string, metricName string) (metric.MetricData, error)
+	// GetNSNetworkMetric get metric of network in the specified namespace.
+	GetNSNetworkMetric(netns, networkName string, metricName string) (metric.MetricData, error)
 	// GetCPUMetric get metric of cpu.
 	GetCPUMetric(coreID int, metricName string) (metric.MetricData, error)
 	// GetContainerMetric get metric of container.

--- a/pkg/util/machine/network.go
+++ b/pkg/util/machine/network.go
@@ -244,3 +244,28 @@ func GetInterfaceAddr(iface net.Interface) (*IfaceAddr, error) {
 func IsContainerNetNS(netnsName string) bool {
 	return strings.HasPrefix(netnsName, ContainerNetNSPrefix)
 }
+
+func FormatNICIdentifier(netns, nic string) string {
+	if netns != DefaultNICNamespace {
+		return fmt.Sprintf("%s-%s", netns, nic)
+	}
+
+	return nic
+}
+
+func ParseNICIdentifier(identifier string) (string, string, bool) {
+	if identifier == "" {
+		return "", "", false
+	}
+
+	if !strings.Contains(identifier, "-") {
+		return DefaultNICNamespace, identifier, true
+	}
+
+	index := strings.LastIndex(identifier, "-")
+	if index <= 0 || index >= len(identifier)-1 {
+		return "", "", false
+	}
+
+	return identifier[:index], identifier[index+1:], true
+}

--- a/pkg/util/machine/network_identifier_test.go
+++ b/pkg/util/machine/network_identifier_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import "testing"
+
+func TestParseNICIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		identifier string
+		wantNetNS  string
+		wantNIC    string
+		wantOK     bool
+	}{
+		{
+			name:       "default namespace identifier",
+			identifier: "eth0",
+			wantNetNS:  DefaultNICNamespace,
+			wantNIC:    "eth0",
+			wantOK:     true,
+		},
+		{
+			name:       "named namespace identifier",
+			identifier: "ns1-eth0",
+			wantNetNS:  "ns1",
+			wantNIC:    "eth0",
+			wantOK:     true,
+		},
+		{
+			name:       "empty identifier",
+			identifier: "",
+			wantOK:     false,
+		},
+		{
+			name:       "missing nic suffix",
+			identifier: "ns1-",
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotNetNS, gotNIC, gotOK := ParseNICIdentifier(tt.identifier)
+			if gotOK != tt.wantOK {
+				t.Fatalf("unexpected ok, got=%t want=%t", gotOK, tt.wantOK)
+			}
+			if gotNetNS != tt.wantNetNS {
+				t.Fatalf("unexpected netns, got=%q want=%q", gotNetNS, tt.wantNetNS)
+			}
+			if gotNIC != tt.wantNIC {
+				t.Fatalf("unexpected nic, got=%q want=%q", gotNIC, tt.wantNIC)
+			}
+			if gotOK && FormatNICIdentifier(gotNetNS, gotNIC) != tt.identifier {
+				t.Fatalf("round trip mismatch, got=%q want=%q", FormatNICIdentifier(gotNetNS, gotNIC), tt.identifier)
+			}
+		})
+	}
+}

--- a/pkg/util/metric/store.go
+++ b/pkg/util/metric/store.go
@@ -44,7 +44,7 @@ type MetricStore struct {
 	nodeMetricMap             map[string]MetricData                               // map[metricName]data
 	numaMetricMap             map[int]map[string]MetricData                       // map[numaID]map[metricName]data
 	deviceMetricMap           map[string]map[string]MetricData                    // map[deviceName]map[metricName]data
-	networkMetricMap          map[string]map[string]MetricData                    // map[networkName]map[metricName]data
+	networkMetricMap          map[string]map[string]map[string]MetricData         // map[netns]map[networkName]map[metricName]data
 	cpuMetricMap              map[int]map[string]MetricData                       // map[cpuID]map[metricName]data
 	podContainerMetricMap     map[string]map[string]map[string]MetricData         // map[podUID]map[containerName]map[metricName]data
 	podContainerNumaMetricMap map[string]map[string]map[int]map[string]MetricData // map[podUID]map[containerName]map[numaID]map[metricName]data
@@ -59,7 +59,7 @@ func NewMetricStore() *MetricStore {
 		nodeMetricMap:             make(map[string]MetricData),
 		numaMetricMap:             make(map[int]map[string]MetricData),
 		deviceMetricMap:           make(map[string]map[string]MetricData),
-		networkMetricMap:          make(map[string]map[string]MetricData),
+		networkMetricMap:          make(map[string]map[string]map[string]MetricData),
 		cpuMetricMap:              make(map[int]map[string]MetricData),
 		podContainerMetricMap:     make(map[string]map[string]map[string]MetricData),
 		podContainerNumaMetricMap: make(map[string]map[string]map[int]map[string]MetricData),
@@ -107,12 +107,19 @@ func (c *MetricStore) SetDeviceMetric(deviceName string, metricName string, data
 }
 
 func (c *MetricStore) SetNetworkMetric(networkName string, metricName string, data MetricData) {
+	c.SetNSNetworkMetric("", networkName, metricName, data)
+}
+
+func (c *MetricStore) SetNSNetworkMetric(netns, networkName string, metricName string, data MetricData) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	if _, ok := c.networkMetricMap[networkName]; !ok {
-		c.networkMetricMap[networkName] = make(map[string]MetricData)
+	if _, ok := c.networkMetricMap[netns]; !ok {
+		c.networkMetricMap[netns] = make(map[string]map[string]MetricData)
 	}
-	c.networkMetricMap[networkName][metricName] = data
+	if _, ok := c.networkMetricMap[netns][networkName]; !ok {
+		c.networkMetricMap[netns][networkName] = make(map[string]MetricData)
+	}
+	c.networkMetricMap[netns][networkName][metricName] = data
 }
 
 func (c *MetricStore) SetCPUMetric(cpuID int, metricName string, data MetricData) {
@@ -207,16 +214,20 @@ func (c *MetricStore) GetDeviceMetric(deviceName string, metricName string) (Met
 }
 
 func (c *MetricStore) GetNetworkMetric(networkName string, metricName string) (MetricData, error) {
+	return c.GetNSNetworkMetric("", networkName, metricName)
+}
+
+func (c *MetricStore) GetNSNetworkMetric(netns, networkName string, metricName string) (MetricData, error) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
-	if c.networkMetricMap[networkName] != nil {
-		if data, ok := c.networkMetricMap[networkName][metricName]; ok {
+	if c.networkMetricMap[netns] != nil && c.networkMetricMap[netns][networkName] != nil {
+		if data, ok := c.networkMetricMap[netns][networkName][metricName]; ok {
 			return data, nil
 		} else {
-			return MetricData{}, errors.New(fmt.Sprintf("[MetricStore] load value failed, metric=%v, networkName=%v", metricName, networkName))
+			return MetricData{}, errors.New(fmt.Sprintf("[MetricStore] load value failed, metric=%v, netns=%v, networkName=%v", metricName, netns, networkName))
 		}
 	}
-	return MetricData{}, errors.New(fmt.Sprintf("[MetricStore] empty map, metric=%v, networkName=%v", metricName, networkName))
+	return MetricData{}, errors.New(fmt.Sprintf("[MetricStore] empty map, metric=%v, netns=%v, networkName=%v", metricName, netns, networkName))
 }
 
 func (c *MetricStore) GetCPUMetric(coreID int, metricName string) (MetricData, error) {

--- a/pkg/util/metric/store_test.go
+++ b/pkg/util/metric/store_test.go
@@ -64,6 +64,32 @@ func TestStore_SetAndGeDeviceMetric(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestStore_SetAndGetNSNetworkMetric(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	store := NewMetricStore()
+	store.SetNetworkMetric("eth0", "test-metric-name", MetricData{Value: 1.0, Time: &now})
+	store.SetNSNetworkMetric("ns1", "eth0", "test-metric-name", MetricData{Value: 2.0, Time: &now})
+	store.SetNSNetworkMetric("ns2", "eth0", "test-metric-name", MetricData{Value: 3.0, Time: &now})
+
+	value, err := store.GetNetworkMetric("eth0", "test-metric-name")
+	assert.NoError(t, err)
+	assert.Equal(t, MetricData{Value: 1.0, Time: &now}, value)
+
+	value, err = store.GetNSNetworkMetric("ns1", "eth0", "test-metric-name")
+	assert.NoError(t, err)
+	assert.Equal(t, MetricData{Value: 2.0, Time: &now}, value)
+
+	value, err = store.GetNSNetworkMetric("ns2", "eth0", "test-metric-name")
+	assert.NoError(t, err)
+	assert.Equal(t, MetricData{Value: 3.0, Time: &now}, value)
+
+	_, err = store.GetNSNetworkMetric("ns3", "eth0", "test-metric-name")
+	assert.Error(t, err)
+}
+
 func TestStore_SetAndGetCPUMetric(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/util/native/pod_sorter.go
+++ b/pkg/util/native/pod_sorter.go
@@ -56,6 +56,17 @@ func PodPriorityCmpFunc(i1, i2 interface{}) int {
 	return general.CmpInt32(priority1, priority2)
 }
 
+// PodSaleModeCmpFunc sorts pods by sale mode with the highest eviction priority first.
+func PodSaleModeCmpFunc(annotationKey string) general.CmpFunc {
+	saleModePriority := GetPodSaleModePriority()
+	return func(i1, i2 interface{}) int {
+		p1SaleMode := GetPodSaleMode(i1.(*v1.Pod), annotationKey)
+		p2SaleMode := GetPodSaleMode(i2.(*v1.Pod), annotationKey)
+
+		return -general.CmpInt32(saleModePriority[p1SaleMode], saleModePriority[p2SaleMode])
+	}
+}
+
 // PodCPURequestCmpFunc sorts cpu request of pods with less comparison
 func PodCPURequestCmpFunc(i1, i2 interface{}) int {
 	p1Request := SumUpPodRequestResources(i1.(*v1.Pod))
@@ -76,6 +87,7 @@ func PodUniqKeyCmpFunc(i1, i2 interface{}) int {
 }
 
 var (
+	_ general.CmpFunc = PodSaleModeCmpFunc("")
 	_ general.CmpFunc = PodPriorityCmpFunc
 	_ general.CmpFunc = PodCPURequestCmpFunc
 	_ general.CmpFunc = PodUniqKeyCmpFunc

--- a/pkg/util/native/pods.go
+++ b/pkg/util/native/pods.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 )
 
@@ -58,6 +60,41 @@ func PodAnnotationFilter(pod *v1.Pod, key, value string) bool {
 	}
 
 	return pod.Annotations[key] == value
+}
+
+func getPodSaleModeAnnotationKey(annotationKey string) string {
+	if annotationKey == "" {
+		return apiconsts.PodAnnotationSaleModeKey
+	}
+	return annotationKey
+}
+
+// GetPodSaleMode returns the normalized sale mode of the given pod.
+func GetPodSaleMode(pod *v1.Pod, annotationKey string) string {
+	if pod == nil || pod.Annotations == nil {
+		return apiconsts.PodSaleModeDefault
+	}
+
+	switch pod.Annotations[getPodSaleModeAnnotationKey(annotationKey)] {
+	case apiconsts.PodSaleModeSpot:
+		return apiconsts.PodSaleModeSpot
+	case apiconsts.PodSaleModeScheduled:
+		return apiconsts.PodSaleModeScheduled
+	case apiconsts.PodSaleModeReserved:
+		return apiconsts.PodSaleModeReserved
+	default:
+		return apiconsts.PodSaleModeDefault
+	}
+}
+
+// GetPodSaleModePriority returns the fixed sale mode order used by eviction.
+func GetPodSaleModePriority() map[string]int32 {
+	return map[string]int32{
+		apiconsts.PodSaleModeSpot:      0,
+		apiconsts.PodSaleModeScheduled: 1,
+		apiconsts.PodSaleModeReserved:  2,
+		apiconsts.PodSaleModeDefault:   3,
+	}
 }
 
 // FilterPods filter pods that filter func return true.

--- a/pkg/util/native/pods_test.go
+++ b/pkg/util/native/pods_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
 
 func TestFilterPodAnnotations(t *testing.T) {
@@ -389,4 +390,134 @@ func TestGetPodRequestResources(t *testing.T) {
 	res := GetPodRequestResources(pods[0], consts.ReclaimedResourceMilliCPU)
 	assert.NotEqual(t, res, (*resource.Quantity)(nil))
 	assert.Equal(t, res.Value(), int64(100))
+}
+
+func TestGetPodSaleMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		annotationKey string
+		want          string
+	}{
+		{
+			name: "nil pod returns default",
+			want: consts.PodSaleModeDefault,
+		},
+		{
+			name: "missing annotations returns default",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-without-annotations"},
+			},
+			annotationKey: consts.PodAnnotationSaleModeKey,
+			want:          consts.PodSaleModeDefault,
+		},
+		{
+			name: "empty annotation key falls back to default api key",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-with-default-key",
+					Annotations: map[string]string{
+						consts.PodAnnotationSaleModeKey: consts.PodSaleModeScheduled,
+					},
+				},
+			},
+			want: consts.PodSaleModeScheduled,
+		},
+		{
+			name: "custom annotation key is respected",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-with-custom-key",
+					Annotations: map[string]string{
+						"bytedance.quota.salemode":      consts.PodSaleModeReserved,
+						consts.PodAnnotationSaleModeKey: consts.PodSaleModeSpot,
+					},
+				},
+			},
+			annotationKey: "bytedance.quota.salemode",
+			want:          consts.PodSaleModeReserved,
+		},
+		{
+			name: "invalid sale mode falls back to default",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod-with-invalid-sale-mode",
+					Annotations: map[string]string{
+						consts.PodAnnotationSaleModeKey: "invalid-sale-mode",
+					},
+				},
+			},
+			annotationKey: consts.PodAnnotationSaleModeKey,
+			want:          consts.PodSaleModeDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, GetPodSaleMode(tt.pod, tt.annotationKey))
+		})
+	}
+}
+
+func TestPodSaleModeCmpFunc(t *testing.T) {
+	t.Parallel()
+
+	spotPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-b",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"salemode": consts.PodSaleModeSpot,
+			},
+		},
+	}
+	scheduledPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-d",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"salemode": consts.PodSaleModeScheduled,
+			},
+		},
+	}
+	reservedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-a",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"salemode": consts.PodSaleModeReserved,
+			},
+		},
+	}
+	defaultPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-c",
+			Namespace: "default",
+		},
+	}
+
+	cmp := PodSaleModeCmpFunc("salemode")
+	assert.Less(t, cmp(spotPod, reservedPod), 0)
+	assert.Greater(t, cmp(defaultPod, scheduledPod), 0)
+
+	pods := []*v1.Pod{defaultPod, reservedPod, scheduledPod, spotPod}
+	general.NewMultiSorter(PodSaleModeCmpFunc("salemode"), PodUniqKeyCmpFunc).Sort(NewPodSourceImpList(pods))
+
+	assert.Equal(t, []string{"pod-b", "pod-d", "pod-a", "pod-c"}, getPodNamesBySaleMode(pods))
+}
+
+func getPodNamesBySaleMode(pods []*v1.Pod) []string {
+	podNames := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		podNames = append(podNames, pod.Name)
+	}
+	return podNames
 }


### PR DESCRIPTION
#### What type of PR is this?

Features

#### What this PR does / why we need it:

add pid overuse and network bandwidth eviction plugin

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable pod sale-mode annotation key (with default) to influence eviction ordering.
  * Introduced NIC bandwidth eviction with new thresholds, continuous/ring-based pressure detection, and grace period.
  * Added PID overuse CPU eviction with enablement, threshold, grace period, and candidate label/annotation selector filters.
  * Enabled namespace-aware network metrics and added a “sleeping” CPU task count metric.
* **Bug Fixes**
  * Improved network metric scoping and standardized NIC identifier formatting.
* **Tests**
  * Added/expanded unit tests for PID overuse, NIC bandwidth eviction, and namespace-scoped metric behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->