### PR TITLE
feat(gpu-plugin): set default required device affinity to false

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
@@ -57,7 +57,7 @@ func NewGPUOptions() *GPUOptions {
 		MilliGPUAllocatablePerGPU:                   "1000",
 		RDMADeviceNames:                             []string{},
 		GPUStrategyOptions:                          gpustrategy.NewGPUStrategyOptions(),
-		RequiredDeviceAffinity:                      true,
+		RequiredDeviceAffinity:                      false,
 		EnableKubeletCheckpointFallback:             true,
 		VirtualGPUPrefersSpreading:                  false,
 		VirtualGPUVisibleDevicesEnvNames:            []string{"NVIDIA_VISIBLE_DEVICES"},

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -130,6 +130,7 @@ type gpuReporterPlugin struct {
 	checkpointManager               checkpointmanager.CheckpointManager
 	kubeletDevicePluginPath         string
 	enableKubeletCheckpointFallback bool
+	requiredDeviceAffinity          bool
 }
 
 var (
@@ -159,6 +160,7 @@ func newGPUReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.
 		checkpointManager:               checkpointManager,
 		kubeletDevicePluginPath:         conf.KubeletDevicePluginPath,
 		enableKubeletCheckpointFallback: conf.EnableKubeletCheckpointFallback,
+		requiredDeviceAffinity:          conf.RequiredDeviceAffinity,
 	}
 	pluginWrapper, err := skeleton.NewRegistrationPluginWrapper(reporter, []string{conf.PluginRegistrationDir},
 		func(key string, value int64) {
@@ -394,7 +396,7 @@ func (p *gpuReporterPlugin) getResourcePropertyReportField(latestDeviceTopology 
 
 // getGPUResourceProperty returns the different dimensions to differentiate affinity priority of gpu devices.
 func (p *gpuReporterPlugin) getGPUResourceProperty(deviceTopology *machine.DeviceTopology) []*nodev1alpha1.Property {
-	if deviceTopology == nil || len(deviceTopology.PriorityDimensions) == 0 {
+	if !p.requiredDeviceAffinity || deviceTopology == nil || len(deviceTopology.PriorityDimensions) == 0 {
 		return nil
 	}
 

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -324,18 +324,97 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		deviceTopology   *machine.DeviceTopology
-		deviceTopologies map[string]*machine.DeviceTopology
-		gpuDeviceNames   []string
-		machineTopology  []cadvisorapi.Node
-		machineState     state.AllocationResourcesMap
-		expectedSpec     []*nodev1alpha1.Property
-		expectedStatus   []*nodev1alpha1.TopologyZone
-		expectedErr      bool
+		name                   string
+		deviceTopology         *machine.DeviceTopology
+		deviceTopologies       map[string]*machine.DeviceTopology
+		gpuDeviceNames         []string
+		requiredDeviceAffinity bool
+		machineTopology        []cadvisorapi.Node
+		machineState           state.AllocationResourcesMap
+		expectedSpec           []*nodev1alpha1.Property
+		expectedStatus         []*nodev1alpha1.TopologyZone
+		expectedErr            bool
 	}{
 		{
-			name: "Able to get report content for one dimension",
+			name: "No gpu topology property when RequiredDeviceAffinity is disabled",
+			deviceTopology: &machine.DeviceTopology{
+				PriorityDimensions: []string{"numa"},
+				Devices: map[string]machine.DeviceInfo{
+					"gpu-0": {
+						Health:     pluginapi.Healthy,
+						NumaNodes:  []int{0},
+						Dimensions: map[string]string{"numa": "0"},
+					},
+					"gpu-1": {
+						Health:     pluginapi.Healthy,
+						NumaNodes:  []int{1},
+						Dimensions: map[string]string{"numa": "1"},
+					},
+				},
+			},
+			machineTopology: []cadvisorapi.Node{
+				{
+					Id: 0,
+					Cores: []cadvisorapi.Core{
+						{SocketID: 0, Id: 0, Threads: []int{0, 4}},
+					},
+				},
+				{
+					Id: 1,
+					Cores: []cadvisorapi.Core{
+						{SocketID: 1, Id: 1, Threads: []int{1, 5}},
+					},
+				},
+			},
+			expectedSpec: nil,
+			expectedStatus: []*nodev1alpha1.TopologyZone{
+				{
+					Type: nodev1alpha1.TopologyTypeSocket,
+					Name: "0",
+					Children: []*nodev1alpha1.TopologyZone{
+						{
+							Type: nodev1alpha1.TopologyTypeNuma,
+							Name: "0",
+							Children: []*nodev1alpha1.TopologyZone{
+								{
+									Type:       nodev1alpha1.TopologyTypeGPU,
+									Name:       "gpu-0",
+									Attributes: []nodev1alpha1.Attribute{{Name: "numa", Value: "0"}},
+									Resources: nodev1alpha1.Resources{
+										Allocatable: &v1.ResourceList{"test-gpu": resource.MustParse("1")},
+										Capacity:    &v1.ResourceList{"test-gpu": resource.MustParse("1")},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: nodev1alpha1.TopologyTypeSocket,
+					Name: "1",
+					Children: []*nodev1alpha1.TopologyZone{
+						{
+							Type: nodev1alpha1.TopologyTypeNuma,
+							Name: "1",
+							Children: []*nodev1alpha1.TopologyZone{
+								{
+									Type:       nodev1alpha1.TopologyTypeGPU,
+									Name:       "gpu-1",
+									Attributes: []nodev1alpha1.Attribute{{Name: "numa", Value: "1"}},
+									Resources: nodev1alpha1.Resources{
+										Allocatable: &v1.ResourceList{"test-gpu": resource.MustParse("1")},
+										Capacity:    &v1.ResourceList{"test-gpu": resource.MustParse("1")},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                   "Able to get report content for one dimension",
+			requiredDeviceAffinity: true,
 			// device topology of 1 dimension
 			// gpu-0, gpu-1, gpu-2, gpu-3 are on numa-0
 			// gpu-4, gpu-5, gpu-6, gpu-7 are on numa-1
@@ -582,7 +661,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Able to get report content for 2 dimensions",
+			name:                   "Able to get report content for 2 dimensions",
+			requiredDeviceAffinity: true,
 			// device topology for 2 dimensions
 			// gpu-0, gpu-1 in pcie 0
 			// gpu-2, gpu-3 in pcie 1
@@ -889,7 +969,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Reporting of 0 value for resources if devices are not healthy",
+			name:                   "Reporting of 0 value for resources if devices are not healthy",
+			requiredDeviceAffinity: true,
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: []string{"numa"},
 				Devices: map[string]machine.DeviceInfo{
@@ -1149,7 +1230,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "No reporting CNR when PriorityDimensions are nil",
+			name:                   "No reporting CNR when PriorityDimensions are nil",
+			requiredDeviceAffinity: true,
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: nil,
 				Devices: map[string]machine.DeviceInfo{
@@ -1356,7 +1438,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "No reporting CNR when device affinity dimensions are empty",
+			name:                   "No reporting CNR when device affinity dimensions are empty",
+			requiredDeviceAffinity: true,
 			// device topology is not populated with dimension names and values
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: []string{"pcie", "numa"},
@@ -1546,7 +1629,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Reporting allocations when pods are assigned to devices",
+			name:                   "Reporting allocations when pods are assigned to devices",
+			requiredDeviceAffinity: true,
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: []string{"numa"},
 				Devices: map[string]machine.DeviceInfo{
@@ -1630,7 +1714,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Reporting allocatable equals allocState for healthy devices",
+			name:                   "Reporting allocatable equals allocState for healthy devices",
+			requiredDeviceAffinity: true,
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: []string{"numa"},
 				Devices: map[string]machine.DeviceInfo{
@@ -1702,7 +1787,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Allocations use resourceName when allocation DeviceName is empty",
+			name:                   "Allocations use resourceName when allocation DeviceName is empty",
+			requiredDeviceAffinity: true,
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: []string{"numa"},
 				Devices: map[string]machine.DeviceInfo{
@@ -1761,7 +1847,8 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name: "Allocations are skipped when allocation DeviceName is not a GPU device",
+			name:                   "Allocations are skipped when allocation DeviceName is not a GPU device",
+			requiredDeviceAffinity: true,
 			deviceTopology: &machine.DeviceTopology{
 				PriorityDimensions: []string{"numa"},
 				Devices: map[string]machine.DeviceInfo{
@@ -1816,8 +1903,9 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			},
 		},
 		{
-			name:           "Merge resources across multiple device names for same device type",
-			gpuDeviceNames: []string{"test-gpu-a", "test-gpu-b"},
+			name:                   "Merge resources across multiple device names for same device type",
+			gpuDeviceNames:         []string{"test-gpu-a", "test-gpu-b"},
+			requiredDeviceAffinity: true,
 			deviceTopologies: map[string]*machine.DeviceTopology{
 				"test-gpu-a": {
 					PriorityDimensions: []string{"numa"},
@@ -1901,6 +1989,7 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			testConfig.PluginRegistrationDir = "test"
 			testConfig.GPUDeviceNames = gpuDeviceNames
 			testConfig.EnableKubeletCheckpointFallback = true
+			testConfig.RequiredDeviceAffinity = tt.requiredDeviceAffinity
 
 			resourceTypeName := v1.ResourceName("test-gpu-resource")
 			deviceIDs := make([]string, 0)

--- a/pkg/config/agent/qrm/gpu_plugin.go
+++ b/pkg/config/agent/qrm/gpu_plugin.go
@@ -36,7 +36,7 @@ type GPUQRMPluginConfig struct {
 	// SkipGPUStateCorruption skip gpu state corruption, and it will be used after updating state properties
 	SkipGPUStateCorruption bool
 	// RequiredDeviceAffinity specifies whether it is required for pods to follow device affinity strictly.
-	// If true, pods will fail to admit if they are not able to satisfy device affinity constraints. Set to true by default.
+	// If true, pods will fail to admit if they are not able to satisfy device affinity constraints. Set to false by default.
 	RequiredDeviceAffinity bool
 	// EnableKubeletCheckpointFallback specifies whether to fallback to kubelet device plugin checkpoint for allocation.
 	EnableKubeletCheckpointFallback bool


### PR DESCRIPTION
Update default value of RequiredDeviceAffinity from true to false, adjust GPU reporter plugin to skip affinity property reporting when the flag is disabled, and update all related test cases to validate the new behavior.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed the default GPU device-affinity behavior to be less restrictive.
  * GPU topology affinity details are now only included when device affinity is explicitly required, avoiding unexpected reporting changes.
  * Added coverage for the updated GPU reporting behavior when affinity is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->