### PR TITLE
fix(gpu reporter): handle devices with no NUMA nodes

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -57,6 +57,10 @@ const (
 	metricGetPodListFailed                      = "qrm_gpu_reporter_get_pod_list_failed"
 	metricAddKubeletCheckpointAllocationsFailed = "qrm_gpu_reporter_add_kubelet_checkpoint_allocations_failed"
 	metricEnsureKubeletDevicePluginPathFailed   = "qrm_gpu_reporter_ensure_kubelet_device_plugin_path_failed"
+	metricAddGPUZoneNodesFallbackNUMA           = "qrm_gpu_reporter_add_gpu_zone_nodes_fallback_numa"
+	// fallbackNUMANodeID is used when a device has no NUMA nodes reported;
+	// the device is attached under this NUMA node so its zone is still emitted.
+	fallbackNUMANodeID = 0
 )
 
 var zeroQuantity = *resource.NewQuantity(0, resource.DecimalSI)
@@ -683,7 +687,7 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 	return nil
 }
 
-// addGPUZoneNodes adds the gpu zone nodes to the topology zone generator
+// addGPUZoneNodes adds the gpu zone nodes to the topology zone generator.
 func (p *gpuReporterPlugin) addGPUZoneNodes(deviceTopology *machine.DeviceTopology, generator *util.TopologyZoneGenerator) error {
 	if deviceTopology == nil {
 		return nil
@@ -693,7 +697,20 @@ func (p *gpuReporterPlugin) addGPUZoneNodes(deviceTopology *machine.DeviceTopolo
 
 	for id, device := range deviceTopology.Devices {
 		deviceNode := util.GenerateDeviceZoneNode(id, string(nodev1alpha1.TopologyTypeGPU))
-		for _, numaNode := range device.NumaNodes {
+
+		numaNodes := device.NumaNodes
+		// If a device has no NUMA nodes, it is attached under NUMA fallbackNUMANodeID
+		// so its zone is still emitted; a warning log and a counter metric are recorded.
+		if len(numaNodes) == 0 {
+			general.Warningf("device %s has no NUMA nodes; defaulting to NUMA %d", id, fallbackNUMANodeID)
+			if p.emitter != nil {
+				_ = p.emitter.StoreInt64(metricAddGPUZoneNodesFallbackNUMA, 1, metrics.MetricTypeNameCount,
+					metrics.MetricTag{Key: "device_id", Val: id})
+			}
+			numaNodes = []int{fallbackNUMANodeID}
+		}
+
+		for _, numaNode := range numaNodes {
 			numaZoneNode := util.GenerateNumaZoneNode(numaNode)
 			err := generator.AddNode(&numaZoneNode, deviceNode)
 			if err != nil {

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -2925,4 +2927,130 @@ func TestGpuReporterPlugin_StartEnsureKubeletDevicePluginPathFailureNilEmitter(t
 	err = p.Start()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ensure kubelet device plugin path")
+}
+
+func TestGpuReporterPlugin_addGPUZoneNodes(t *testing.T) {
+	t.Parallel()
+
+	numaSocketMap := map[util.ZoneNode]util.ZoneNode{
+		util.GenerateNumaZoneNode(0): util.GenerateSocketZoneNode(0),
+		util.GenerateNumaZoneNode(1): util.GenerateSocketZoneNode(0),
+	}
+
+	testCases := []struct {
+		name              string
+		topology          *machine.DeviceTopology
+		expectedParents   map[string][]int
+		expectFallbackIDs []string
+	}{
+		{
+			name:              "nil topology is a no-op",
+			topology:          nil,
+			expectedParents:   map[string][]int{},
+			expectFallbackIDs: nil,
+		},
+		{
+			name: "device with populated NumaNodes",
+			topology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"gpu-0": {NumaNodes: []int{0}},
+				},
+			},
+			expectedParents:   map[string][]int{"gpu-0": {0}},
+			expectFallbackIDs: nil,
+		},
+		{
+			name: "device with nil NumaNodes falls back to NUMA 0",
+			topology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"gpu-0": {NumaNodes: nil},
+				},
+			},
+			expectedParents:   map[string][]int{"gpu-0": {0}},
+			expectFallbackIDs: []string{"gpu-0"},
+		},
+		{
+			name: "device with empty NumaNodes slice falls back to NUMA 0",
+			topology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"gpu-0": {NumaNodes: []int{}},
+				},
+			},
+			expectedParents:   map[string][]int{"gpu-0": {0}},
+			expectFallbackIDs: []string{"gpu-0"},
+		},
+		{
+			name: "mixed devices: populated + empty",
+			topology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"gpu-0": {NumaNodes: []int{1}},
+					"gpu-1": {NumaNodes: nil},
+				},
+			},
+			expectedParents:   map[string][]int{"gpu-0": {1}, "gpu-1": {0}},
+			expectFallbackIDs: []string{"gpu-1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			generator, err := util.NewNumaSocketTopologyZoneGenerator(numaSocketMap)
+			assert.NoError(t, err)
+
+			emitter := newMockMetricsEmitter()
+			p := &gpuReporterPlugin{emitter: emitter}
+
+			err = p.addGPUZoneNodes(tc.topology, generator)
+			assert.NoError(t, err)
+
+			got := collectDeviceParents(t, generator)
+			assert.Equal(t, tc.expectedParents, got)
+
+			gotVals := emitter.storedInt64[metricAddGPUZoneNodesFallbackNUMA]
+			assert.Len(t, gotVals, len(tc.expectFallbackIDs))
+
+			gotTagIDs := make([]string, 0, len(emitter.storedTags[metricAddGPUZoneNodesFallbackNUMA]))
+			for _, tags := range emitter.storedTags[metricAddGPUZoneNodesFallbackNUMA] {
+				for _, tag := range tags {
+					if tag.Key == "device_id" {
+						gotTagIDs = append(gotTagIDs, tag.Val)
+					}
+				}
+			}
+			assert.ElementsMatch(t, tc.expectFallbackIDs, gotTagIDs)
+		})
+	}
+}
+
+// collectDeviceParents walks the topology zone tree produced by `generator` and
+// returns a mapping from each device zone's Name (= device id) to the sorted
+// list of NUMA IDs that appear as its parent in the tree.
+func collectDeviceParents(t *testing.T, generator *util.TopologyZoneGenerator) map[string][]int {
+	t.Helper()
+	zones := generator.GenerateTopologyZoneStatus(nil, nil, nil, nil, nil, nil)
+
+	out := map[string][]int{}
+	var walk func(parentNumaID *int, zs []*nodev1alpha1.TopologyZone)
+	walk = func(parentNumaID *int, zs []*nodev1alpha1.TopologyZone) {
+		for _, z := range zs {
+			var nextParent *int
+			if z.Type == nodev1alpha1.TopologyTypeNuma {
+				id, err := strconv.Atoi(z.Name)
+				assert.NoError(t, err)
+				nextParent = &id
+			} else if z.Type == nodev1alpha1.TopologyTypeGPU && parentNumaID != nil {
+				out[z.Name] = append(out[z.Name], *parentNumaID)
+			}
+			walk(nextParent, z.Children)
+		}
+	}
+	walk(nil, zones)
+
+	for k := range out {
+		sort.Ints(out[k])
+	}
+	return out
 }


### PR DESCRIPTION
Add fallback NUMA node 0 for GPU devices that report no NUMA affinity, add a metric and warning log for this case, and add comprehensive unit tests to validate the behavior.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
