### PR TITLE
fix(qrm): qrm_mb_plugin uses 1000*1000 in args of mb usage

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/mb_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/mb_plugin.go
@@ -82,7 +82,7 @@ func (o *MBOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.Float64Var(&o.CCDCapKp, "mb-ccd-cap-kp",
 		o.CCDCapKp, "proportional gain for ccd cap governance")
 	fs.StringToIntVar(&o.CCDCapGroups, "mb-ccd-cap-groups",
-		o.CCDCapGroups, "per-group target actual mb per ccd (e.g. dedicated=20000,shared-50=24000)")
+		o.CCDCapGroups, "per-group target actual MB(not MiB) per ccd (e.g. dedicated=20000,shared-50=24000)")
 	fs.IntVar(&o.MaxIncomingRemoteMB, "mb-remote-limit",
 		o.MaxIncomingRemoteMB, "max mb allowed from remote domains")
 	fs.IntVar(&o.MBCapLimitPercent, "mb-cap-limit-percent",

--- a/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/advisor/resource"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/plan"
+	mbconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/policy/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
 
@@ -46,8 +47,8 @@ func (a *uniqPriorityAdvisor) emitDomIncomingStatSummaryMetrics(domLimits map[in
 			"domain": fmt.Sprintf("%d", domID),
 			"state":  string(limit.ResourceState),
 		}
-		emitKV(a.emitter, nameMBMCapacity, limit.CapacityInMB, tags)
-		emitKV(a.emitter, nameMBMFree, limit.FreeInMB, tags)
+		emitKV(a.emitter, nameMBMCapacity, int64(limit.CapacityInMB*mbconsts.BytesPerMB), tags)
+		emitKV(a.emitter, nameMBMFree, int64(limit.FreeInMB*mbconsts.BytesPerMB), tags)
 	}
 }
 
@@ -74,7 +75,9 @@ func (a *uniqPriorityAdvisor) emitStat(stats map[int]monitor.DomainMonStat, metr
 					"group":  group,
 					"ccd":    fmt.Sprintf("%d", ccd),
 				}
-				emitKV(a.emitter, metricName, v.TotalMB, tags)
+				// MBInfo stores MB to avoid int32 overflow (60 GB = 60000 MB, within int range),
+				// but metrics are emitted in bytes for consistency with other systems.
+				emitKV(a.emitter, metricName, int64(v.TotalMB)*mbconsts.BytesPerMB, tags)
 			}
 		}
 	}
@@ -111,14 +114,14 @@ func (a *uniqPriorityAdvisor) emitPlanWithMetricName(plan *plan.MBPlan, metricNa
 				"group": group,
 				"ccd":   fmt.Sprintf("%d", ccd),
 			}
-			emitKV(a.emitter, metricName, v, tags)
+			emitKV(a.emitter, metricName, int64(v*mbconsts.BytesPerMB), tags)
 		}
 	}
 }
 
-func emitKV(emitter metrics.MetricEmitter, k string, v int, tags map[string]string) {
+func emitKV(emitter metrics.MetricEmitter, k string, v int64, tags map[string]string) {
 	_ = emitter.StoreInt64(k,
-		int64(v),
+		v,
 		metrics.MetricTypeNameRaw,
 		metrics.ConvertMapToTags(tags)...,
 	)
@@ -131,7 +134,7 @@ func emitNamedGroupTargets(emitter metrics.MetricEmitter, name string, groupedDo
 				"group":  group,
 				"domain": fmt.Sprintf("%d", domID),
 			}
-			emitKV(emitter, name, v, tags)
+			emitKV(emitter, name, int64(v*mbconsts.BytesPerMB), tags)
 		}
 	}
 }

--- a/pkg/agent/qrm-plugins/mb/allocator/resctrl_allocator_test.go
+++ b/pkg/agent/qrm-plugins/mb/allocator/resctrl_allocator_test.go
@@ -143,8 +143,8 @@ func Test_resctrlAllocator_Allocate(t *testing.T) {
 			},
 			wantErr: false,
 			want: map[string]string{
-				"shared-50": "MB:0=32;2=36;\n",
-				"shared-30": "MB:1=48;2=24;\n",
+				"shared-50": "MB:0=30;2=34;\n",
+				"shared-30": "MB:1=45;2=23;\n",
 			},
 		},
 	}

--- a/pkg/agent/qrm-plugins/mb/plan/types.go
+++ b/pkg/agent/qrm-plugins/mb/plan/types.go
@@ -21,10 +21,12 @@ import (
 	"sort"
 	"strings"
 
+	mbconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/policy/consts"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 )
 
-const mbUnitAMD = 1_000 / 8 // AMD schemata value in unit of 1/8 GB
+// AMD schemata MB value in unit of 1/8 GiB (128 MiB)
+const mbUnitAMD = 1024 / 8
 
 // GroupCCDPlan is for single control group, with
 // key as CCD id, value as memory bandwidth quota in MegaBytes
@@ -83,6 +85,11 @@ func getSortedCCDs(c GroupCCDPlan) []int {
 	return keys
 }
 
+// mbToMiB converts MB (1000*1000 bytes) to MiB (1024*1024 bytes) for AMD schemata
+func mbToMiB(mb int) int {
+	return mb * mbconsts.BytesPerMB / mbconsts.BytesPerMiB
+}
+
 func (c GroupCCDPlan) ToSchemataInstruction() []byte {
 	// the result looks like  "MB:2=32;3=32;"
 	var sb strings.Builder
@@ -90,7 +97,8 @@ func (c GroupCCDPlan) ToSchemataInstruction() []byte {
 
 	for _, ccd := range getSortedCCDs(c) {
 		mb := c[ccd]
-		v := (mb + mbUnitAMD - 1) / mbUnitAMD
+		miB := mbToMiB(mb)
+		v := (miB + mbUnitAMD - 1) / mbUnitAMD
 		sb.WriteString(fmt.Sprintf("%d=%d;", ccd, v))
 	}
 

--- a/pkg/agent/qrm-plugins/mb/plan/types_test.go
+++ b/pkg/agent/qrm-plugins/mb/plan/types_test.go
@@ -34,7 +34,7 @@ func TestCCDPlan_ToSchemataInstruction(t *testing.T) {
 			c: GroupCCDPlan{
 				0: 4_000, 2: 4_500,
 			},
-			want: []byte("MB:0=32;2=36;\n"),
+			want: []byte("MB:0=30;2=34;\n"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/agent/qrm-plugins/mb/policy/capacity.go
+++ b/pkg/agent/qrm-plugins/mb/policy/capacity.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/policy/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/helper"
 	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
@@ -60,7 +61,7 @@ func initGroupCapacities(metricFetcher metrictypes.MetricsFetcher,
 		break
 	}
 	// mb_plugin processes mem bandwidth in MB units
-	defaultMBDomainCapacity := int(mbAllocatable / 1024 / 1024)
+	defaultMBDomainCapacity := int(mbAllocatable / consts.BytesPerMB)
 	if defaultMBDomainCapacity < minMBCapacity {
 		return nil, 0, fmt.Errorf("invalid domain mb capacity %d as configured", defaultMBDomainCapacity)
 	}

--- a/pkg/agent/qrm-plugins/mb/policy/consts/consts.go
+++ b/pkg/agent/qrm-plugins/mb/policy/consts/consts.go
@@ -16,4 +16,12 @@ limitations under the License.
 
 package consts
 
-const MBPluginPolicyNameGeneric = "generic"
+const (
+	MBPluginPolicyNameGeneric = "generic"
+
+	// BytesPerMB is 1,000,000 for mem bandwidth usage calculation, not 1024*1024
+	BytesPerMB = 1000 * 1000
+
+	// BytesPerMiB is 2-based 1024*1024, for internal stats  and metrics reported
+	BytesPerMiB = 1024 * 1024
+)

--- a/pkg/agent/qrm-plugins/mb/reader/mb_reader.go
+++ b/pkg/agent/qrm-plugins/mb/reader/mb_reader.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/monitor"
+	mbconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/mb/policy/consts"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	malachitetypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/provisioner/malachite/types"
 	metrictypes "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric/types"
@@ -34,9 +35,11 @@ import (
 )
 
 const (
+	// increase toleration threshold as previous 3 seconds lead to quite some portion of skipped cycles
 	tolerationTime = 3 * time.Second
-	rootGroup      = "root"
-	maxCCDTotalMB  = 60 * 1024
+
+	rootGroup     = "root"
+	maxCCDTotalMB = 60 * 1024 * mbconsts.BytesPerMiB / mbconsts.BytesPerMB // 60 GiB in MB
 )
 
 // localIsVictimAndTotalIsAllRead indicates special settings of resctrl controlling reg1 & reg2 which yield
@@ -195,13 +198,13 @@ func calcGroupMBRate(newCounter, oldCounter []malachitetypes.MBCCDStat, msElapse
 				ccd, ccdCounter.MBTotalCounter, oldCCDCounter.MBTotalCounter)
 		}
 
-		rateLocalMB := int64(ccdCounter.MBLocalCounter-oldCCDCounter.MBLocalCounter) * 1000 / msElapsed / 1024 / 1024
+		rateLocalMB := toMB(int64(ccdCounter.MBLocalCounter-oldCCDCounter.MBLocalCounter) * 1000 / msElapsed)
 		if rateLocalMB < 0 {
 			return nil, fmt.Errorf("skip local mb cal: ccd %d, new %v, old %v",
 				ccd, ccdCounter.MBLocalCounter, oldCCDCounter.MBLocalCounter)
 		}
 
-		rateTotalMB := int64(ccdCounter.MBTotalCounter-oldCCDCounter.MBTotalCounter) * 1000 / msElapsed / 1024 / 1024
+		rateTotalMB := toMB(int64(ccdCounter.MBTotalCounter-oldCCDCounter.MBTotalCounter) * 1000 / msElapsed)
 		if rateTotalMB < 0 {
 			return nil, fmt.Errorf("skip total mb cal: ccd %v, new %v, old %v",
 				ccd, ccdCounter.MBTotalCounter, oldCCDCounter.MBTotalCounter)
@@ -222,6 +225,10 @@ func calcGroupMBRate(newCounter, oldCounter []malachitetypes.MBCCDStat, msElapse
 				ccd, rateTotalMB)
 		}
 
+		// Store in MB:
+		//   1) Avoid int32 overflow — 60 GB = 60000 MB fits within int.
+		//   2) Control simplicity — downstream plan/advisor all work in MB.
+		// Converted back to bytes when emitting metrics in advisor_metrics.go.
 		result[ccd] = monitor.MBInfo{
 			LocalMB:  int(rateLocalMB),
 			RemoteMB: int(rateTotalMB - rateLocalMB),
@@ -230,6 +237,10 @@ func calcGroupMBRate(newCounter, oldCounter []malachitetypes.MBCCDStat, msElapse
 	}
 
 	return result, nil
+}
+
+func toMB(value int64) int64 {
+	return value / mbconsts.BytesPerMB
 }
 
 func calcVictimTotalLocalMB(statTotal, statLocal int64) (total, local int64) {

--- a/pkg/agent/qrm-plugins/mb/reader/mb_reader_test.go
+++ b/pkg/agent/qrm-plugins/mb/reader/mb_reader_test.go
@@ -147,16 +147,16 @@ func Test_metaServerMBReader_getMBData(t *testing.T) {
 				MBBody: monitor.GroupMBStats{
 					"/": {
 						1: {
-							LocalMB:  10,
+							LocalMB:  11,
 							RemoteMB: 0,
-							TotalMB:  10,
+							TotalMB:  11,
 						},
 					},
 					"shared-50": {
 						2: {
-							LocalMB:  10,
+							LocalMB:  11,
 							RemoteMB: 0,
-							TotalMB:  10,
+							TotalMB:  11,
 						},
 					},
 				},


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
Current mem bandwidth args uses MiB/s (1024*1024) a unit of args. This unit is off to MB/s that customers are used to. We need to switch to MB/s in consistency.

Besides, metrics the plugin emits is in unit of MiB/s, which is unnecessary and sort of rigidity - raw byte/s is more flexible and intuitive.
  
1. for all args about qrm_mb_plugin, it is in MB/s (10^6) unit, in line with customer jargon;
2. mem bandwidth stats metrics reported by qrm_mb_plugin is in raw BYTEs; so the grafana could display in GB or GiB as needed:
<img width="1495" height="475" alt="image" src="https://github.com/user-attachments/assets/c229c431-95bc-499d-b248-1750e8e4ca81" />
<img width="1495" height="305" alt="image" src="https://github.com/user-attachments/assets/7b24278d-e435-4eda-a23a-27a392def68c" />
