### PR TITLE
fix(qrm): mb-plugin realtime_mb toleration cutoff time from 3s to 4s

### DIFF
--- a/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/advisor_metrics.go
@@ -51,7 +51,7 @@ func (a *uniqPriorityAdvisor) emitDomIncomingStatSummaryMetrics(domLimits map[in
 	}
 }
 
-func (a *uniqPriorityAdvisor) emitStatsMtrics(domainsMon *monitor.DomainStats) {
+func (a *uniqPriorityAdvisor) emitStatsMetrics(domainsMon *monitor.DomainStats) {
 	a.emitOutgoingStats(domainsMon.Outgoings)
 	a.emitIncomingStats(domainsMon.Incomings)
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_advisor.go
@@ -40,11 +40,6 @@ type pControllerAdvisor struct {
 	lastCCDLimitSuppression map[int]map[string]map[int]string
 }
 
-type groupPCtrlState struct {
-	pCtrl    pController
-	ccdCapMB int
-}
-
 func (p *pControllerAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error) {
 	result, err := p.inner.GetPlan(ctx, domainsMon)
 	if err != nil {
@@ -82,7 +77,7 @@ func (p *pControllerAdvisor) restrictGroupCCDCap(group string, groupState *group
 	domainsMon *monitor.DomainStats, plan *plan.MBPlan,
 ) {
 	maxObservedMB := p.maxObservedCCDMBForGroup(domainsMon.Outgoings, group)
-	groupState.ccdCapMB = p.getGroupCapUpdate(groupState, maxObservedMB)
+	groupState.setCCDCapMB(p.getGroupCapUpdate(groupState, maxObservedMB))
 
 	ccdMBs, ok := plan.MBGroups[group]
 	if !ok {
@@ -102,8 +97,7 @@ func (p *pControllerAdvisor) getGroupCapUpdate(state *groupPCtrlState, maxObserv
 		return state.ccdCapMB
 	}
 
-	delta := state.pCtrl.update(maxObservedMB)
-	newCap := state.ccdCapMB + delta
+	newCap := state.getCapUpdate(maxObservedMB)
 	return clampMB(newCap, p.ccdMinMB, p.ccdMaxMB)
 }
 
@@ -172,13 +166,7 @@ func NewPControllerAdvisor(Kp float64,
 ) Advisor {
 	groupStates := make(map[string]*groupPCtrlState, len(groupTargets))
 	for group, target := range groupTargets {
-		groupStates[group] = &groupPCtrlState{
-			pCtrl: pController{
-				kp:     Kp,
-				target: target,
-			},
-			ccdCapMB: maxValue,
-		}
+		groupStates[group] = newGroupPCtrlState(Kp, target, maxValue)
 	}
 
 	return &pControllerAdvisor{
@@ -187,14 +175,4 @@ func NewPControllerAdvisor(Kp float64,
 		inner:       inner,
 		groupStates: groupStates,
 	}
-}
-
-type pController struct {
-	kp     float64
-	target int
-}
-
-func (p *pController) update(measurement int) int {
-	gap := float64(p.target - measurement)
-	return int(p.kp * gap)
 }

--- a/pkg/agent/qrm-plugins/mb/advisor/pcontroller_group_state.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/pcontroller_group_state.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package advisor
+
+type groupPCtrlState struct {
+	pCtrl    pController
+	ccdCapMB int
+}
+
+func (g *groupPCtrlState) getCapUpdate(maxObservedMB int) int {
+	delta := g.pCtrl.update(maxObservedMB)
+	newCap := g.ccdCapMB + delta
+	return newCap
+}
+
+func (g *groupPCtrlState) setCCDCapMB(cap int) {
+	// todo: allow cap increase a bit
+	if cap > g.ccdCapMB {
+		return
+	}
+
+	g.ccdCapMB = cap
+}
+
+func newGroupPCtrlState(Kp float64, target int, maxValue int) *groupPCtrlState {
+	return &groupPCtrlState{
+		pCtrl: pController{
+			kp:     Kp,
+			target: target,
+		},
+		ccdCapMB: maxValue,
+	}
+}
+
+type pController struct {
+	kp     float64
+	target int
+}
+
+func (p *pController) update(measurement int) int {
+	gap := float64(p.target - measurement)
+	return int(p.kp * gap)
+}

--- a/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor.go
+++ b/pkg/agent/qrm-plugins/mb/advisor/uniq_priority_advisor.go
@@ -64,7 +64,7 @@ type uniqPriorityAdvisor struct {
 }
 
 func (a *uniqPriorityAdvisor) GetPlan(ctx context.Context, domainsMon *monitor.DomainStats) (*plan.MBPlan, error) {
-	a.emitStatsMtrics(domainsMon)
+	a.emitStatsMetrics(domainsMon)
 
 	// identify mb incoming usage etc since the capacity applies to incoming traffic
 	domIncomingInfo, err := a.calcIncomingDomainStats(ctx, domainsMon)

--- a/pkg/agent/qrm-plugins/mb/reader/mb_reader.go
+++ b/pkg/agent/qrm-plugins/mb/reader/mb_reader.go
@@ -34,9 +34,11 @@ import (
 )
 
 const (
-	tolerationTime = 3 * time.Second
-	rootGroup      = "root"
-	maxCCDTotalMB  = 60 * 1024
+	// increase toleration threshold as previous 3 seconds lead to quite some portion of skipped cycles
+	tolerationTime = 4 * time.Second
+
+	rootGroup     = "root"
+	maxCCDTotalMB = 60 * 1024
 )
 
 // localIsVictimAndTotalIsAllRead indicates special settings of resctrl controlling reg1 & reg2 which yield


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the freshness/staleness threshold used in MB rate calculations, allowing a slightly longer window before data is treated as stale.
  * Corrected per-domain metrics emission so stats names are spelled correctly and consistently reported.
* **Refactor**
  * Improved MB capacity (CCD cap) update handling by centralizing controller-based cap delta computation and applying updates in a more consistent way during planning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->