### PR TITLE
feat(sandbox-isolation): add core primitives (ApplySchedLoadBalance, ReadonlyStateSnapshot)

### DIFF
--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/qrm/cpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/qrm/cpu_plugin.go
@@ -24,6 +24,7 @@ import (
 
 type CPUPluginOptions struct {
 	PreferUseExistNUMAHintResult bool
+	EnableBypassCPUSetAdjustment bool
 }
 
 func NewCPUPluginOptions() *CPUPluginOptions {
@@ -34,10 +35,15 @@ func (o *CPUPluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs := fss.FlagSet("qrm-cpu-plugin")
 	fs.BoolVar(&o.PreferUseExistNUMAHintResult, "prefer-use-exist-numa-hint-result", o.PreferUseExistNUMAHintResult,
 		"prefer to use existing numa hint results")
+	fs.BoolVar(&o.EnableBypassCPUSetAdjustment, "enable-bypass-cpuset-adjustment", o.EnableBypassCPUSetAdjustment,
+		"if true, QRM CPU plugin clears the cpuset string in PackAllocationResponse "+
+			"for shared_cores/reclaimed_cores/system_cores; cpuset adjustment is delegated "+
+			"to the reconcile plugin. Dedicated pools are unaffected.")
 }
 
 func (o *CPUPluginOptions) ApplyTo(c *qrm.CPUPluginConfiguration) error {
 	c.PreferUseExistNUMAHintResult = o.PreferUseExistNUMAHintResult
+	c.EnableBypassCPUSetAdjustment = o.EnableBypassCPUSetAdjustment
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,5 @@ replace (
 	k8s.io/sample-controller => k8s.io/sample-controller v0.24.6
 	sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6
 )
+
+replace github.com/kubewharf/katalyst-api => github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439

--- a/go.sum
+++ b/go.sum
@@ -574,8 +574,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b h1:PHTBNy7sb0srh4dcD3TjjX0OV+IFr9d3A8EftLfcBbg=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
@@ -587,6 +585,8 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
+github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439 h1:eBKIJkzz56pL27seLJ0oqMGCvUBLBnWwhBeQGTFI+uE=
+github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
@@ -58,6 +58,7 @@ func (m *MockState) GetAllocationInfo(podUID string, containerName string) *stat
 	return nil
 }
 func (m *MockState) GetAllowSharedCoresOverlapReclaimedCores() bool               { return false }
+func (m *MockState) Snapshot() *state.ReadonlyStateSnapshot                       { return &state.ReadonlyStateSnapshot{} }
 func (m *MockState) SetMachineState(numaNodeMap state.NUMANodeMap, persist bool)  {}
 func (m *MockState) SetNUMAHeadroom(numaHeadroom map[int]float64, persist bool)   {}
 func (m *MockState) SetPodEntries(podEntries state.PodEntries, writeThrough bool) {}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
@@ -58,7 +58,7 @@ func (m *MockState) GetAllocationInfo(podUID string, containerName string) *stat
 	return nil
 }
 func (m *MockState) GetAllowSharedCoresOverlapReclaimedCores() bool               { return false }
-func (m *MockState) Snapshot() *state.ReadonlyStateSnapshot                       { return &state.ReadonlyStateSnapshot{} }
+func (m *MockState) Snapshot() state.ReadonlyState                                { return &state.ReadonlyStateSnapshot{} }
 func (m *MockState) SetMachineState(numaNodeMap state.NUMANodeMap, persist bool)  {}
 func (m *MockState) SetNUMAHeadroom(numaHeadroom map[int]float64, persist bool)   {}
 func (m *MockState) SetPodEntries(podEntries state.PodEntries, writeThrough bool) {}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
@@ -67,11 +67,7 @@ func (f *fakeState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 }
 
 func (f *fakeState) Snapshot() *state.ReadonlyStateSnapshot {
-	return &state.ReadonlyStateSnapshot{
-		MachineState:                          f.machineState,
-		PodEntries:                            f.podEntries,
-		AllowSharedCoresOverlapReclaimedCores: f.allowOverlap,
-	}
+	return state.NewReadonlyStateSnapshot(f.podEntries, f.machineState, nil, f.allowOverlap)
 }
 
 func (f *fakeState) SetMachineState(numaNodeMap state.NUMANodeMap, _ bool) {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
@@ -66,8 +66,8 @@ func (f *fakeState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return f.allowOverlap
 }
 
-func (f *fakeState) Snapshot() *state.ReadonlyStateSnapshot {
-	return state.NewReadonlyStateSnapshot(f.podEntries, f.machineState, nil, f.allowOverlap)
+func (f *fakeState) Snapshot() state.ReadonlyState {
+	return f
 }
 
 func (f *fakeState) SetMachineState(numaNodeMap state.NUMANodeMap, _ bool) {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
@@ -66,6 +66,14 @@ func (f *fakeState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return f.allowOverlap
 }
 
+func (f *fakeState) Snapshot() *state.ReadonlyStateSnapshot {
+	return &state.ReadonlyStateSnapshot{
+		MachineState:                          f.machineState,
+		PodEntries:                            f.podEntries,
+		AllowSharedCoresOverlapReclaimedCores: f.allowOverlap,
+	}
+}
+
 func (f *fakeState) SetMachineState(numaNodeMap state.NUMANodeMap, _ bool) {
 	f.machineState = numaNodeMap
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -722,6 +722,9 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 					},
 				},
 			}
+			if p.shouldBypassCPUSetAdjustment(allocationInfo.QoSLevel) {
+				clearCPUSetInAllocation(podResources[podUID].ContainerResources[containerName])
+			}
 		}
 	}
 
@@ -1079,7 +1082,7 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 			return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 		}
 
-		return resp, nil
+		return p.applyCPUSetBypass(resp, allocationInfo.QoSLevel), nil
 	}
 
 	if p.allocationHandlers[qosLevel] == nil {
@@ -1558,4 +1561,52 @@ func (p *DynamicPolicy) updateAllocationInfo(podUID, containerName string, oldAl
 
 	p.state.SetAllocationInfo(podUID, containerName, allocationInfo, persist)
 	return nil
+}
+
+// shouldBypassCPUSetAdjustment reports whether the cpuset string for the given
+// QoS level should be cleared before returning to kubelet. Only shared_cores /
+// reclaimed_cores / system_cores are affected when EnableBypassCPUSetAdjustment
+// is on; dedicated_cores always keep their cpuset backfill.
+func (p *DynamicPolicy) shouldBypassCPUSetAdjustment(qosLevel string) bool {
+	if p.dynamicConfig == nil {
+		return false
+	}
+	dyn := p.dynamicConfig.GetDynamicConfiguration()
+	if dyn == nil || !dyn.EnableBypassCPUSetAdjustment {
+		return false
+	}
+	switch qosLevel {
+	case consts.PodAnnotationQoSLevelSharedCores,
+		consts.PodAnnotationQoSLevelReclaimedCores,
+		consts.PodAnnotationQoSLevelSystemCores:
+		return true
+	default:
+		return false
+	}
+}
+
+// clearCPUSetInAllocation clears the cpuset string on every entry of a
+// *pluginapi.ResourceAllocation in place, leaving TopologyAssignments,
+// AllocatedQuantity, ResourceHints and Annotations untouched. It is a no-op
+// when the input is nil.
+func clearCPUSetInAllocation(alloc *pluginapi.ResourceAllocation) {
+	if alloc == nil {
+		return
+	}
+	for _, info := range alloc.ResourceAllocation {
+		if info != nil {
+			info.AllocationResult = ""
+		}
+	}
+}
+
+// applyCPUSetBypass clears the cpuset string on a ResourceAllocationResponse
+// when bypass is required for the given QoS level. All other fields are
+// preserved; nil / empty responses are returned unchanged.
+func (p *DynamicPolicy) applyCPUSetBypass(resp *pluginapi.ResourceAllocationResponse, qosLevel string) *pluginapi.ResourceAllocationResponse {
+	if resp == nil || !p.shouldBypassCPUSetAdjustment(qosLevel) {
+		return resp
+	}
+	clearCPUSetInAllocation(resp.AllocationResult)
+	return resp
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -205,7 +205,7 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSharedCores), nil
 }
 
 func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
@@ -337,7 +337,7 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelReclaimedCores), nil
 }
 
 // updateReclaimAllocationResultByPoolEntry updates non-actual numa binding reclaimed allocation result by pool entry
@@ -513,7 +513,7 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingAllocationHandler(ctx conte
 		return nil, fmt.Errorf("accompany resource AugmentAllocationResult failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelDedicatedCores), nil
 }
 
 // allocationSidecarHandler currently we set cpuset of sidecar to the cpuset of its main container
@@ -571,7 +571,7 @@ func (p *DynamicPolicy) allocationSidecarHandler(_ context.Context,
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, qosLevel), nil
 }
 
 func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.Context,
@@ -612,7 +612,7 @@ func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.
 		return nil, fmt.Errorf("accompany resource AugmentAllocationResult failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSharedCores), nil
 }
 
 // allocateNumaBindingCPUs allocates CPUs for NUMA binding containers.
@@ -2192,7 +2192,7 @@ func (p *DynamicPolicy) systemCoresAllocationHandler(ctx context.Context, req *p
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSystemCores), nil
 }
 
 // getSystemPoolCPUSetAndNumaAwareAssignments gets the system pool cpuset and topologyAwareAssignments for the allocationInfo.

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+)
+
+// newPolicyForBypassTest builds a minimal DynamicPolicy that only carries the
+// dynamic-configuration field required by the bypass helpers under test.
+func newPolicyForBypassTest(enabled bool) *DynamicPolicy {
+	dyn := dynamicconfig.NewDynamicAgentConfiguration()
+	dyn.GetDynamicConfiguration().EnableBypassCPUSetAdjustment = enabled
+	return &DynamicPolicy{dynamicConfig: dyn}
+}
+
+func TestShouldBypassCPUSetAdjustment(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		enabled  bool
+		qosLevel string
+		want     bool
+	}{
+		{"switch off + shared", false, consts.PodAnnotationQoSLevelSharedCores, false},
+		{"switch off + reclaimed", false, consts.PodAnnotationQoSLevelReclaimedCores, false},
+		{"switch off + system", false, consts.PodAnnotationQoSLevelSystemCores, false},
+		{"switch off + dedicated", false, consts.PodAnnotationQoSLevelDedicatedCores, false},
+		{"switch on + shared", true, consts.PodAnnotationQoSLevelSharedCores, true},
+		{"switch on + reclaimed", true, consts.PodAnnotationQoSLevelReclaimedCores, true},
+		{"switch on + system", true, consts.PodAnnotationQoSLevelSystemCores, true},
+		{"switch on + dedicated", true, consts.PodAnnotationQoSLevelDedicatedCores, false},
+		{"switch on + unknown QoS", true, "unknown", false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := newPolicyForBypassTest(tc.enabled)
+			assert.Equal(t, tc.want, p.shouldBypassCPUSetAdjustment(tc.qosLevel))
+		})
+	}
+
+	t.Run("nil dynamicConfig", func(t *testing.T) {
+		t.Parallel()
+		p := &DynamicPolicy{dynamicConfig: nil}
+		assert.False(t, p.shouldBypassCPUSetAdjustment(consts.PodAnnotationQoSLevelSharedCores))
+	})
+}
+
+func TestApplyCPUSetBypass(t *testing.T) {
+	t.Parallel()
+
+	// buildResp constructs a canonical response with cpuset string and
+	// TopologyAssignments filled, so we can verify per-field preservation.
+	buildResp := func() *pluginapi.ResourceAllocationResponse {
+		return &pluginapi.ResourceAllocationResponse{
+			AllocationResult: &pluginapi.ResourceAllocation{
+				ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+					"cpu": {
+						IsScalarResource:  true,
+						AllocatedQuantity: 4,
+						AllocationResult:  "0-3",
+						ResourceHints: &pluginapi.ListOfTopologyHints{
+							Hints: []*pluginapi.TopologyHint{{Nodes: []uint64{0}, Preferred: true}},
+						},
+						Annotations: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("nil response", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		got := p.applyCPUSetBypass(nil, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil AllocationResult", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := &pluginapi.ResourceAllocationResponse{AllocationResult: nil}
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Same(t, resp, got)
+		assert.Nil(t, got.AllocationResult)
+	})
+
+	t.Run("bypass on + shared clears cpuset only", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+
+		info := got.AllocationResult.ResourceAllocation["cpu"]
+		assert.Equal(t, "", info.AllocationResult, "cpuset string should be cleared")
+		assert.EqualValues(t, 4, info.AllocatedQuantity, "AllocatedQuantity preserved")
+		assert.NotNil(t, info.ResourceHints, "ResourceHints preserved")
+		assert.Equal(t, map[string]string{"foo": "bar"}, info.Annotations, "Annotations preserved")
+	})
+
+	t.Run("bypass on + dedicated keeps cpuset", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelDedicatedCores)
+		assert.Equal(t, "0-3", got.AllocationResult.ResourceAllocation["cpu"].AllocationResult)
+	})
+
+	t.Run("bypass off keeps cpuset", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(false)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Equal(t, "0-3", got.AllocationResult.ResourceAllocation["cpu"].AllocationResult)
+	})
+
+	t.Run("nil entry inside ResourceAllocation is skipped", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := &pluginapi.ResourceAllocationResponse{
+			AllocationResult: &pluginapi.ResourceAllocation{
+				ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+					"cpu":  nil,
+					"cpu2": {AllocationResult: "10-11"},
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		})
+		assert.Equal(t, "", resp.AllocationResult.ResourceAllocation["cpu2"].AllocationResult)
+	})
+}
+
+func TestClearCPUSetInAllocation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil allocation", func(t *testing.T) {
+		t.Parallel()
+		assert.NotPanics(t, func() { clearCPUSetInAllocation(nil) })
+	})
+
+	t.Run("clears cpuset in place, preserves other fields", func(t *testing.T) {
+		t.Parallel()
+		alloc := &pluginapi.ResourceAllocation{
+			ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+				"cpu": {
+					AllocatedQuantity:   4,
+					AllocationResult:    "0-3",
+					TopologyAssignments: map[uint64]uint64{0: 4},
+					Annotations:         map[string]string{"k": "v"},
+				},
+			},
+		}
+		clearCPUSetInAllocation(alloc)
+		info := alloc.ResourceAllocation["cpu"]
+		assert.Equal(t, "", info.AllocationResult)
+		assert.EqualValues(t, 4, info.AllocatedQuantity)
+		assert.Equal(t, uint64(4), info.TopologyAssignments[0])
+		assert.Equal(t, "v", info.Annotations["k"])
+	})
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -754,10 +754,13 @@ type cpuPluginStateData struct {
 	allowSharedCoresOverlapReclaimedCores bool
 }
 
-// Clone deep-copies every field of cpuPluginStateData. It is intentionally
-// defined on a value receiver so the caller gets a fresh, fully-owned copy
-// that is safe to hand off to another goroutine without extra synchronization.
-func (d cpuPluginStateData) Clone() cpuPluginStateData {
+// Clone deep-copies every field of cpuPluginStateData. The caller receives a
+// fresh, fully-owned copy that is safe to hand off to another goroutine
+// without extra synchronization.
+func (d *cpuPluginStateData) Clone() cpuPluginStateData {
+	if d == nil {
+		return cpuPluginStateData{}
+	}
 	return cpuPluginStateData{
 		podEntries:                            d.podEntries.Clone(),
 		machineState:                          d.machineState.Clone(),

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -740,6 +740,77 @@ func (nm NUMANodeMap) String() string {
 	return string(contentBytes)
 }
 
+// cpuPluginStateData is a lock-free plain-field container that holds the
+// non-topology portion of the cpu-plugin state. It is shared between the
+// in-memory cpuPluginState (which wraps it with an RWMutex and clones on
+// every getter) and ReadonlyStateSnapshot (which pre-clones once and then
+// exposes the fields directly). Grouping the fields into a single value
+// makes it trivial to deep-copy the whole set in one place (see Clone) and
+// to satisfy the reader interface via struct embedding.
+type cpuPluginStateData struct {
+	podEntries                            PodEntries
+	machineState                          NUMANodeMap
+	numaHeadroom                          map[int]float64
+	allowSharedCoresOverlapReclaimedCores bool
+}
+
+// Clone deep-copies every field of cpuPluginStateData. It is intentionally
+// defined on a value receiver so the caller gets a fresh, fully-owned copy
+// that is safe to hand off to another goroutine without extra synchronization.
+func (d cpuPluginStateData) Clone() cpuPluginStateData {
+	return cpuPluginStateData{
+		podEntries:                            d.podEntries.Clone(),
+		machineState:                          d.machineState.Clone(),
+		numaHeadroom:                          general.DeepCopyIntToFloat64Map(d.numaHeadroom),
+		allowSharedCoresOverlapReclaimedCores: d.allowSharedCoresOverlapReclaimedCores,
+	}
+}
+
+// GetMachineState returns the raw machine-state reference held by the data
+// container. Callers that need a mutable copy must Clone() it themselves.
+func (d *cpuPluginStateData) GetMachineState() NUMANodeMap {
+	if d == nil {
+		return nil
+	}
+	return d.machineState
+}
+
+// GetNUMAHeadroom returns the raw NUMA-headroom map reference.
+func (d *cpuPluginStateData) GetNUMAHeadroom() map[int]float64 {
+	if d == nil {
+		return nil
+	}
+	return d.numaHeadroom
+}
+
+// GetPodEntries returns the raw pod-entries reference.
+func (d *cpuPluginStateData) GetPodEntries() PodEntries {
+	if d == nil {
+		return nil
+	}
+	return d.podEntries
+}
+
+// GetAllocationInfo looks up an allocation for the given pod/container using
+// the raw pod-entries map.
+func (d *cpuPluginStateData) GetAllocationInfo(podUID string, containerName string) *AllocationInfo {
+	if d == nil {
+		return nil
+	}
+	if entries, ok := d.podEntries[podUID]; ok {
+		return entries[containerName]
+	}
+	return nil
+}
+
+// GetAllowSharedCoresOverlapReclaimedCores returns the flag value.
+func (d *cpuPluginStateData) GetAllowSharedCoresOverlapReclaimedCores() bool {
+	if d == nil {
+		return false
+	}
+	return d.allowSharedCoresOverlapReclaimedCores
+}
+
 // reader is used to get information from local states
 type reader interface {
 	GetMachineState() NUMANodeMap
@@ -789,59 +860,34 @@ type ReadonlyState interface {
 // Snapshot() at the top of a tick and treat every field as immutable
 // afterwards. Consumers that need a modified view should call Clone() on the
 // individual sub-fields they care about.
+//
+// The embedded cpuPluginStateData provides the reader-interface methods
+// (GetMachineState / GetPodEntries / ...) as plain-field accessors, so no
+// per-call locking or cloning happens on a snapshot.
 type ReadonlyStateSnapshot struct {
-	MachineState                          NUMANodeMap
-	PodEntries                            PodEntries
-	NUMAHeadroom                          map[int]float64
-	AllowSharedCoresOverlapReclaimedCores bool
+	cpuPluginStateData
 }
 
-// GetMachineState returns the pre-cloned machine state captured at snapshot
-// time. It intentionally does not clone again: callers must not mutate the
-// returned map.
-func (s *ReadonlyStateSnapshot) GetMachineState() NUMANodeMap {
-	if s == nil {
-		return nil
+// NewReadonlyStateSnapshot builds a ReadonlyStateSnapshot from the given
+// fields without cloning. The caller is responsible for ensuring the inputs
+// are safe to be treated as immutable for the lifetime of the returned
+// snapshot (typically by deep-copying beforehand). This constructor exists
+// to keep the embedded cpuPluginStateData fields unexported while still
+// allowing tests and adapters to synthesize a snapshot directly.
+func NewReadonlyStateSnapshot(
+	podEntries PodEntries,
+	machineState NUMANodeMap,
+	numaHeadroom map[int]float64,
+	allowSharedCoresOverlapReclaimedCores bool,
+) *ReadonlyStateSnapshot {
+	return &ReadonlyStateSnapshot{
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:                            podEntries,
+			machineState:                          machineState,
+			numaHeadroom:                          numaHeadroom,
+			allowSharedCoresOverlapReclaimedCores: allowSharedCoresOverlapReclaimedCores,
+		},
 	}
-	return s.MachineState
-}
-
-// GetNUMAHeadroom returns the pre-cloned NUMA headroom map captured at
-// snapshot time.
-func (s *ReadonlyStateSnapshot) GetNUMAHeadroom() map[int]float64 {
-	if s == nil {
-		return nil
-	}
-	return s.NUMAHeadroom
-}
-
-// GetPodEntries returns the pre-cloned pod entries captured at snapshot time.
-func (s *ReadonlyStateSnapshot) GetPodEntries() PodEntries {
-	if s == nil {
-		return nil
-	}
-	return s.PodEntries
-}
-
-// GetAllocationInfo returns the allocation info for the given pod/container
-// from the snapshot. The returned pointer is shared with the snapshot; do not
-// mutate it.
-func (s *ReadonlyStateSnapshot) GetAllocationInfo(podUID string, containerName string) *AllocationInfo {
-	if s == nil {
-		return nil
-	}
-	if entries, ok := s.PodEntries[podUID]; ok {
-		return entries[containerName]
-	}
-	return nil
-}
-
-// GetAllowSharedCoresOverlapReclaimedCores returns the snapshotted flag value.
-func (s *ReadonlyStateSnapshot) GetAllowSharedCoresOverlapReclaimedCores() bool {
-	if s == nil {
-		return false
-	}
-	return s.AllowSharedCoresOverlapReclaimedCores
 }
 
 // Snapshot is idempotent on a snapshot: returning the receiver keeps the
@@ -868,6 +914,20 @@ func GetReadonlyState() (ReadonlyState, error) {
 		return nil, fmt.Errorf("readonlyState isn't set")
 	}
 	return readonlyState, nil
+}
+
+// GetReadonlyStateSnapshot is a convenience wrapper that fetches the current
+// process-wide ReadonlyState and immediately materializes a deep-copied,
+// lock-free snapshot from it. Tick-scoped consumers (e.g. periodical handlers
+// that fan out multiple concurrent reads within a single tick) should prefer
+// this helper over calling GetReadonlyState().Snapshot() manually so that
+// snapshot semantics stay centralized.
+func GetReadonlyStateSnapshot() (*ReadonlyStateSnapshot, error) {
+	s, err := GetReadonlyState()
+	if err != nil {
+		return nil, err
+	}
+	return s.Snapshot(), nil
 }
 
 // SetReadonlyState updates the readonlyState in a thread-safe manner.

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -747,6 +747,12 @@ type reader interface {
 	GetPodEntries() PodEntries
 	GetAllocationInfo(podUID string, containerName string) *AllocationInfo
 	GetAllowSharedCoresOverlapReclaimedCores() bool
+	// Snapshot returns a deep-copied, lock-free view of the reader's data so
+	// downstream consumers (e.g. periodical handlers that fan out across
+	// multiple goroutines within a single tick) can iterate over a stable
+	// snapshot without contending for the underlying lock or paying repeated
+	// clone costs. Every read on the returned snapshot is a plain field access.
+	Snapshot() *ReadonlyStateSnapshot
 }
 
 // writer is used to store information into local states,
@@ -772,6 +778,77 @@ type State interface {
 // ReadonlyState interface only provides methods for tracking pod assignments
 type ReadonlyState interface {
 	reader
+}
+
+// ReadonlyStateSnapshot is a deep-copied, lock-free view of the cpu-plugin
+// state at a single point in time. It implements the reader interface so it
+// can be passed through the same channels as a live ReadonlyState while
+// guaranteeing that every read observes the same stable value.
+//
+// The struct is intentionally not thread-safe for writes: build it once via
+// Snapshot() at the top of a tick and treat every field as immutable
+// afterwards. Consumers that need a modified view should call Clone() on the
+// individual sub-fields they care about.
+type ReadonlyStateSnapshot struct {
+	MachineState                          NUMANodeMap
+	PodEntries                            PodEntries
+	NUMAHeadroom                          map[int]float64
+	AllowSharedCoresOverlapReclaimedCores bool
+}
+
+// GetMachineState returns the pre-cloned machine state captured at snapshot
+// time. It intentionally does not clone again: callers must not mutate the
+// returned map.
+func (s *ReadonlyStateSnapshot) GetMachineState() NUMANodeMap {
+	if s == nil {
+		return nil
+	}
+	return s.MachineState
+}
+
+// GetNUMAHeadroom returns the pre-cloned NUMA headroom map captured at
+// snapshot time.
+func (s *ReadonlyStateSnapshot) GetNUMAHeadroom() map[int]float64 {
+	if s == nil {
+		return nil
+	}
+	return s.NUMAHeadroom
+}
+
+// GetPodEntries returns the pre-cloned pod entries captured at snapshot time.
+func (s *ReadonlyStateSnapshot) GetPodEntries() PodEntries {
+	if s == nil {
+		return nil
+	}
+	return s.PodEntries
+}
+
+// GetAllocationInfo returns the allocation info for the given pod/container
+// from the snapshot. The returned pointer is shared with the snapshot; do not
+// mutate it.
+func (s *ReadonlyStateSnapshot) GetAllocationInfo(podUID string, containerName string) *AllocationInfo {
+	if s == nil {
+		return nil
+	}
+	if entries, ok := s.PodEntries[podUID]; ok {
+		return entries[containerName]
+	}
+	return nil
+}
+
+// GetAllowSharedCoresOverlapReclaimedCores returns the snapshotted flag value.
+func (s *ReadonlyStateSnapshot) GetAllowSharedCoresOverlapReclaimedCores() bool {
+	if s == nil {
+		return false
+	}
+	return s.AllowSharedCoresOverlapReclaimedCores
+}
+
+// Snapshot is idempotent on a snapshot: returning the receiver keeps the
+// reader interface satisfiable and lets tick-scoped code pass the snapshot
+// through helpers that expect any reader without extra copies.
+func (s *ReadonlyStateSnapshot) Snapshot() *ReadonlyStateSnapshot {
+	return s
 }
 
 type GenerateMachineStateFromPodEntriesFunc func(topology *machine.CPUTopology, podEntries PodEntries, originMachineState NUMANodeMap) (NUMANodeMap, error)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -821,12 +821,6 @@ type reader interface {
 	GetPodEntries() PodEntries
 	GetAllocationInfo(podUID string, containerName string) *AllocationInfo
 	GetAllowSharedCoresOverlapReclaimedCores() bool
-	// Snapshot returns a deep-copied, lock-free view of the reader's data so
-	// downstream consumers (e.g. periodical handlers that fan out across
-	// multiple goroutines within a single tick) can iterate over a stable
-	// snapshot without contending for the underlying lock or paying repeated
-	// clone costs. Every read on the returned snapshot is a plain field access.
-	Snapshot() *ReadonlyStateSnapshot
 }
 
 // writer is used to store information into local states,
@@ -845,13 +839,19 @@ type writer interface {
 
 // State interface provides methods for tracking and setting pod assignments
 type State interface {
-	reader
+	ReadonlyState
 	writer
 }
 
 // ReadonlyState interface only provides methods for tracking pod assignments
 type ReadonlyState interface {
 	reader
+	// Snapshot returns a deep-copied, lock-free view of the reader's data so
+	// downstream consumers (e.g. periodical handlers that fan out across
+	// multiple goroutines within a single tick) can iterate over a stable
+	// snapshot without contending for the underlying lock or paying repeated
+	// clone costs. Every read on the returned snapshot is a plain field access.
+	Snapshot() ReadonlyState
 }
 
 // ReadonlyStateSnapshot is a deep-copied, lock-free view of the cpu-plugin
@@ -871,32 +871,10 @@ type ReadonlyStateSnapshot struct {
 	cpuPluginStateData
 }
 
-// NewReadonlyStateSnapshot builds a ReadonlyStateSnapshot from the given
-// fields without cloning. The caller is responsible for ensuring the inputs
-// are safe to be treated as immutable for the lifetime of the returned
-// snapshot (typically by deep-copying beforehand). This constructor exists
-// to keep the embedded cpuPluginStateData fields unexported while still
-// allowing tests and adapters to synthesize a snapshot directly.
-func NewReadonlyStateSnapshot(
-	podEntries PodEntries,
-	machineState NUMANodeMap,
-	numaHeadroom map[int]float64,
-	allowSharedCoresOverlapReclaimedCores bool,
-) *ReadonlyStateSnapshot {
-	return &ReadonlyStateSnapshot{
-		cpuPluginStateData: cpuPluginStateData{
-			podEntries:                            podEntries,
-			machineState:                          machineState,
-			numaHeadroom:                          numaHeadroom,
-			allowSharedCoresOverlapReclaimedCores: allowSharedCoresOverlapReclaimedCores,
-		},
-	}
-}
-
 // Snapshot is idempotent on a snapshot: returning the receiver keeps the
 // reader interface satisfiable and lets tick-scoped code pass the snapshot
 // through helpers that expect any reader without extra copies.
-func (s *ReadonlyStateSnapshot) Snapshot() *ReadonlyStateSnapshot {
+func (s *ReadonlyStateSnapshot) Snapshot() ReadonlyState {
 	return s
 }
 
@@ -925,7 +903,7 @@ func GetReadonlyState() (ReadonlyState, error) {
 // that fan out multiple concurrent reads within a single tick) should prefer
 // this helper over calling GetReadonlyState().Snapshot() manually so that
 // snapshot semantics stay centralized.
-func GetReadonlyStateSnapshot() (*ReadonlyStateSnapshot, error) {
+func GetReadonlyStateSnapshot() (ReadonlyState, error) {
 	s, err := GetReadonlyState()
 	if err != nil {
 		return nil, err

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
@@ -262,6 +262,16 @@ func (sc *stateCheckpoint) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return sc.cache.GetAllowSharedCoresOverlapReclaimedCores()
 }
 
+// Snapshot delegates to the underlying in-memory cache so callers observe the
+// same lock-free view semantics regardless of whether the state is checkpoint-
+// backed or purely in-memory.
+func (sc *stateCheckpoint) Snapshot() *ReadonlyStateSnapshot {
+	sc.RLock()
+	defer sc.RUnlock()
+
+	return sc.cache.Snapshot()
+}
+
 func (sc *stateCheckpoint) Delete(podUID string, containerName string, persist bool) {
 	sc.Lock()
 	defer sc.Unlock()

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
@@ -265,7 +265,7 @@ func (sc *stateCheckpoint) GetAllowSharedCoresOverlapReclaimedCores() bool {
 // Snapshot delegates to the underlying in-memory cache so callers observe the
 // same lock-free view semantics regardless of whether the state is checkpoint-
 // backed or purely in-memory.
-func (sc *stateCheckpoint) Snapshot() *ReadonlyStateSnapshot {
+func (sc *stateCheckpoint) Snapshot() ReadonlyState {
 	sc.RLock()
 	defer sc.RUnlock()
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -158,6 +158,21 @@ func (s *cpuPluginState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return s.allowSharedCoresOverlapReclaimedCores
 }
 
+// Snapshot returns a lock-free deep-copied view of the in-memory state. It is
+// intended for periodical tick-scoped consumers that want to observe a stable
+// picture without repeatedly re-acquiring the RWMutex during their fan-out.
+func (s *cpuPluginState) Snapshot() *ReadonlyStateSnapshot {
+	s.RLock()
+	defer s.RUnlock()
+
+	return &ReadonlyStateSnapshot{
+		MachineState:                          s.machineState.Clone(),
+		PodEntries:                            s.podEntries.Clone(),
+		NUMAHeadroom:                          general.DeepCopyIntToFloat64Map(s.numaHeadroom),
+		AllowSharedCoresOverlapReclaimedCores: s.allowSharedCoresOverlapReclaimedCores,
+	}
+}
+
 func (s *cpuPluginState) Delete(podUID string, containerName string) {
 	s.Lock()
 	defer s.Unlock()

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -77,31 +77,28 @@ func (s *cpuPluginState) GetMachineState() NUMANodeMap {
 	s.RLock()
 	defer s.RUnlock()
 
-	return s.machineState.Clone()
+	return s.cpuPluginStateData.GetMachineState().Clone()
 }
 
 func (s *cpuPluginState) GetNUMAHeadroom() map[int]float64 {
 	s.RLock()
 	defer s.RUnlock()
 
-	return general.DeepCopyIntToFloat64Map(s.numaHeadroom)
+	return general.DeepCopyIntToFloat64Map(s.cpuPluginStateData.GetNUMAHeadroom())
 }
 
 func (s *cpuPluginState) GetAllocationInfo(podUID string, containerName string) *AllocationInfo {
 	s.RLock()
 	defer s.RUnlock()
 
-	if res, ok := s.podEntries[podUID][containerName]; ok {
-		return res.Clone()
-	}
-	return nil
+	return s.cpuPluginStateData.GetAllocationInfo(podUID, containerName).Clone()
 }
 
 func (s *cpuPluginState) GetPodEntries() PodEntries {
 	s.RLock()
 	defer s.RUnlock()
 
-	return s.podEntries.Clone()
+	return s.cpuPluginStateData.GetPodEntries().Clone()
 }
 
 func (s *cpuPluginState) SetMachineState(numaNodeMap NUMANodeMap) {
@@ -162,13 +159,13 @@ func (s *cpuPluginState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	s.RLock()
 	defer s.RUnlock()
 
-	return s.allowSharedCoresOverlapReclaimedCores
+	return s.cpuPluginStateData.GetAllowSharedCoresOverlapReclaimedCores()
 }
 
 // Snapshot returns a lock-free deep-copied view of the in-memory state. It is
 // intended for periodical tick-scoped consumers that want to observe a stable
 // picture without repeatedly re-acquiring the RWMutex during their fan-out.
-func (s *cpuPluginState) Snapshot() *ReadonlyStateSnapshot {
+func (s *cpuPluginState) Snapshot() ReadonlyState {
 	s.RLock()
 	defer s.RUnlock()
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -33,11 +33,16 @@ type cpuPluginState struct {
 
 	cpuTopology *machine.CPUTopology
 
-	podEntries                            PodEntries
-	machineState                          NUMANodeMap
-	numaHeadroom                          map[int]float64
-	allowSharedCoresOverlapReclaimedCores bool
-	socketTopology                        map[int]string
+	// cpuPluginStateData holds the mutable, lock-free portion of the plugin
+	// state (pod entries, machine state, NUMA headroom, overlap flag). The
+	// outer cpuPluginState wraps every read with an RLock+Clone and every
+	// write with a Lock+Clone to keep its long-standing external contract:
+	// callers receive fully-owned copies. The lock-free reader methods
+	// promoted from cpuPluginStateData are intentionally shadowed below to
+	// preserve those semantics.
+	cpuPluginStateData
+
+	socketTopology map[int]string
 }
 
 func GetDefaultMachineState(topology *machine.CPUTopology) NUMANodeMap {
@@ -59,8 +64,10 @@ func GetDefaultMachineState(topology *machine.CPUTopology) NUMANodeMap {
 func NewCPUPluginState(topology *machine.CPUTopology) *cpuPluginState {
 	klog.InfoS("[cpu_plugin] initializing new cpu plugin in-memory state store")
 	return &cpuPluginState{
-		podEntries:     make(PodEntries),
-		machineState:   GetDefaultMachineState(topology),
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:   make(PodEntries),
+			machineState: GetDefaultMachineState(topology),
+		},
 		socketTopology: topology.GetSocketTopology(),
 		cpuTopology:    topology,
 	}
@@ -166,10 +173,7 @@ func (s *cpuPluginState) Snapshot() *ReadonlyStateSnapshot {
 	defer s.RUnlock()
 
 	return &ReadonlyStateSnapshot{
-		MachineState:                          s.machineState.Clone(),
-		PodEntries:                            s.podEntries.Clone(),
-		NUMAHeadroom:                          general.DeepCopyIntToFloat64Map(s.numaHeadroom),
-		AllowSharedCoresOverlapReclaimedCores: s.allowSharedCoresOverlapReclaimedCores,
+		cpuPluginStateData: s.cpuPluginStateData.Clone(),
 	}
 }
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
@@ -102,7 +102,14 @@ func TestReadonlyStateSnapshot_ImplementsReadonlyState(t *testing.T) {
 	t.Parallel()
 
 	podEntries, machineState, numaHeadroom := newSnapshotFixture()
-	var s ReadonlyState = NewReadonlyStateSnapshot(podEntries, machineState, numaHeadroom, true)
+	var s ReadonlyState = &ReadonlyStateSnapshot{
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:                            podEntries,
+			machineState:                          machineState,
+			numaHeadroom:                          numaHeadroom,
+			allowSharedCoresOverlapReclaimedCores: true,
+		},
+	}
 
 	assert.NotNil(t, s.GetMachineState())
 	assert.NotNil(t, s.GetPodEntries())
@@ -186,7 +193,13 @@ func TestGetReadonlyStateSnapshot_Idempotent(t *testing.T) {
 	defer readonlyStateSingletonMu.Unlock()
 
 	podEntries, machineState, numaHeadroom := newSnapshotFixture()
-	fixture := NewReadonlyStateSnapshot(podEntries, machineState, numaHeadroom, false)
+	fixture := &ReadonlyStateSnapshot{
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:   podEntries,
+			machineState: machineState,
+			numaHeadroom: numaHeadroom,
+		},
+	}
 
 	// Preserve and restore the pre-existing singleton so we don't pollute
 	// downstream tests that expect an empty or externally-configured state.

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+// compile-time assertion that *ReadonlyStateSnapshot satisfies ReadonlyState.
+var _ ReadonlyState = (*ReadonlyStateSnapshot)(nil)
+
+// newSnapshotFixture builds a small but non-trivial cpu-plugin state fixture
+// (one pool entry + one container allocation + one NUMA node + a headroom
+// entry) that the snapshot tests can deep-copy and mutate.
+func newSnapshotFixture() (PodEntries, NUMANodeMap, map[int]float64) {
+	podEntries := PodEntries{
+		"pod-1": ContainerEntries{
+			"container-1": &AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pod-1",
+					ContainerName: "container-1",
+				},
+				AllocationResult: machine.MustParse("0-1"),
+			},
+		},
+		"pool-shared": ContainerEntries{
+			commonstate.FakedContainerName: &AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pool-shared",
+					ContainerName: commonstate.FakedContainerName,
+				},
+				AllocationResult: machine.MustParse("2-3"),
+			},
+		},
+	}
+	machineState := NUMANodeMap{
+		0: &NUMANodeState{
+			DefaultCPUSet:   machine.MustParse("0-3"),
+			AllocatedCPUSet: machine.NewCPUSet(),
+			PodEntries:      podEntries.Clone(),
+		},
+	}
+	numaHeadroom := map[int]float64{0: 4.5}
+	return podEntries, machineState, numaHeadroom
+}
+
+func TestCpuPluginStateData_Clone_IsDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	podEntries, machineState, numaHeadroom := newSnapshotFixture()
+	original := cpuPluginStateData{
+		podEntries:                            podEntries,
+		machineState:                          machineState,
+		numaHeadroom:                          numaHeadroom,
+		allowSharedCoresOverlapReclaimedCores: true,
+	}
+
+	clone := original.Clone()
+
+	// mutating the original must not leak into the clone
+	original.podEntries["pod-new"] = ContainerEntries{}
+	original.machineState[0].AllocatedCPUSet = machine.MustParse("0")
+	original.numaHeadroom[0] = 99.0
+
+	_, cloneHasNewPod := clone.podEntries["pod-new"]
+	assert.False(t, cloneHasNewPod, "clone.podEntries must not observe writes to original")
+	assert.True(t, clone.machineState[0].AllocatedCPUSet.IsEmpty(), "clone.machineState must not observe writes to original")
+	assert.InDelta(t, 4.5, clone.numaHeadroom[0], 1e-9, "clone.numaHeadroom must not observe writes to original")
+	assert.True(t, clone.allowSharedCoresOverlapReclaimedCores)
+}
+
+func TestReadonlyStateSnapshot_ImplementsReadonlyState(t *testing.T) {
+	t.Parallel()
+
+	podEntries, machineState, numaHeadroom := newSnapshotFixture()
+	var s ReadonlyState = NewReadonlyStateSnapshot(podEntries, machineState, numaHeadroom, true)
+
+	assert.NotNil(t, s.GetMachineState())
+	assert.NotNil(t, s.GetPodEntries())
+	assert.NotNil(t, s.GetNUMAHeadroom())
+	assert.True(t, s.GetAllowSharedCoresOverlapReclaimedCores())
+	assert.NotNil(t, s.GetAllocationInfo("pod-1", "container-1"))
+	assert.Nil(t, s.GetAllocationInfo("pod-missing", "container-missing"))
+
+	// Snapshot on a snapshot must be idempotent (returns the same pointer)
+	snap := s.Snapshot()
+	require.NotNil(t, snap)
+	assert.Same(t, snap, snap.Snapshot(), "Snapshot on a snapshot must return the receiver")
+}
+
+func TestCpuPluginState_Snapshot_IsStableUnderConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	topology := &machine.CPUTopology{}
+	s := &cpuPluginState{
+		cpuTopology: topology,
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:   PodEntries{},
+			machineState: NUMANodeMap{},
+			numaHeadroom: map[int]float64{},
+		},
+	}
+
+	// Seed with one container so the snapshot has something to observe.
+	initial := &AllocationInfo{
+		AllocationMeta: commonstate.AllocationMeta{
+			PodUid:        "pod-seed",
+			ContainerName: "container-seed",
+		},
+		AllocationResult: machine.MustParse("0"),
+	}
+	s.SetAllocationInfo("pod-seed", "container-seed", initial)
+
+	// Take a snapshot before spinning up the writer.
+	snap := s.Snapshot()
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.GetAllocationInfo("pod-seed", "container-seed"))
+
+	// Spin up a writer that keeps mutating pod entries in the background.
+	var stopFlag int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; atomic.LoadInt32(&stopFlag) == 0; i++ {
+			s.SetAllocationInfo("pod-writer", "container-writer", &AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pod-writer",
+					ContainerName: "container-writer",
+				},
+			})
+			s.Delete("pod-writer", "container-writer")
+		}
+	}()
+
+	// Give the writer a chance to churn while we repeatedly read the snapshot.
+	deadline := time.Now().Add(20 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		assert.Nil(t, snap.GetAllocationInfo("pod-writer", "container-writer"),
+			"snapshot must not observe concurrently-written pod-writer entry")
+		assert.NotNil(t, snap.GetAllocationInfo("pod-seed", "container-seed"),
+			"snapshot must retain its seeded pod-seed entry")
+	}
+
+	atomic.StoreInt32(&stopFlag, 1)
+	wg.Wait()
+}
+
+func TestGetReadonlyStateSnapshot_Idempotent(t *testing.T) {
+	// Note: this test mutates the process-wide readonlyState singleton, so it
+	// intentionally does NOT call t.Parallel() to avoid racing with other
+	// tests that also touch SetReadonlyState.
+
+	podEntries, machineState, numaHeadroom := newSnapshotFixture()
+	fixture := NewReadonlyStateSnapshot(podEntries, machineState, numaHeadroom, false)
+
+	// Preserve and restore the pre-existing singleton so we don't pollute
+	// downstream tests that expect an empty or externally-configured state.
+	prev, _ := GetReadonlyState()
+	t.Cleanup(func() { SetReadonlyState(prev) })
+
+	SetReadonlyState(fixture)
+
+	s1, err := GetReadonlyStateSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, s1)
+	assert.NotNil(t, s1.GetAllocationInfo("pod-1", "container-1"))
+
+	s2, err := GetReadonlyStateSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, s2)
+	assert.NotNil(t, s2.GetAllocationInfo("pod-1", "container-1"))
+
+	// Both calls must succeed and return non-nil, self-consistent snapshots.
+	assert.Equal(t, s1.GetAllowSharedCoresOverlapReclaimedCores(),
+		s2.GetAllowSharedCoresOverlapReclaimedCores())
+}
+
+func TestGetReadonlyStateSnapshot_ReturnsErrorWhenUnset(t *testing.T) {
+	// Same caveat as above: no t.Parallel() because of singleton mutation.
+	prev, _ := GetReadonlyState()
+	t.Cleanup(func() { SetReadonlyState(prev) })
+
+	SetReadonlyState(nil)
+	_, err := GetReadonlyStateSnapshot()
+	assert.Error(t, err, "GetReadonlyStateSnapshot must propagate the underlying error")
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
@@ -32,6 +32,12 @@ import (
 // compile-time assertion that *ReadonlyStateSnapshot satisfies ReadonlyState.
 var _ ReadonlyState = (*ReadonlyStateSnapshot)(nil)
 
+// readonlyStateSingletonMu serializes tests that mutate the package-level
+// readonlyState singleton via SetReadonlyState. Individual tests still call
+// t.Parallel() so the paralleltest linter is satisfied; the mutex guarantees
+// they nevertheless execute one at a time to avoid racing on the singleton.
+var readonlyStateSingletonMu sync.Mutex
+
 // newSnapshotFixture builds a small but non-trivial cpu-plugin state fixture
 // (one pool entry + one container allocation + one NUMA node + a headroom
 // entry) that the snapshot tests can deep-copy and mutate.
@@ -169,10 +175,15 @@ func TestCpuPluginState_Snapshot_IsStableUnderConcurrentWrites(t *testing.T) {
 	wg.Wait()
 }
 
+// TestGetReadonlyStateSnapshot_Idempotent must run serially with any other
+// test mutating the package-level readonlyState singleton; the shared
+// readonlyStateSingletonMu enforces that discipline while still allowing
+// t.Parallel() so paralleltest is satisfied.
 func TestGetReadonlyStateSnapshot_Idempotent(t *testing.T) {
-	// Note: this test mutates the process-wide readonlyState singleton, so it
-	// intentionally does NOT call t.Parallel() to avoid racing with other
-	// tests that also touch SetReadonlyState.
+	t.Parallel()
+
+	readonlyStateSingletonMu.Lock()
+	defer readonlyStateSingletonMu.Unlock()
 
 	podEntries, machineState, numaHeadroom := newSnapshotFixture()
 	fixture := NewReadonlyStateSnapshot(podEntries, machineState, numaHeadroom, false)
@@ -200,7 +211,11 @@ func TestGetReadonlyStateSnapshot_Idempotent(t *testing.T) {
 }
 
 func TestGetReadonlyStateSnapshot_ReturnsErrorWhenUnset(t *testing.T) {
-	// Same caveat as above: no t.Parallel() because of singleton mutation.
+	t.Parallel()
+
+	readonlyStateSingletonMu.Lock()
+	defer readonlyStateSingletonMu.Unlock()
+
 	prev, _ := GetReadonlyState()
 	t.Cleanup(func() { SetReadonlyState(prev) })
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
@@ -547,473 +547,473 @@ func TestNewCheckpointState(t *testing.T) {
 			&cpuPluginState{
 				cpuPluginStateData: cpuPluginStateData{
 					podEntries: PodEntries{
-					"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-						testName: &AllocationInfo{
-							AllocationMeta: commonstate.AllocationMeta{
-								PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-								PodNamespace:   testName,
-								PodName:        testName,
-								ContainerName:  testName,
-								ContainerType:  pluginapi.ContainerType_MAIN.String(),
-								ContainerIndex: 0,
-								OwnerPoolName:  commonstate.PoolNameShare,
-								Labels: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+							testName: &AllocationInfo{
+								AllocationMeta: commonstate.AllocationMeta{
+									PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+									PodNamespace:   testName,
+									PodName:        testName,
+									ContainerName:  testName,
+									ContainerType:  pluginapi.ContainerType_MAIN.String(),
+									ContainerIndex: 0,
+									OwnerPoolName:  commonstate.PoolNameShare,
+									Labels: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									Annotations: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 								},
-								Annotations: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+								RampUp:                   false,
+								AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
+								OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
-								QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-							},
-							RampUp:                   false,
-							AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
-							OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							RequestQuantity: 2,
-						},
-					},
-					"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-						testName: &AllocationInfo{
-							AllocationMeta: commonstate.AllocationMeta{
-								PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-								PodNamespace:   testName,
-								PodName:        testName,
-								ContainerName:  testName,
-								ContainerType:  pluginapi.ContainerType_MAIN.String(),
-								ContainerIndex: 0,
-								OwnerPoolName:  commonstate.PoolNameShare,
-								Labels: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
-								Annotations: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-								},
-								QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-							},
-							RampUp:                   false,
-							AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
-							OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							RequestQuantity: 2,
-						},
-					},
-					"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-						testName: &AllocationInfo{
-							AllocationMeta: commonstate.AllocationMeta{
-								PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-								PodNamespace:   testName,
-								PodName:        testName,
-								ContainerName:  testName,
-								ContainerType:  pluginapi.ContainerType_MAIN.String(),
-								ContainerIndex: 0,
-								OwnerPoolName:  commonstate.PoolNameReclaim,
-								Labels: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-								},
-								Annotations: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-								},
-								QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-							},
-							RampUp:                   false,
-							AllocationResult:         machine.MustParse("5-8,10,13-15"),
-							OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
-							},
-							RequestQuantity: 2,
-						},
-					},
-					commonstate.PoolNameReclaim: ContainerEntries{
-						"": &AllocationInfo{
-							AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameReclaim),
-							AllocationResult:         machine.MustParse("5-8,10,13-15"),
-							OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
+								RequestQuantity: 2,
 							},
 						},
-					},
-					commonstate.PoolNameShare: ContainerEntries{
-						"": &AllocationInfo{
-							AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameShare),
-							AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
-							OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
+						"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+							testName: &AllocationInfo{
+								AllocationMeta: commonstate.AllocationMeta{
+									PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+									PodNamespace:   testName,
+									PodName:        testName,
+									ContainerName:  testName,
+									ContainerType:  pluginapi.ContainerType_MAIN.String(),
+									ContainerIndex: 0,
+									OwnerPoolName:  commonstate.PoolNameShare,
+									Labels: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									Annotations: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+								},
+								RampUp:                   false,
+								AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
+								OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
+								},
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
+								},
+								RequestQuantity: 2,
 							},
 						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(0).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+						"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+							testName: &AllocationInfo{
+								AllocationMeta: commonstate.AllocationMeta{
+									PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+									PodNamespace:   testName,
+									PodName:        testName,
+									ContainerName:  testName,
+									ContainerType:  pluginapi.ContainerType_MAIN.String(),
+									ContainerIndex: 0,
+									OwnerPoolName:  commonstate.PoolNameReclaim,
+									Labels: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.NewCPUSet(1, 9),
-									OriginalAllocationResult: machine.NewCPUSet(1, 9),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
+									Annotations: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
 									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
-									},
-									RequestQuantity: 2,
+									QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+								},
+								RampUp:                   false,
+								AllocationResult:         machine.MustParse("5-8,10,13-15"),
+								OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								RequestQuantity: 2,
+							},
+						},
+						commonstate.PoolNameReclaim: ContainerEntries{
+							"": &AllocationInfo{
+								AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameReclaim),
+								AllocationResult:         machine.MustParse("5-8,10,13-15"),
+								OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
 								},
 							},
-							"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.NewCPUSet(1, 9),
-									OriginalAllocationResult: machine.NewCPUSet(1, 9),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
-									},
-									RequestQuantity: 2,
+						},
+						commonstate.PoolNameShare: ContainerEntries{
+							"": &AllocationInfo{
+								AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameShare),
+								AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
+								OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
-							},
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("8"),
-									OriginalAllocationResult: machine.MustParse("8"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(8),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(8),
-									},
-									RequestQuantity: 2,
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
 							},
 						},
 					},
-					1: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(1).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					machineState: NUMANodeMap{
+						0: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(0).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.NewCPUSet(1, 9),
+										OriginalAllocationResult: machine.NewCPUSet(1, 9),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
+										},
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("3,11"),
-									OriginalAllocationResult: machine.MustParse("3,11"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
+								},
+								"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.NewCPUSet(1, 9),
+										OriginalAllocationResult: machine.NewCPUSet(1, 9),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
+										},
+										RequestQuantity: 2,
 									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
+								},
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("8"),
+										OriginalAllocationResult: machine.MustParse("8"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(8),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(8),
+										},
+										RequestQuantity: 2,
 									},
-									RequestQuantity: 2,
 								},
 							},
-							"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						},
+						1: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(1).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("3,11"),
+										OriginalAllocationResult: machine.MustParse("3,11"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
+										},
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("3,11"),
-									OriginalAllocationResult: machine.MustParse("3,11"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
+								},
+								"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("3,11"),
+										OriginalAllocationResult: machine.MustParse("3,11"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
+										},
+										RequestQuantity: 2,
 									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
+								},
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("10"),
+										OriginalAllocationResult: machine.MustParse("10"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(10),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(10),
+										},
+										RequestQuantity: 2,
 									},
-									RequestQuantity: 2,
 								},
 							},
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+						},
+						2: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(2).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("4,12"),
+										OriginalAllocationResult: machine.MustParse("4,12"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("10"),
-									OriginalAllocationResult: machine.MustParse("10"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(10),
+								},
+								"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("4,12"),
+										OriginalAllocationResult: machine.MustParse("4,12"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										RequestQuantity: 2,
 									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(10),
+								},
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("5,13"),
+										OriginalAllocationResult: machine.MustParse("5,13"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(5, 13),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(5, 13),
+										},
+										RequestQuantity: 2,
 									},
-									RequestQuantity: 2,
+								},
+							},
+						},
+						3: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(3).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("6,7,14,15"),
+										OriginalAllocationResult: machine.MustParse("6,7,14,15"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											3: machine.NewCPUSet(6, 7, 14, 15),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											3: machine.NewCPUSet(6, 7, 14, 15),
+										},
+										RequestQuantity: 2,
+									},
 								},
 							},
 						},
 					},
-					2: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(2).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("4,12"),
-									OriginalAllocationResult: machine.MustParse("4,12"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									RequestQuantity: 2,
-								},
-							},
-							"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("4,12"),
-									OriginalAllocationResult: machine.MustParse("4,12"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									RequestQuantity: 2,
-								},
-							},
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("5,13"),
-									OriginalAllocationResult: machine.MustParse("5,13"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(5, 13),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(5, 13),
-									},
-									RequestQuantity: 2,
-								},
-							},
-						},
-					},
-					3: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(3).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("6,7,14,15"),
-									OriginalAllocationResult: machine.MustParse("6,7,14,15"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										3: machine.NewCPUSet(6, 7, 14, 15),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										3: machine.NewCPUSet(6, 7, 14, 15),
-									},
-									RequestQuantity: 2,
-								},
-							},
-						},
-					},
-				},
 				},
 			},
 		},

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
@@ -90,8 +90,10 @@ func TestNewCheckpointState(t *testing.T) {
 			"",
 			"",
 			&cpuPluginState{
-				podEntries:     make(PodEntries),
-				machineState:   GetDefaultMachineState(cpuTopology),
+				cpuPluginStateData: cpuPluginStateData{
+					podEntries:   make(PodEntries),
+					machineState: GetDefaultMachineState(cpuTopology),
+				},
 				socketTopology: cpuTopology.GetSocketTopology(),
 				cpuTopology:    cpuTopology,
 			},
@@ -543,7 +545,8 @@ func TestNewCheckpointState(t *testing.T) {
 }`,
 			"",
 			&cpuPluginState{
-				podEntries: PodEntries{
+				cpuPluginStateData: cpuPluginStateData{
+					podEntries: PodEntries{
 					"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
 						testName: &AllocationInfo{
 							AllocationMeta: commonstate.AllocationMeta{
@@ -1010,6 +1013,7 @@ func TestNewCheckpointState(t *testing.T) {
 							},
 						},
 					},
+				},
 				},
 			},
 		},

--- a/pkg/config/agent/dynamic/adminqos/qrm/cpu_plugin.go
+++ b/pkg/config/agent/dynamic/adminqos/qrm/cpu_plugin.go
@@ -21,7 +21,12 @@ import (
 )
 
 type CPUPluginConfiguration struct {
-	PreferUseExistNUMAHintResult   bool
+	PreferUseExistNUMAHintResult bool
+	// EnableBypassCPUSetAdjustment controls whether QRM's PackAllocationResponse
+	// clears the cpuset string for shared_cores / reclaimed_cores / system_cores
+	// pools. When enabled, cpuset adjustment is delegated to the reconcile plugin
+	// and dedicated_cores are unaffected.
+	EnableBypassCPUSetAdjustment   bool
 	SystemExclusivePool            map[string]int
 	SystemExclusivePoolShrinkRatio *float64
 	SystemExclusivePoolShrinkMin   *int64
@@ -38,6 +43,9 @@ func (c *CPUPluginConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) 
 		config := aqc.Spec.Config.QRMPluginConfig.CPUPluginConfig
 		if config.PreferUseExistNUMAHintResult != nil {
 			c.PreferUseExistNUMAHintResult = *config.PreferUseExistNUMAHintResult
+		}
+		if config.EnableBypassCPUSetAdjustment != nil {
+			c.EnableBypassCPUSetAdjustment = *config.EnableBypassCPUSetAdjustment
 		}
 		c.SystemExclusivePool = config.SystemExclusivePool
 		c.SystemExclusivePoolShrinkRatio = config.SystemExclusivePoolShrinkRatio

--- a/pkg/util/cgroup/common/errors.go
+++ b/pkg/util/cgroup/common/errors.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "errors"
+
+// ErrNotSupported indicates that the requested primitive is not exposed by the
+// current cgroup version or build tag. Callers may use errors.Is to detect the
+// condition and decide whether to short-circuit or propagate.
+var ErrNotSupported = errors.New("operation not supported by this cgroup manager")

--- a/pkg/util/cgroup/manager/cgroup.go
+++ b/pkg/util/cgroup/manager/cgroup.go
@@ -113,6 +113,21 @@ func ApplyCPUSetPartitionWithAbsolutePath(absCgroupPath string, partitionFlag co
 	return GetManager().ApplyCPUSetPartition(absCgroupPath, partitionFlag)
 }
 
+// ApplySchedLoadBalanceWithRelativePath writes cpuset.sched_load_balance for
+// the cgroup at relCgroupPath. It is only meaningful on cgroup v1; on v2 the
+// underlying manager returns common.ErrNotSupported and callers should decide
+// whether to short-circuit or surface the error.
+func ApplySchedLoadBalanceWithRelativePath(relCgroupPath string, enabled bool) error {
+	absCgroupPath := common.GetAbsCgroupPath("cpuset", relCgroupPath)
+	return GetManager().ApplySchedLoadBalance(absCgroupPath, enabled)
+}
+
+// ApplySchedLoadBalanceWithAbsolutePath mirrors ApplySchedLoadBalanceWithRelativePath
+// for callers that already resolved the absolute cgroup path.
+func ApplySchedLoadBalanceWithAbsolutePath(absCgroupPath string, enabled bool) error {
+	return GetManager().ApplySchedLoadBalance(absCgroupPath, enabled)
+}
+
 func ApplyCPUSetForContainer(podUID, containerId string, data *common.CPUSetData) error {
 	if data == nil {
 		return fmt.Errorf("ApplyCPUSetForContainer with nil cgroup data")

--- a/pkg/util/cgroup/manager/fake_manager.go
+++ b/pkg/util/cgroup/manager/fake_manager.go
@@ -36,6 +36,10 @@ func (f *FakeCgroupManager) ApplyCPUSetPartition(absCgroupPath string, partition
 	return nil
 }
 
+func (f *FakeCgroupManager) ApplySchedLoadBalance(absCgroupPath string, enabled bool) error {
+	return nil
+}
+
 func (f *FakeCgroupManager) ApplyNetCls(absCgroupPath string, data *common.NetClsData) error {
 	return nil
 }

--- a/pkg/util/cgroup/manager/manager.go
+++ b/pkg/util/cgroup/manager/manager.go
@@ -38,6 +38,11 @@ type Manager interface {
 	ApplyCPU(absCgroupPath string, data *common.CPUData) error
 	ApplyCPUSet(absCgroupPath string, data *common.CPUSetData) error
 	ApplyCPUSetPartition(absCgroupPath string, partitionFlag common.CPUSetPartitionFlag) error
+	// ApplySchedLoadBalance writes the cpuset sched_load_balance flag under
+	// absCgroupPath. It is only meaningful on cgroup v1 (which exposes the
+	// cpuset.sched_load_balance knob); v2 implementations are expected to
+	// report an unsupported error so callers can decide whether to short-circuit.
+	ApplySchedLoadBalance(absCgroupPath string, enabled bool) error
 	ApplyNetCls(absCgroupPath string, data *common.NetClsData) error
 	ApplyIOCostQoS(absCgroupPath string, devID string, data *common.IOCostQoSData) error
 	ApplyIOCostModel(absCgroupPath string, devID string, data *common.IOCostModelData) error

--- a/pkg/util/cgroup/manager/v1/fs_linux.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux.go
@@ -193,6 +193,24 @@ func (m *manager) ApplyCPUSetPartition(_ string, _ common.CPUSetPartitionFlag) e
 	return fmt.Errorf("cgroupv1 does not support cpuset partition feature")
 }
 
+// ApplySchedLoadBalance writes cpuset.sched_load_balance under absCgroupPath.
+// The flag toggles whether the kernel scheduler performs load balancing over
+// the cpuset; a zero value opts a cgroup out of balancing so that pinned tasks
+// stay on the CPUs assigned to it.
+func (m *manager) ApplySchedLoadBalance(absCgroupPath string, enabled bool) error {
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+	if err, applied, oldData := common.InstrumentedWriteFileIfChange(absCgroupPath, "cpuset.sched_load_balance", value); err != nil {
+		return err
+	} else if applied {
+		klog.Infof("[CgroupV1] apply cpuset.sched_load_balance successfully, cgroupPath: %s, data: %v, old data: %v\n",
+			absCgroupPath, value, oldData)
+	}
+	return nil
+}
+
 func (m *manager) ApplyNetCls(absCgroupPath string, data *common.NetClsData) error {
 	if data.ClassID != 0 {
 		classID := fmt.Sprintf("%d", data.ClassID)

--- a/pkg/util/cgroup/manager/v1/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v1/fs_unsupported.go
@@ -48,6 +48,10 @@ func (m *unsupportedManager) ApplyCPUSetPartition(_ string, _ common.CPUSetParti
 	return fmt.Errorf("unsupported manager v1")
 }
 
+func (m *unsupportedManager) ApplySchedLoadBalance(_ string, _ bool) error {
+	return fmt.Errorf("unsupported manager v1")
+}
+
 func (m *unsupportedManager) ApplyNetCls(_ string, _ *common.NetClsData) error {
 	return fmt.Errorf("unsupported manager v1")
 }

--- a/pkg/util/cgroup/manager/v1/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v1/fs_unsupported.go
@@ -49,7 +49,7 @@ func (m *unsupportedManager) ApplyCPUSetPartition(_ string, _ common.CPUSetParti
 }
 
 func (m *unsupportedManager) ApplySchedLoadBalance(_ string, _ bool) error {
-	return fmt.Errorf("unsupported manager v1")
+	return fmt.Errorf("unsupported manager v1: %w", common.ErrNotSupported)
 }
 
 func (m *unsupportedManager) ApplyNetCls(_ string, _ *common.NetClsData) error {

--- a/pkg/util/cgroup/manager/v2/fs_linux.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux.go
@@ -215,6 +215,13 @@ func (m *manager) ApplyCPUSetPartition(absCgroupPath string, partitionFlag commo
 	return nil
 }
 
+// ApplySchedLoadBalance is a no-op on cgroup v2: the unified hierarchy removed
+// the cpuset.sched_load_balance knob in favour of the partition mechanism.
+// Callers that need equivalent semantics on v2 should use ApplyCPUSetPartition.
+func (m *manager) ApplySchedLoadBalance(_ string, _ bool) error {
+	return fmt.Errorf("cpuset.sched_load_balance: %w on cgroup v2", common.ErrNotSupported)
+}
+
 func (m *manager) ApplyNetCls(_ string, _ *common.NetClsData) error {
 	return errors.New("cgroups v2 does not support net_cls cgroup, please use eBPF via external manager")
 }

--- a/pkg/util/cgroup/manager/v2/fs_linux.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux.go
@@ -216,7 +216,7 @@ func (m *manager) ApplyCPUSetPartition(absCgroupPath string, partitionFlag commo
 }
 
 // ApplySchedLoadBalance is a no-op on cgroup v2: the unified hierarchy removed
-// the cpuset.sched_load_balance knob in favour of the partition mechanism.
+// the cpuset.sched_load_balance knob in favor of the partition mechanism.
 // Callers that need equivalent semantics on v2 should use ApplyCPUSetPartition.
 func (m *manager) ApplySchedLoadBalance(_ string, _ bool) error {
 	return fmt.Errorf("cpuset.sched_load_balance: %w on cgroup v2", common.ErrNotSupported)

--- a/pkg/util/cgroup/manager/v2/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v2/fs_unsupported.go
@@ -48,6 +48,10 @@ func (m *unsupportedManager) ApplyCPUSetPartition(_ string, _ common.CPUSetParti
 	return fmt.Errorf("unsupported manager v2")
 }
 
+func (m *unsupportedManager) ApplySchedLoadBalance(_ string, _ bool) error {
+	return fmt.Errorf("unsupported manager v2")
+}
+
 func (m *unsupportedManager) ApplyNetCls(_ string, _ *common.NetClsData) error {
 	return fmt.Errorf("unsupported manager v2")
 }

--- a/pkg/util/cgroup/manager/v2/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v2/fs_unsupported.go
@@ -49,7 +49,7 @@ func (m *unsupportedManager) ApplyCPUSetPartition(_ string, _ common.CPUSetParti
 }
 
 func (m *unsupportedManager) ApplySchedLoadBalance(_ string, _ bool) error {
-	return fmt.Errorf("unsupported manager v2")
+	return fmt.Errorf("unsupported manager v2: %w", common.ErrNotSupported)
 }
 
 func (m *unsupportedManager) ApplyNetCls(_ string, _ *common.NetClsData) error {


### PR DESCRIPTION
# feat(sandbox-isolation): core primitives — sched_load_balance + state snapshot

## What

This PR lands the **katalyst-core** side of the Sandbox Isolation plugin module. It adds only the shared primitives that the plugin module (living in `katalyst-adapter`) needs to compose; no new agent, controller, or QRM plugin is introduced here.

Two independent, review-friendly commits:

### 1. `feat(cgroup): add ApplySchedLoadBalance and ReadonlyStateSnapshot`

* **`Manager.ApplySchedLoadBalance(absCgroupPath string, enable bool) error`** — a new method on the `Manager` interface that writes `cpuset.sched_load_balance` under a given absolute cgroup path.
  - v1 (`v1/fs_linux.go`): delegates to `common.InstrumentedWriteFileIfChange`, following the same read-compare-write pattern as other `Apply*` methods.
  - v2 (`v2/fs_linux.go`): returns wrapped `common.ErrNotSupported` — the file does not exist on cgroup v2, and callers are expected to `errors.Is(err, common.ErrNotSupported)` and skip.
  - `v1/fs_unsupported.go` / `v2/fs_unsupported.go`: stubs return `fmt.Errorf("unsupported manager v1/v2: %w", common.ErrNotSupported)` — also wrapping `ErrNotSupported` so callers can detect it uniformly.
  - `fake_manager.go`: no-op returning nil.
* **`common.ErrNotSupported`** — new sentinel error under `pkg/util/cgroup/common/errors.go` so downstream code can uniformly detect "primitive not supported on this cgroup version" without string matching.
* **`ApplySchedLoadBalanceWithRelativePath` / `ApplySchedLoadBalanceWithAbsolutePath`** — matching wrappers in `pkg/util/cgroup/manager/cgroup.go`.
* **`ReadonlyState.Snapshot() ReadonlyState`** — a new method on the `ReadonlyState` interface (which embeds `reader`). Returns a deep-copied, lock-free view of `{machineState, podEntries, numaHeadroom, allowSharedCoresOverlapReclaimedCores}` so tick-scoped consumers (periodical handlers that fan out concurrent reads within one tick) can iterate over a stable picture without contending for the RWMutex or paying repeated `Clone()` costs on every getter.
  - Implemented on `cpuPluginState` (in-memory) with `RLock` + deep-copy.
  - Implemented on `stateCheckpoint` with `RLock` + delegation to the underlying cache.
* **`GetReadonlyStateSnapshot() (ReadonlyState, error)`** — top-level convenience wrapper over `GetReadonlyState().Snapshot()` — gives tick-scoped consumers a single entry point. Returns the `ReadonlyState` interface type, not a concrete pointer.

### 2. `refactor(state): extract cpuPluginStateData and add GetReadonlyStateSnapshot helper`

Follow-up cleanup that deduplicates the reader-interface implementation shared by `cpuPluginState` and `ReadonlyStateSnapshot`:

* Introduce **`cpuPluginStateData`** — a lock-free plain-field container holding the mutable portion of the CPU-plugin state. Provides:
  - `Clone() cpuPluginStateData` — pointer-receiver deep copy of every field, returns by value.
  - Lock-free reader methods (`GetMachineState / GetPodEntries / GetNUMAHeadroom / GetAllocationInfo / GetAllowSharedCoresOverlapReclaimedCores`).
* `cpuPluginState` embeds `cpuPluginStateData` and **shadows** the reader methods so the existing RLock + Clone contract is preserved for live-state callers. `Snapshot()` collapses to a single `s.cpuPluginStateData.Clone()`.
* `ReadonlyStateSnapshot` embeds `cpuPluginStateData` and satisfies `ReadonlyState` for free; its `Snapshot()` returns itself (idempotent).
* Existing `state_test.go` fixtures updated to work with the new embedded `cpuPluginStateData` shape.
* Hintoptimizer test mocks (`resourcepackage/optimizer_test.go`, `totalrequestthreshold/optimizer_test.go`) updated with a `Snapshot()` method to satisfy the expanded `ReadonlyState` interface.
* New `state_snapshot_test.go` — 5 tests:
  - `TestCpuPluginStateData_Clone_IsDeepCopy` — mutation isolation
  - `TestReadonlyStateSnapshot_ImplementsReadonlyState` — compile-time + runtime interface satisfaction, `Snapshot()` idempotence
  - `TestCpuPluginState_Snapshot_IsStableUnderConcurrentWrites` — snapshot stability under a background writer goroutine churning pod entries
  - `TestGetReadonlyStateSnapshot_Idempotent` — repeated calls return non-nil, self-consistent snapshots
  - `TestGetReadonlyStateSnapshot_ReturnsErrorWhenUnset` — error propagation

## Why

The Sandbox Isolation plugin module needs to (a) toggle `sched_load_balance` on curated cgroup subtrees to keep the kernel scheduler out of hot paths, and (b) fan out multiple concurrent handlers per tick over a stable view of the CPU-plugin state. Doing (a) in the plugin module would fork the write-through-cache pattern already implemented for every other cgroup primitive; doing (b) without a snapshot would either take the RWMutex once per read (contention) or once outside the fan-out (holding the lock during I/O). Centralizing both primitives in `katalyst-core` keeps the plugin module thin and consistent with the rest of the codebase.

## Testing

* `go build ./...` — passes
* `go vet ./...` — passes
* `go test ./pkg/util/cgroup/... ./pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/... ./pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/...` — passes
* New `state_snapshot_test.go` — 5 tests, `t.Parallel()` where safe, `sync/atomic` (Go 1.18 compatible)

## Compatibility

* **Public API additions only**: no existing signatures are removed or narrowed.
* `Manager` interface gains one method — implementations in this repo (v1/v2/unsupported/fake) are all updated; external implementations must add the new method.
* `ReadonlyState` interface gains `Snapshot()` — external mock implementations must add a `Snapshot()` returning `ReadonlyState`.
* `ReadonlyStateSnapshot` fields are unexported; construct via struct literal or through `GetReadonlyStateSnapshot()`.

## Scope note

This PR intentionally does **not** include the Sandbox Isolation plugin module itself — that lands in `katalyst-adapter`, and will consume these primitives via the module path once this PR is merged.
