### PR TITLE
feat(qrm/cpu): add EnableBypassCPUSetAdjustment to skip cpuset backfill for shared/reclaimed/system pools

### DIFF
--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/qrm/cpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/qrm/cpu_plugin.go
@@ -24,6 +24,7 @@ import (
 
 type CPUPluginOptions struct {
 	PreferUseExistNUMAHintResult bool
+	EnableBypassCPUSetAdjustment bool
 }
 
 func NewCPUPluginOptions() *CPUPluginOptions {
@@ -34,10 +35,15 @@ func (o *CPUPluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs := fss.FlagSet("qrm-cpu-plugin")
 	fs.BoolVar(&o.PreferUseExistNUMAHintResult, "prefer-use-exist-numa-hint-result", o.PreferUseExistNUMAHintResult,
 		"prefer to use existing numa hint results")
+	fs.BoolVar(&o.EnableBypassCPUSetAdjustment, "enable-bypass-cpuset-adjustment", o.EnableBypassCPUSetAdjustment,
+		"if true, QRM CPU plugin clears the cpuset string in PackAllocationResponse "+
+			"for shared_cores/reclaimed_cores/system_cores; cpuset adjustment is delegated "+
+			"to the reconcile plugin. Dedicated pools are unaffected.")
 }
 
 func (o *CPUPluginOptions) ApplyTo(c *qrm.CPUPluginConfiguration) error {
 	c.PreferUseExistNUMAHintResult = o.PreferUseExistNUMAHintResult
+	c.EnableBypassCPUSetAdjustment = o.EnableBypassCPUSetAdjustment
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,5 @@ replace (
 	k8s.io/sample-controller => k8s.io/sample-controller v0.24.6
 	sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6
 )
+
+replace github.com/kubewharf/katalyst-api => github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439

--- a/go.sum
+++ b/go.sum
@@ -574,8 +574,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b h1:PHTBNy7sb0srh4dcD3TjjX0OV+IFr9d3A8EftLfcBbg=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
@@ -587,6 +585,8 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
+github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439 h1:eBKIJkzz56pL27seLJ0oqMGCvUBLBnWwhBeQGTFI+uE=
+github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -722,6 +722,9 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 					},
 				},
 			}
+			if p.shouldBypassCPUSetAdjustment(allocationInfo.QoSLevel) {
+				clearCPUSetInAllocation(podResources[podUID].ContainerResources[containerName])
+			}
 		}
 	}
 
@@ -1079,7 +1082,7 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 			return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 		}
 
-		return resp, nil
+		return p.applyCPUSetBypass(resp, allocationInfo.QoSLevel), nil
 	}
 
 	if p.allocationHandlers[qosLevel] == nil {
@@ -1558,4 +1561,52 @@ func (p *DynamicPolicy) updateAllocationInfo(podUID, containerName string, oldAl
 
 	p.state.SetAllocationInfo(podUID, containerName, allocationInfo, persist)
 	return nil
+}
+
+// shouldBypassCPUSetAdjustment reports whether the cpuset string for the given
+// QoS level should be cleared before returning to kubelet. Only shared_cores /
+// reclaimed_cores / system_cores are affected when EnableBypassCPUSetAdjustment
+// is on; dedicated_cores always keep their cpuset backfill.
+func (p *DynamicPolicy) shouldBypassCPUSetAdjustment(qosLevel string) bool {
+	if p.dynamicConfig == nil {
+		return false
+	}
+	dyn := p.dynamicConfig.GetDynamicConfiguration()
+	if dyn == nil || !dyn.EnableBypassCPUSetAdjustment {
+		return false
+	}
+	switch qosLevel {
+	case consts.PodAnnotationQoSLevelSharedCores,
+		consts.PodAnnotationQoSLevelReclaimedCores,
+		consts.PodAnnotationQoSLevelSystemCores:
+		return true
+	default:
+		return false
+	}
+}
+
+// clearCPUSetInAllocation clears the cpuset string on every entry of a
+// *pluginapi.ResourceAllocation in place, leaving TopologyAssignments,
+// AllocatedQuantity, ResourceHints and Annotations untouched. It is a no-op
+// when the input is nil.
+func clearCPUSetInAllocation(alloc *pluginapi.ResourceAllocation) {
+	if alloc == nil {
+		return
+	}
+	for _, info := range alloc.ResourceAllocation {
+		if info != nil {
+			info.AllocationResult = ""
+		}
+	}
+}
+
+// applyCPUSetBypass clears the cpuset string on a ResourceAllocationResponse
+// when bypass is required for the given QoS level. All other fields are
+// preserved; nil / empty responses are returned unchanged.
+func (p *DynamicPolicy) applyCPUSetBypass(resp *pluginapi.ResourceAllocationResponse, qosLevel string) *pluginapi.ResourceAllocationResponse {
+	if resp == nil || !p.shouldBypassCPUSetAdjustment(qosLevel) {
+		return resp
+	}
+	clearCPUSetInAllocation(resp.AllocationResult)
+	return resp
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -205,7 +205,7 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSharedCores), nil
 }
 
 func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
@@ -337,7 +337,7 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelReclaimedCores), nil
 }
 
 // updateReclaimAllocationResultByPoolEntry updates non-actual numa binding reclaimed allocation result by pool entry
@@ -513,7 +513,7 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingAllocationHandler(ctx conte
 		return nil, fmt.Errorf("accompany resource AugmentAllocationResult failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelDedicatedCores), nil
 }
 
 // allocationSidecarHandler currently we set cpuset of sidecar to the cpuset of its main container
@@ -571,7 +571,7 @@ func (p *DynamicPolicy) allocationSidecarHandler(_ context.Context,
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, qosLevel), nil
 }
 
 func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.Context,
@@ -612,7 +612,7 @@ func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.
 		return nil, fmt.Errorf("accompany resource AugmentAllocationResult failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSharedCores), nil
 }
 
 // allocateNumaBindingCPUs allocates CPUs for NUMA binding containers.
@@ -2192,7 +2192,7 @@ func (p *DynamicPolicy) systemCoresAllocationHandler(ctx context.Context, req *p
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSystemCores), nil
 }
 
 // getSystemPoolCPUSetAndNumaAwareAssignments gets the system pool cpuset and topologyAwareAssignments for the allocationInfo.

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+)
+
+// newPolicyForBypassTest builds a minimal DynamicPolicy that only carries the
+// dynamic-configuration field required by the bypass helpers under test.
+func newPolicyForBypassTest(enabled bool) *DynamicPolicy {
+	dyn := dynamicconfig.NewDynamicAgentConfiguration()
+	dyn.GetDynamicConfiguration().EnableBypassCPUSetAdjustment = enabled
+	return &DynamicPolicy{dynamicConfig: dyn}
+}
+
+func TestShouldBypassCPUSetAdjustment(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		enabled  bool
+		qosLevel string
+		want     bool
+	}{
+		{"switch off + shared", false, consts.PodAnnotationQoSLevelSharedCores, false},
+		{"switch off + reclaimed", false, consts.PodAnnotationQoSLevelReclaimedCores, false},
+		{"switch off + system", false, consts.PodAnnotationQoSLevelSystemCores, false},
+		{"switch off + dedicated", false, consts.PodAnnotationQoSLevelDedicatedCores, false},
+		{"switch on + shared", true, consts.PodAnnotationQoSLevelSharedCores, true},
+		{"switch on + reclaimed", true, consts.PodAnnotationQoSLevelReclaimedCores, true},
+		{"switch on + system", true, consts.PodAnnotationQoSLevelSystemCores, true},
+		{"switch on + dedicated", true, consts.PodAnnotationQoSLevelDedicatedCores, false},
+		{"switch on + unknown QoS", true, "unknown", false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := newPolicyForBypassTest(tc.enabled)
+			assert.Equal(t, tc.want, p.shouldBypassCPUSetAdjustment(tc.qosLevel))
+		})
+	}
+
+	t.Run("nil dynamicConfig", func(t *testing.T) {
+		t.Parallel()
+		p := &DynamicPolicy{dynamicConfig: nil}
+		assert.False(t, p.shouldBypassCPUSetAdjustment(consts.PodAnnotationQoSLevelSharedCores))
+	})
+}
+
+func TestApplyCPUSetBypass(t *testing.T) {
+	t.Parallel()
+
+	// buildResp constructs a canonical response with cpuset string and
+	// TopologyAssignments filled, so we can verify per-field preservation.
+	buildResp := func() *pluginapi.ResourceAllocationResponse {
+		return &pluginapi.ResourceAllocationResponse{
+			AllocationResult: &pluginapi.ResourceAllocation{
+				ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+					"cpu": {
+						IsScalarResource:  true,
+						AllocatedQuantity: 4,
+						AllocationResult:  "0-3",
+						ResourceHints: &pluginapi.ListOfTopologyHints{
+							Hints: []*pluginapi.TopologyHint{{Nodes: []uint64{0}, Preferred: true}},
+						},
+						Annotations: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("nil response", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		got := p.applyCPUSetBypass(nil, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil AllocationResult", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := &pluginapi.ResourceAllocationResponse{AllocationResult: nil}
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Same(t, resp, got)
+		assert.Nil(t, got.AllocationResult)
+	})
+
+	t.Run("bypass on + shared clears cpuset only", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+
+		info := got.AllocationResult.ResourceAllocation["cpu"]
+		assert.Equal(t, "", info.AllocationResult, "cpuset string should be cleared")
+		assert.EqualValues(t, 4, info.AllocatedQuantity, "AllocatedQuantity preserved")
+		assert.NotNil(t, info.ResourceHints, "ResourceHints preserved")
+		assert.Equal(t, map[string]string{"foo": "bar"}, info.Annotations, "Annotations preserved")
+	})
+
+	t.Run("bypass on + dedicated keeps cpuset", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelDedicatedCores)
+		assert.Equal(t, "0-3", got.AllocationResult.ResourceAllocation["cpu"].AllocationResult)
+	})
+
+	t.Run("bypass off keeps cpuset", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(false)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Equal(t, "0-3", got.AllocationResult.ResourceAllocation["cpu"].AllocationResult)
+	})
+
+	t.Run("nil entry inside ResourceAllocation is skipped", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := &pluginapi.ResourceAllocationResponse{
+			AllocationResult: &pluginapi.ResourceAllocation{
+				ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+					"cpu":  nil,
+					"cpu2": {AllocationResult: "10-11"},
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		})
+		assert.Equal(t, "", resp.AllocationResult.ResourceAllocation["cpu2"].AllocationResult)
+	})
+}
+
+func TestClearCPUSetInAllocation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil allocation", func(t *testing.T) {
+		t.Parallel()
+		assert.NotPanics(t, func() { clearCPUSetInAllocation(nil) })
+	})
+
+	t.Run("clears cpuset in place, preserves other fields", func(t *testing.T) {
+		t.Parallel()
+		alloc := &pluginapi.ResourceAllocation{
+			ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+				"cpu": {
+					AllocatedQuantity:   4,
+					AllocationResult:    "0-3",
+					TopologyAssignments: map[uint64]uint64{0: 4},
+					Annotations:         map[string]string{"k": "v"},
+				},
+			},
+		}
+		clearCPUSetInAllocation(alloc)
+		info := alloc.ResourceAllocation["cpu"]
+		assert.Equal(t, "", info.AllocationResult)
+		assert.EqualValues(t, 4, info.AllocatedQuantity)
+		assert.Equal(t, uint64(4), info.TopologyAssignments[0])
+		assert.Equal(t, "v", info.Annotations["k"])
+	})
+}

--- a/pkg/config/agent/dynamic/adminqos/qrm/cpu_plugin.go
+++ b/pkg/config/agent/dynamic/adminqos/qrm/cpu_plugin.go
@@ -21,7 +21,12 @@ import (
 )
 
 type CPUPluginConfiguration struct {
-	PreferUseExistNUMAHintResult   bool
+	PreferUseExistNUMAHintResult bool
+	// EnableBypassCPUSetAdjustment controls whether QRM's PackAllocationResponse
+	// clears the cpuset string for shared_cores / reclaimed_cores / system_cores
+	// pools. When enabled, cpuset adjustment is delegated to the reconcile plugin
+	// and dedicated_cores are unaffected.
+	EnableBypassCPUSetAdjustment   bool
 	SystemExclusivePool            map[string]int
 	SystemExclusivePoolShrinkRatio *float64
 	SystemExclusivePoolShrinkMin   *int64
@@ -38,6 +43,9 @@ func (c *CPUPluginConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) 
 		config := aqc.Spec.Config.QRMPluginConfig.CPUPluginConfig
 		if config.PreferUseExistNUMAHintResult != nil {
 			c.PreferUseExistNUMAHintResult = *config.PreferUseExistNUMAHintResult
+		}
+		if config.EnableBypassCPUSetAdjustment != nil {
+			c.EnableBypassCPUSetAdjustment = *config.EnableBypassCPUSetAdjustment
 		}
 		c.SystemExclusivePool = config.SystemExclusivePool
 		c.SystemExclusivePoolShrinkRatio = config.SystemExclusivePoolShrinkRatio


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

Add a new dynamic switch `EnableBypassCPUSetAdjustment` to the QRM CPU plugin. When enabled, the QRM CPU plugin **skips backfilling the cpuset string** in `AllocationResult` on the `ResourceAllocationResponse` returned to kubelet for the following QoS pools:

- `shared_cores`
- `reclaimed_cores`
- `system_cores`

`dedicated_cores` are unaffected (still bound by QRM). `TopologyAssignments` (NUMA-aware assignment counts) are also preserved on all paths.

Why: In the "Sandbox on GPU" scheduling-domain adjustment work, the actual cpuset delivery is delegated to the reconcile plugin (async path). The QRM sync path clearing its cpuset string prevents the two paths from overwriting each other.

Related design: Feishu doc `MUQJdbx5koOzSRxfAUHcwg4dnRd`.
Related API PR: kubewharf/katalyst-api#204 (adds the `EnableBypassCPUSetAdjustment` field).

## Design highlights

- **Signature stable**: `PackAllocationResponse` is unchanged; bypass is a *response post-process* inside `dynamicpolicy`.
- **Single point of convergence**: two small helpers in `policy.go`:
  - `shouldBypassCPUSetAdjustment(qosLevel)` — decides whether to bypass based on the dynamic config + QoS level.
  - `applyCPUSetBypass(resp, qosLevel)` / `clearCPUSetInAllocation(alloc)` — clears only the `AllocationResult` cpuset string; all other fields (TopologyAssignments, AllocatedQuantity, Annotations, hints) are preserved.
- **Two response paths covered**:
  - `Allocate` fast-return in `policy.go` and all six allocation handlers in `policy_allocation_handlers.go`.
  - `GetResourcesAllocation` (kubelet's periodic re-check) in `policy.go`.
- **Native policy is untouched**.
- **Default off**: field defaults to `false`; behavior is identical to main branch when disabled.

## Which issue(s) this PR fixes

Depends-on: kubewharf/katalyst-api#204

## Special notes for your reviewer

- `go.mod` currently uses a temporary `replace` directive pointing at `luomingmeng/katalyst-api` at commit `dc80502b4439`, since the API PR has not merged yet. Once katalyst-api#204 lands and a proper release/pseudo-version is available, the `replace` will be removed and the `require` line will be bumped.
- Unit tests: `pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go` covers `shouldBypassCPUSetAdjustment`, `applyCPUSetBypass`, and `clearCPUSetInAllocation` with table-driven cases.

## Does this PR introduce a user-facing change?

```release-note
Add a dynamic switch `EnableBypassCPUSetAdjustment` to the QRM CPU plugin. When enabled, cpuset string backfill is skipped for shared/reclaimed/system pools in both the Allocate response and GetResourcesAllocation, allowing the reconcile plugin to own cpuset delivery. Default: disabled. Dedicated pools are unaffected.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CPU set bypass option for the CPU agent, available through configuration and a command-line flag.
  * When enabled, certain CPU allocation results now omit CPU set adjustments for specific QoS levels.

* **Bug Fixes**
  * Improved allocation handling so CPU set values are cleared only where intended, while preserving other allocation details.

* **Tests**
  * Added coverage for the new bypass behavior and allocation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->