### PR TITLE
feat(util): add reusable cgroup and procfs helpers

### DIFF
--- a/pkg/util/cgroup/client/cache.go
+++ b/pkg/util/cgroup/client/cache.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+type cachedCgroupClient struct {
+	inner CgroupClient
+
+	mu    sync.Mutex
+	cache map[cacheKey]cacheEntry
+	now   func() time.Time
+}
+
+type cacheKey struct {
+	rel  string
+	file string
+}
+
+type cacheEntry struct {
+	value     string
+	mtime     time.Time
+	size      int64
+	writtenAt time.Time
+}
+
+// NewCachedCgroupClient decorates inner with write-if-change caching.
+func NewCachedCgroupClient(inner CgroupClient) CgroupClient {
+	if inner == nil {
+		panic("NewCachedCgroupClient: inner CgroupClient must not be nil")
+	}
+	return &cachedCgroupClient{
+		inner: inner,
+		cache: map[cacheKey]cacheEntry{},
+		now:   time.Now,
+	}
+}
+
+func (c *cachedCgroupClient) Version(ctx context.Context) CgroupVersion {
+	return c.inner.Version(ctx)
+}
+
+func (c *cachedCgroupClient) ReadCPUSet(ctx context.Context, rel string) (machine.CPUSet, error) {
+	return c.inner.ReadCPUSet(ctx, rel)
+}
+
+func (c *cachedCgroupClient) StatCPUSet(ctx context.Context, rel string) (time.Time, int64, error) {
+	return c.inner.StatCPUSet(ctx, rel)
+}
+
+func (c *cachedCgroupClient) StatCgroupFile(ctx context.Context, rel, file string) (time.Time, int64, error) {
+	return c.inner.StatCgroupFile(ctx, rel, file)
+}
+
+func (c *cachedCgroupClient) ReadCPUSetPartition(ctx context.Context, rel string) (cgcommon.CPUSetPartitionFlag, error) {
+	return c.inner.ReadCPUSetPartition(ctx, rel)
+}
+
+func (c *cachedCgroupClient) ListRootChildren(ctx context.Context) ([]string, error) {
+	return c.inner.ListRootChildren(ctx)
+}
+
+func (c *cachedCgroupClient) ListChildren(ctx context.Context, rel string) ([]string, error) {
+	return c.inner.ListChildren(ctx, rel)
+}
+
+func (c *cachedCgroupClient) StatDir(ctx context.Context, rel string) (time.Time, error) {
+	return c.inner.StatDir(ctx, rel)
+}
+
+func (c *cachedCgroupClient) AttachPID(ctx context.Context, rel string, pid int) error {
+	return c.inner.AttachPID(ctx, rel, pid)
+}
+
+func (c *cachedCgroupClient) ApplyCPUSet(ctx context.Context, rel string, data *cgcommon.CPUSetData) error {
+	if data == nil {
+		return c.inner.ApplyCPUSet(ctx, rel, data)
+	}
+	skipCPUs := data.CPUs == "" || c.shouldSkip(ctx, rel, "cpuset.cpus", data.CPUs)
+	skipMems := data.Mems == "" || c.shouldSkip(ctx, rel, "cpuset.mems", data.Mems)
+	if skipCPUs && skipMems {
+		return nil
+	}
+	if err := c.inner.ApplyCPUSet(ctx, rel, data); err != nil {
+		if data.CPUs != "" {
+			c.invalidate(rel, "cpuset.cpus")
+		}
+		if data.Mems != "" {
+			c.invalidate(rel, "cpuset.mems")
+		}
+		return err
+	}
+	if data.CPUs != "" {
+		c.recordWrite(ctx, rel, "cpuset.cpus", data.CPUs)
+	}
+	if data.Mems != "" {
+		c.recordWrite(ctx, rel, "cpuset.mems", data.Mems)
+	}
+	return nil
+}
+
+func (c *cachedCgroupClient) ApplyCPUSetPartition(ctx context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error {
+	value := string(flag)
+	if c.shouldSkip(ctx, rel, "cpuset.cpus.partition", value) {
+		return nil
+	}
+	if err := c.inner.ApplyCPUSetPartition(ctx, rel, flag); err != nil {
+		c.invalidate(rel, "cpuset.cpus.partition")
+		return err
+	}
+	c.recordWrite(ctx, rel, "cpuset.cpus.partition", value)
+	return nil
+}
+
+func (c *cachedCgroupClient) ApplyCPU(ctx context.Context, rel string, data *cgcommon.CPUData) error {
+	if data == nil {
+		return c.inner.ApplyCPU(ctx, rel, data)
+	}
+	fields := cpuDataFields(data)
+	allSkip := true
+	for _, f := range fields {
+		if !c.shouldSkip(ctx, rel, f.file, f.value) {
+			allSkip = false
+			break
+		}
+	}
+	if allSkip && len(fields) > 0 {
+		return nil
+	}
+	if err := c.inner.ApplyCPU(ctx, rel, data); err != nil {
+		for _, f := range fields {
+			c.invalidate(rel, f.file)
+		}
+		return err
+	}
+	for _, f := range fields {
+		c.recordWrite(ctx, rel, f.file, f.value)
+	}
+	return nil
+}
+
+func (c *cachedCgroupClient) ApplySchedLoadBalance(ctx context.Context, rel string, enabled bool) error {
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+	if c.shouldSkip(ctx, rel, "cpuset.sched_load_balance", value) {
+		return nil
+	}
+	if err := c.inner.ApplySchedLoadBalance(ctx, rel, enabled); err != nil {
+		c.invalidate(rel, "cpuset.sched_load_balance")
+		return err
+	}
+	c.recordWrite(ctx, rel, "cpuset.sched_load_balance", value)
+	return nil
+}
+
+func (c *cachedCgroupClient) shouldSkip(ctx context.Context, rel, file, want string) bool {
+	c.mu.Lock()
+	entry, ok := c.cache[cacheKey{rel: rel, file: file}]
+	c.mu.Unlock()
+	if !ok {
+		return false
+	}
+	if entry.value != want {
+		return false
+	}
+	mtime, size, err := c.statFile(ctx, rel, file)
+	if err != nil {
+		c.invalidate(rel, file)
+		return false
+	}
+	return mtime.Equal(entry.mtime) && size == entry.size
+}
+
+func (c *cachedCgroupClient) recordWrite(ctx context.Context, rel, file, value string) {
+	mtime, size, err := c.statFile(ctx, rel, file)
+	if err != nil {
+		c.invalidate(rel, file)
+		return
+	}
+	c.mu.Lock()
+	c.cache[cacheKey{rel: rel, file: file}] = cacheEntry{
+		value:     value,
+		mtime:     mtime,
+		size:      size,
+		writtenAt: c.now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *cachedCgroupClient) invalidate(rel, file string) {
+	c.mu.Lock()
+	delete(c.cache, cacheKey{rel: rel, file: file})
+	c.mu.Unlock()
+}
+
+func (c *cachedCgroupClient) Prune(activeRels map[string]struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.cache {
+		if _, ok := activeRels[k.rel]; !ok {
+			delete(c.cache, k)
+		}
+	}
+}
+
+func (c *cachedCgroupClient) statFile(ctx context.Context, rel, file string) (time.Time, int64, error) {
+	switch file {
+	case "cpuset.cpus":
+		return c.inner.StatCPUSet(ctx, rel)
+	case "cpuset.mems", "cpuset.cpus.partition", "cpuset.sched_load_balance":
+		return c.inner.StatCgroupFile(ctx, rel, file)
+	}
+	mtime, err := c.inner.StatDir(ctx, rel)
+	return mtime, 0, err
+}
+
+type cachedApplyFieldValue struct {
+	file  string
+	value string
+}
+
+func cpuDataFields(data *cgcommon.CPUData) []cachedApplyFieldValue {
+	if data == nil {
+		return nil
+	}
+	var out []cachedApplyFieldValue
+	if data.Shares != 0 {
+		out = append(out, cachedApplyFieldValue{file: "cpu.shares", value: strconv.FormatUint(data.Shares, 10)})
+	}
+	if data.CpuPeriod != 0 {
+		out = append(out, cachedApplyFieldValue{file: "cpu.cfs_period_us", value: strconv.FormatUint(data.CpuPeriod, 10)})
+	}
+	if data.CpuQuota != 0 {
+		out = append(out, cachedApplyFieldValue{file: "cpu.cfs_quota_us", value: strconv.FormatInt(data.CpuQuota, 10)})
+	}
+	if data.CpuIdlePtr != nil {
+		v := "0"
+		if *data.CpuIdlePtr {
+			v = "1"
+		}
+		out = append(out, cachedApplyFieldValue{file: "cpu.idle", value: v})
+	}
+	if data.CpuBurst != nil {
+		out = append(out, cachedApplyFieldValue{file: "cpu.cfs_burst_us", value: strconv.FormatUint(*data.CpuBurst, 10)})
+	}
+	return out
+}

--- a/pkg/util/cgroup/client/cache_test.go
+++ b/pkg/util/cgroup/client/cache_test.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+type fakeCgroupClient struct{}
+
+var _ CgroupClient = (*fakeCgroupClient)(nil)
+
+func (fakeCgroupClient) ApplyCPUSet(context.Context, string, *cgcommon.CPUSetData) error {
+	return nil
+}
+
+func (fakeCgroupClient) ApplyCPUSetPartition(context.Context, string, cgcommon.CPUSetPartitionFlag) error {
+	return nil
+}
+
+func (fakeCgroupClient) ApplyCPU(context.Context, string, *cgcommon.CPUData) error {
+	return nil
+}
+
+func (fakeCgroupClient) ApplySchedLoadBalance(context.Context, string, bool) error {
+	return nil
+}
+
+func (fakeCgroupClient) AttachPID(context.Context, string, int) error {
+	return nil
+}
+
+func (fakeCgroupClient) Version(context.Context) CgroupVersion {
+	return CgroupVersionV2
+}
+
+func (fakeCgroupClient) ReadCPUSet(context.Context, string) (machine.CPUSet, error) {
+	return machine.NewCPUSet(), nil
+}
+
+func (fakeCgroupClient) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	return time.Time{}, 0, nil
+}
+
+func (fakeCgroupClient) StatCgroupFile(context.Context, string, string) (time.Time, int64, error) {
+	return time.Time{}, 0, nil
+}
+
+func (fakeCgroupClient) ReadCPUSetPartition(context.Context, string) (cgcommon.CPUSetPartitionFlag, error) {
+	return cgcommon.CPUSetPartitionFlagMember, nil
+}
+
+func (fakeCgroupClient) ListRootChildren(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (fakeCgroupClient) ListChildren(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (fakeCgroupClient) StatDir(context.Context, string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (fakeCgroupClient) Prune(map[string]struct{}) {}
+
+type countingFake struct {
+	fakeCgroupClient
+
+	applyCPUSetN          int64
+	applyCPUSetPartitionN int64
+	applyCPUN             int64
+	applySchedLBN         int64
+	attachPIDN            int64
+	statErr               error
+	mtime                 int64
+	size                  int64
+}
+
+func newCountingFake() *countingFake {
+	f := &countingFake{}
+	atomic.StoreInt64(&f.mtime, 1)
+	atomic.StoreInt64(&f.size, 4)
+	return f
+}
+
+func (f *countingFake) bumpMTime() {
+	atomic.AddInt64(&f.mtime, 1)
+}
+
+func (f *countingFake) statNow() (time.Time, int64, error) {
+	if f.statErr != nil {
+		return time.Time{}, 0, f.statErr
+	}
+	return time.Unix(0, atomic.LoadInt64(&f.mtime)), atomic.LoadInt64(&f.size), nil
+}
+
+func (f *countingFake) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	return f.statNow()
+}
+
+func (f *countingFake) StatCgroupFile(context.Context, string, string) (time.Time, int64, error) {
+	return f.statNow()
+}
+
+func (f *countingFake) StatDir(context.Context, string) (time.Time, error) {
+	t, _, err := f.statNow()
+	return t, err
+}
+
+func (f *countingFake) ApplyCPUSet(context.Context, string, *cgcommon.CPUSetData) error {
+	atomic.AddInt64(&f.applyCPUSetN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) ApplyCPUSetPartition(context.Context, string, cgcommon.CPUSetPartitionFlag) error {
+	atomic.AddInt64(&f.applyCPUSetPartitionN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) ApplyCPU(context.Context, string, *cgcommon.CPUData) error {
+	atomic.AddInt64(&f.applyCPUN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) ApplySchedLoadBalance(context.Context, string, bool) error {
+	atomic.AddInt64(&f.applySchedLBN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) AttachPID(context.Context, string, int) error {
+	atomic.AddInt64(&f.attachPIDN, 1)
+	return nil
+}
+
+func TestCachedCgroupClient_ApplyCPU_ShortCircuitsAndInvalidates(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+	idleOn := true
+	idleOff := false
+
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("first ApplyCPU: %v", err)
+	}
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("second ApplyCPU: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 1 {
+		t.Fatalf("inner ApplyCPU calls after idempotent write = %d, want 1", got)
+	}
+
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOff}); err != nil {
+		t.Fatalf("third ApplyCPU: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 2 {
+		t.Fatalf("inner ApplyCPU calls after value change = %d, want 2", got)
+	}
+
+	inner.bumpMTime()
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOff}); err != nil {
+		t.Fatalf("fourth ApplyCPU: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 3 {
+		t.Fatalf("inner ApplyCPU calls after external drift = %d, want 3", got)
+	}
+}
+
+func TestCachedCgroupClient_ApplyCPUSet_PerFileCache(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+
+	if err := c.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1", Mems: "0"}); err != nil {
+		t.Fatalf("first ApplyCPUSet: %v", err)
+	}
+	if err := c.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1", Mems: "0"}); err != nil {
+		t.Fatalf("second ApplyCPUSet: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUSetN); got != 1 {
+		t.Fatalf("inner ApplyCPUSet calls after idempotent write = %d, want 1", got)
+	}
+	if err := c.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1", Mems: "1"}); err != nil {
+		t.Fatalf("third ApplyCPUSet: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUSetN); got != 2 {
+		t.Fatalf("inner ApplyCPUSet calls after mems change = %d, want 2", got)
+	}
+}
+
+func TestCachedCgroupClient_ApplyCPUSetPartitionAndSchedLoadBalance(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+
+	if err := c.ApplyCPUSetPartition(ctx, "kubepods", cgcommon.CPUSetPartitionFlagRoot); err != nil {
+		t.Fatalf("first partition: %v", err)
+	}
+	if err := c.ApplyCPUSetPartition(ctx, "kubepods", cgcommon.CPUSetPartitionFlagRoot); err != nil {
+		t.Fatalf("second partition: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUSetPartitionN); got != 1 {
+		t.Fatalf("partition writes = %d, want 1", got)
+	}
+
+	if err := c.ApplySchedLoadBalance(ctx, "kubepods", true); err != nil {
+		t.Fatalf("first sched_load_balance: %v", err)
+	}
+	if err := c.ApplySchedLoadBalance(ctx, "kubepods", true); err != nil {
+		t.Fatalf("second sched_load_balance: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applySchedLBN); got != 1 {
+		t.Fatalf("sched_load_balance writes = %d, want 1", got)
+	}
+}
+
+func TestCachedCgroupClient_StatFailureInvalidates(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+	idleOn := true
+
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("first ApplyCPU: %v", err)
+	}
+	inner.statErr = errors.New("stat failed")
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("second ApplyCPU after stat failure: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 2 {
+		t.Fatalf("ApplyCPU calls after stat failure = %d, want 2", got)
+	}
+}
+
+func TestCachedCgroupClient_AttachPIDNeverCaches(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+
+	if err := c.AttachPID(ctx, "kubepods", 1234); err != nil {
+		t.Fatalf("first AttachPID: %v", err)
+	}
+	if err := c.AttachPID(ctx, "kubepods", 1234); err != nil {
+		t.Fatalf("second AttachPID: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.attachPIDN); got != 2 {
+		t.Fatalf("AttachPID calls = %d, want 2", got)
+	}
+}
+
+type statFileFake struct {
+	fakeCgroupClient
+
+	statCPUSetCalls int
+	statCgroupFile  []string
+	statDirCalls    int
+	mtimeCPUSet     time.Time
+	mtimeCgroupFile time.Time
+	mtimeDir        time.Time
+}
+
+func (f *statFileFake) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	f.statCPUSetCalls++
+	return f.mtimeCPUSet, 0, nil
+}
+
+func (f *statFileFake) StatCgroupFile(_ context.Context, _ string, file string) (time.Time, int64, error) {
+	f.statCgroupFile = append(f.statCgroupFile, file)
+	return f.mtimeCgroupFile, 0, nil
+}
+
+func (f *statFileFake) StatDir(context.Context, string) (time.Time, error) {
+	f.statDirCalls++
+	return f.mtimeDir, nil
+}
+
+func TestCachedCgroupClient_statFile_PerFileRouting(t *testing.T) {
+	t.Parallel()
+
+	f := &statFileFake{
+		mtimeCPUSet:     time.Unix(1, 0),
+		mtimeCgroupFile: time.Unix(2, 0),
+		mtimeDir:        time.Unix(3, 0),
+	}
+	c := NewCachedCgroupClient(f).(*cachedCgroupClient)
+	ctx := context.Background()
+
+	mt, _, err := c.statFile(ctx, "kubepods", "cpuset.cpus")
+	if err != nil || !mt.Equal(f.mtimeCPUSet) {
+		t.Fatalf("statFile(cpuset.cpus) = (%v,%v), want %v", mt, err, f.mtimeCPUSet)
+	}
+	if f.statCPUSetCalls != 1 || len(f.statCgroupFile) != 0 || f.statDirCalls != 0 {
+		t.Fatalf("cpuset.cpus routing: statCPUSet=%d statCgroupFile=%v statDir=%d",
+			f.statCPUSetCalls, f.statCgroupFile, f.statDirCalls)
+	}
+
+	perFile := []string{"cpuset.mems", "cpuset.cpus.partition", "cpuset.sched_load_balance"}
+	for _, name := range perFile {
+		if _, _, err := c.statFile(ctx, "kubepods", name); err != nil {
+			t.Fatalf("statFile(%s): %v", name, err)
+		}
+	}
+	for i, name := range perFile {
+		if f.statCgroupFile[i] != name {
+			t.Fatalf("statCgroupFile[%d] = %q, want %q", i, f.statCgroupFile[i], name)
+		}
+	}
+
+	mt, size, err := c.statFile(ctx, "kubepods", "cpu.max")
+	if err != nil || !mt.Equal(f.mtimeDir) || size != 0 {
+		t.Fatalf("statFile(cpu.max) = (%v,%d,%v), want (%v,0,nil)", mt, size, err, f.mtimeDir)
+	}
+	if f.statDirCalls != 1 {
+		t.Fatalf("StatDir calls = %d, want 1", f.statDirCalls)
+	}
+}
+
+func TestCachedCgroupClient_Prune(t *testing.T) {
+	t.Parallel()
+
+	c := NewCachedCgroupClient(&fakeCgroupClient{}).(*cachedCgroupClient)
+	c.cache[cacheKey{rel: "rel-a", file: "cpuset.cpus"}] = cacheEntry{value: "0-1"}
+	c.cache[cacheKey{rel: "rel-a", file: "cpuset.mems"}] = cacheEntry{value: "0"}
+	c.cache[cacheKey{rel: "rel-b", file: "cpuset.cpus"}] = cacheEntry{value: "2-3"}
+
+	c.Prune(map[string]struct{}{"rel-a": {}})
+
+	if len(c.cache) != 2 {
+		t.Fatalf("cache size after Prune = %d, want 2", len(c.cache))
+	}
+	if _, ok := c.cache[cacheKey{rel: "rel-b", file: "cpuset.cpus"}]; ok {
+		t.Fatalf("rel-b/cpuset.cpus should be dropped")
+	}
+
+	c.Prune(nil)
+	if len(c.cache) != 0 {
+		t.Fatalf("Prune(nil) left %d entries, want 0", len(c.cache))
+	}
+}

--- a/pkg/util/cgroup/client/client.go
+++ b/pkg/util/cgroup/client/client.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client provides a small cgroup manager facade with write-if-change caching.
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	cgmanager "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+// CgroupVersion tags the cgroup hierarchy layout the current host is booted into.
+type CgroupVersion string
+
+const (
+	// CgroupVersionV1 indicates the host is using cgroup v1 hierarchies.
+	CgroupVersionV1 CgroupVersion = "v1"
+	// CgroupVersionV2 indicates the host is using cgroup v2 unified hierarchy.
+	CgroupVersionV2 CgroupVersion = "v2"
+)
+
+// CgroupClient is the narrow cgroup interface consumed by reconciliation code.
+type CgroupClient interface {
+	// ApplyCPUSet writes cpuset.cpus and cpuset.mems to rel.
+	ApplyCPUSet(ctx context.Context, rel string, data *cgcommon.CPUSetData) error
+	// ApplyCPUSetPartition writes cpuset.cpus.partition to rel.
+	ApplyCPUSetPartition(ctx context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error
+	// ApplyCPU writes cpu controller data to rel.
+	ApplyCPU(ctx context.Context, rel string, data *cgcommon.CPUData) error
+	// ApplySchedLoadBalance toggles cpuset.sched_load_balance at rel.
+	ApplySchedLoadBalance(ctx context.Context, rel string, enabled bool) error
+	// AttachPID writes pid into cgroup.procs at rel.
+	AttachPID(ctx context.Context, rel string, pid int) error
+	// Version reports whether the host is running cgroup v1 or v2.
+	Version(ctx context.Context) CgroupVersion
+	// ReadCPUSet parses cpuset.cpus at rel.
+	ReadCPUSet(ctx context.Context, rel string) (machine.CPUSet, error)
+	// StatCPUSet returns metadata for cpuset.cpus at rel.
+	StatCPUSet(ctx context.Context, rel string) (mtime time.Time, size int64, err error)
+	// StatCgroupFile returns metadata for file under rel's cpuset cgroup directory.
+	StatCgroupFile(ctx context.Context, rel, file string) (mtime time.Time, size int64, err error)
+	// ReadCPUSetPartition reads cpuset.cpus.partition at rel.
+	ReadCPUSetPartition(ctx context.Context, rel string) (cgcommon.CPUSetPartitionFlag, error)
+	// ListRootChildren returns direct child directory names under the cpuset cgroup root.
+	ListRootChildren(ctx context.Context) ([]string, error)
+	// ListChildren returns direct child directory names under rel.
+	ListChildren(ctx context.Context, rel string) ([]string, error)
+	// StatDir returns the mtime of the cgroup directory at rel.
+	StatDir(ctx context.Context, rel string) (mtime time.Time, err error)
+	// Prune drops cached state whose rel is not active.
+	Prune(activeRels map[string]struct{})
+}
+
+type coreCgroupClient struct{}
+
+// NewCgroupClient returns a core cgroup client wrapped by a write-if-change cache.
+func NewCgroupClient() CgroupClient {
+	return NewCachedCgroupClient(coreCgroupClient{})
+}
+
+func (coreCgroupClient) ApplyCPUSet(_ context.Context, rel string, data *cgcommon.CPUSetData) error {
+	if data == nil {
+		return fmt.Errorf("ApplyCPUSet: nil data")
+	}
+	return cgmanager.ApplyCPUSetWithRelativePath(rel, data)
+}
+
+func (coreCgroupClient) ApplyCPUSetPartition(_ context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error {
+	return cgmanager.ApplyCPUSetPartitionWithRelativePath(rel, flag)
+}
+
+func (coreCgroupClient) ApplyCPU(_ context.Context, rel string, data *cgcommon.CPUData) error {
+	if data == nil {
+		return fmt.Errorf("ApplyCPU: nil data")
+	}
+	return cgmanager.ApplyCPUWithRelativePath(rel, data)
+}
+
+func (coreCgroupClient) ApplySchedLoadBalance(_ context.Context, rel string, enabled bool) error {
+	err := cgmanager.ApplySchedLoadBalanceWithRelativePath(rel, enabled)
+	if err != nil && errors.Is(err, cgcommon.ErrNotSupported) {
+		return fmt.Errorf("sched_load_balance @ %s: %w", rel, err)
+	}
+	return err
+}
+
+func (coreCgroupClient) AttachPID(_ context.Context, rel string, pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("AttachPID: invalid pid %d", pid)
+	}
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	f, err := os.OpenFile(filepath.Join(abs, "cgroup.procs"), os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open cgroup.procs @ %s: %w", rel, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := fmt.Fprintf(f, "%d", pid); err != nil {
+		return fmt.Errorf("write pid %d @ %s: %w", pid, rel, err)
+	}
+	return nil
+}
+
+func (coreCgroupClient) Version(context.Context) CgroupVersion {
+	if cgcommon.CheckCgroup2UnifiedMode() {
+		return CgroupVersionV2
+	}
+	return CgroupVersionV1
+}
+
+func (coreCgroupClient) ReadCPUSet(_ context.Context, rel string) (machine.CPUSet, error) {
+	stats, err := cgmanager.GetCPUSetWithRelativePath(rel)
+	if err != nil {
+		return machine.NewCPUSet(), fmt.Errorf("read cpuset @ %s: %w", rel, err)
+	}
+	if stats == nil {
+		return machine.NewCPUSet(), nil
+	}
+	cs, err := machine.Parse(stats.CPUs)
+	if err != nil {
+		return machine.NewCPUSet(), fmt.Errorf("parse cpuset %q @ %s: %w", stats.CPUs, rel, err)
+	}
+	return cs, nil
+}
+
+func (coreCgroupClient) StatCPUSet(_ context.Context, rel string) (time.Time, int64, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	info, err := os.Stat(filepath.Join(abs, "cpuset.cpus"))
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+	return info.ModTime(), info.Size(), nil
+}
+
+func (coreCgroupClient) StatCgroupFile(_ context.Context, rel, file string) (time.Time, int64, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	info, err := os.Stat(filepath.Join(abs, file))
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+	return info.ModTime(), info.Size(), nil
+}
+
+func (coreCgroupClient) ReadCPUSetPartition(_ context.Context, rel string) (cgcommon.CPUSetPartitionFlag, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	raw, err := os.ReadFile(filepath.Join(abs, "cpuset.cpus.partition"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("read cpuset.cpus.partition @ %s: %w", rel, cgcommon.ErrNotSupported)
+		}
+		return "", fmt.Errorf("read cpuset.cpus.partition @ %s: %w", rel, err)
+	}
+	val := strings.TrimSpace(string(raw))
+	switch cgcommon.CPUSetPartitionFlag(val) {
+	case cgcommon.CPUSetPartitionFlagRoot, cgcommon.CPUSetPartitionFlagMember, cgcommon.CPUSetPartitionFlagIsolated:
+		return cgcommon.CPUSetPartitionFlag(val), nil
+	default:
+		if idx := strings.IndexAny(val, " \t"); idx > 0 {
+			return cgcommon.CPUSetPartitionFlag(val[:idx]), nil
+		}
+		return cgcommon.CPUSetPartitionFlag(val), nil
+	}
+}
+
+func (c coreCgroupClient) ListRootChildren(ctx context.Context) ([]string, error) {
+	return c.ListChildren(ctx, "")
+}
+
+func (coreCgroupClient) ListChildren(_ context.Context, rel string) ([]string, error) {
+	var abs string
+	if strings.TrimSpace(rel) == "" {
+		abs = cgcommon.GetCgroupRootPath(cgcommon.CgroupSubsysCPUSet)
+	} else {
+		abs = cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	}
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		return nil, fmt.Errorf("readdir %s: %w", abs, err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (coreCgroupClient) StatDir(_ context.Context, rel string) (time.Time, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
+func (coreCgroupClient) Prune(map[string]struct{}) {}

--- a/pkg/util/cgroup/client/client_test.go
+++ b/pkg/util/cgroup/client/client_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+)
+
+func TestNewCgroupClient_ReturnsCachedClient(t *testing.T) {
+	t.Parallel()
+
+	c := NewCgroupClient()
+	if c == nil {
+		t.Fatalf("NewCgroupClient() = nil")
+	}
+	if _, ok := c.(*cachedCgroupClient); !ok {
+		t.Fatalf("NewCgroupClient() type = %T, want *cachedCgroupClient", c)
+	}
+}
+
+func TestNewCachedCgroupClient_PanicsOnNilInner(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("NewCachedCgroupClient(nil) must panic")
+		}
+	}()
+	_ = NewCachedCgroupClient(nil)
+}
+
+func TestCoreCgroupClient_ApplyCPUSet_NilDataRejected(t *testing.T) {
+	t.Parallel()
+
+	err := NewCgroupClient().ApplyCPUSet(context.Background(), "kubepods", nil)
+	if err == nil {
+		t.Fatalf("ApplyCPUSet(nil) must fail")
+	}
+	if !strings.Contains(err.Error(), "nil data") {
+		t.Fatalf("error must mention nil data, got: %v", err)
+	}
+}
+
+func TestCoreCgroupClient_ApplyCPU_NilDataRejected(t *testing.T) {
+	t.Parallel()
+
+	err := NewCgroupClient().ApplyCPU(context.Background(), "kubepods", nil)
+	if err == nil {
+		t.Fatalf("ApplyCPU(nil) must fail")
+	}
+	if !strings.Contains(err.Error(), "nil data") {
+		t.Fatalf("error must mention nil data, got: %v", err)
+	}
+}
+
+func TestCoreCgroupClient_AttachPID_InvalidPIDRejected(t *testing.T) {
+	t.Parallel()
+
+	c := NewCgroupClient()
+	for _, pid := range []int{0, -1, -1000} {
+		if err := c.AttachPID(context.Background(), "kubepods", pid); err == nil {
+			t.Fatalf("AttachPID(%d) must fail", pid)
+		}
+	}
+}
+
+func TestCoreCgroupClient_Version_ReturnsKnownEnum(t *testing.T) {
+	t.Parallel()
+
+	got := NewCgroupClient().Version(context.Background())
+	if got != CgroupVersionV1 && got != CgroupVersionV2 {
+		t.Fatalf("Version() = %q, want %q or %q", got, CgroupVersionV1, CgroupVersionV2)
+	}
+}
+
+func TestCoreCgroupClient_StatCPUSet_MissingPathSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := NewCgroupClient().StatCPUSet(context.Background(), "/definitely/not/a/real/cgroup/path")
+	if err == nil {
+		t.Fatalf("StatCPUSet on missing path must error")
+	}
+}
+
+func TestCoreCgroupClient_StatDir_MissingPathSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewCgroupClient().StatDir(context.Background(), "/definitely/not/a/real/cgroup/path")
+	if err == nil {
+		t.Fatalf("StatDir on missing path must error")
+	}
+}
+
+func TestCoreCgroupClient_ReadCPUSetPartition_ErrNotSupportedOnMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewCgroupClient().ReadCPUSetPartition(context.Background(), "/definitely/not/a/real/cgroup/path")
+	if err == nil {
+		t.Fatalf("ReadCPUSetPartition on missing path must error")
+	}
+	if !errors.Is(err, cgcommon.ErrNotSupported) {
+		t.Fatalf("ReadCPUSetPartition error = %v, want ErrNotSupported-compatible", err)
+	}
+}

--- a/pkg/util/cgroup/common/errors.go
+++ b/pkg/util/cgroup/common/errors.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "errors"
+
+// ErrNotSupported indicates that a cgroup operation is not supported by the current hierarchy.
+var ErrNotSupported = errors.New("cgroup operation is not supported")

--- a/pkg/util/cgroup/manager/cgroup.go
+++ b/pkg/util/cgroup/manager/cgroup.go
@@ -113,6 +113,15 @@ func ApplyCPUSetPartitionWithAbsolutePath(absCgroupPath string, partitionFlag co
 	return GetManager().ApplyCPUSetPartition(absCgroupPath, partitionFlag)
 }
 
+func ApplySchedLoadBalanceWithRelativePath(relCgroupPath string, enabled bool) error {
+	absCgroupPath := common.GetAbsCgroupPath(common.CgroupSubsysCPUSet, relCgroupPath)
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+	return ApplyUnifiedDataWithAbsolutePath(absCgroupPath, "cpuset.sched_load_balance", value)
+}
+
 func ApplyCPUSetForContainer(podUID, containerId string, data *common.CPUSetData) error {
 	if data == nil {
 		return fmt.Errorf("ApplyCPUSetForContainer with nil cgroup data")

--- a/pkg/util/fs/fs.go
+++ b/pkg/util/fs/fs.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fs provides small filesystem helpers that can be replaced by fakes in tests.
+package fs
+
+import (
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"strings"
+)
+
+// FS provides the filesystem operations required by util helpers.
+type FS interface {
+	// ReadFile returns the raw bytes at path.
+	ReadFile(path string) ([]byte, error)
+	// WriteFile writes b to path with mode.
+	WriteFile(path string, b []byte, mode os.FileMode) error
+	// Exists reports whether path exists.
+	Exists(path string) bool
+	// ReadDir returns the direct children of dir.
+	ReadDir(dir string) ([]iofs.DirEntry, error)
+}
+
+// OSFS implements FS using the local operating system filesystem.
+type OSFS struct{}
+
+// NewOSFS returns an FS backed by the local operating system filesystem.
+func NewOSFS() FS {
+	return OSFS{}
+}
+
+// ReadFile reads file content from path.
+func (OSFS) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// WriteFile writes b to path with mode.
+func (OSFS) WriteFile(path string, b []byte, mode os.FileMode) error {
+	return os.WriteFile(path, b, mode)
+}
+
+// Exists reports whether path exists.
+func (OSFS) Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// ReadDir returns the direct children of dir.
+func (OSFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
+	return os.ReadDir(dir)
+}
+
+// WriteStringIfChanged writes s to path only if the current content differs.
+func WriteStringIfChanged(f FS, path string, s string, mode os.FileMode) (bool, error) {
+	if cur, err := f.ReadFile(path); err == nil {
+		if strings.TrimRight(string(cur), "\n") == strings.TrimRight(s, "\n") {
+			return false, nil
+		}
+	}
+	if err := f.WriteFile(path, []byte(s), mode); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}

--- a/pkg/util/fs/fs_test.go
+++ b/pkg/util/fs/fs_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fs
+
+import (
+	"errors"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeFS struct {
+	files    map[string][]byte
+	readErr  map[string]error
+	writeErr map[string]error
+	writes   []fakeWrite
+}
+
+type fakeWrite struct {
+	path string
+	data string
+	mode os.FileMode
+}
+
+func newFakeFS() *fakeFS {
+	return &fakeFS{
+		files:    map[string][]byte{},
+		readErr:  map[string]error{},
+		writeErr: map[string]error{},
+	}
+}
+
+func (f *fakeFS) ReadFile(path string) ([]byte, error) {
+	if err, ok := f.readErr[path]; ok {
+		return nil, err
+	}
+	b, ok := f.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), b...), nil
+}
+
+func (f *fakeFS) WriteFile(path string, b []byte, mode os.FileMode) error {
+	if err, ok := f.writeErr[path]; ok {
+		return err
+	}
+	f.files[path] = append([]byte(nil), b...)
+	f.writes = append(f.writes, fakeWrite{
+		path: path,
+		data: string(b),
+		mode: mode,
+	})
+	return nil
+}
+
+func (f *fakeFS) Exists(path string) bool {
+	_, ok := f.files[path]
+	return ok
+}
+
+func (f *fakeFS) ReadDir(string) ([]iofs.DirEntry, error) {
+	return nil, errors.New("unsupported")
+}
+
+var _ FS = (*fakeFS)(nil)
+
+func TestWriteStringIfChanged_Table(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		current    string
+		readErr    error
+		writeErr   error
+		want       string
+		wantChange bool
+		wantErr    bool
+		wantWrites int
+	}{
+		{
+			name:       "unchanged after trimming trailing newlines",
+			current:    "hello\n",
+			want:       "hello",
+			wantChange: false,
+			wantWrites: 0,
+		},
+		{
+			name:       "different content writes",
+			current:    "hello\n",
+			want:       "world",
+			wantChange: true,
+			wantWrites: 1,
+		},
+		{
+			name:       "read error still writes",
+			readErr:    os.ErrNotExist,
+			want:       "created",
+			wantChange: true,
+			wantWrites: 1,
+		},
+		{
+			name:       "write error returns context",
+			readErr:    os.ErrNotExist,
+			writeErr:   errors.New("denied"),
+			want:       "created",
+			wantChange: false,
+			wantErr:    true,
+			wantWrites: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const path = "/tmp/value"
+			fsys := newFakeFS()
+			if tt.current != "" {
+				fsys.files[path] = []byte(tt.current)
+			}
+			if tt.readErr != nil {
+				fsys.readErr[path] = tt.readErr
+			}
+			if tt.writeErr != nil {
+				fsys.writeErr[path] = tt.writeErr
+			}
+
+			changed, err := WriteStringIfChanged(fsys, path, tt.want, 0o644)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("WriteStringIfChanged() error = nil, want non-nil")
+				}
+				if !strings.Contains(err.Error(), path) {
+					t.Fatalf("error %q must include path %q", err.Error(), path)
+				}
+			} else if err != nil {
+				t.Fatalf("WriteStringIfChanged() error = %v", err)
+			}
+			if changed != tt.wantChange {
+				t.Fatalf("changed = %v, want %v", changed, tt.wantChange)
+			}
+			if len(fsys.writes) != tt.wantWrites {
+				t.Fatalf("writes = %d, want %d", len(fsys.writes), tt.wantWrites)
+			}
+			if tt.wantWrites > 0 {
+				got := fsys.writes[0]
+				if got.data != tt.want || got.mode != 0o644 {
+					t.Fatalf("write = %+v, want data=%q mode=%#o", got, tt.want, 0o644)
+				}
+			}
+		})
+	}
+}
+
+func TestOSFS_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fsys := NewOSFS()
+	path := filepath.Join(dir, "hello.txt")
+
+	if fsys.Exists(path) {
+		t.Fatalf("Exists(%q) = true, want false", path)
+	}
+	if err := fsys.WriteFile(path, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !fsys.Exists(path) {
+		t.Fatalf("Exists(%q) = false, want true", path)
+	}
+	b, err := fsys.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(b) != "hi" {
+		t.Fatalf("ReadFile = %q, want %q", string(b), "hi")
+	}
+	entries, err := fsys.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "hello.txt" {
+		t.Fatalf("ReadDir = %v, want [hello.txt]", entries)
+	}
+}

--- a/pkg/util/procfs/common/proc_reader.go
+++ b/pkg/util/procfs/common/proc_reader.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	utilfs "github.com/kubewharf/katalyst-core/pkg/util/fs"
+)
+
+// ProcInfo is a coarse snapshot of one PID's classification.
+type ProcInfo struct {
+	PID       int
+	Comm      string
+	IsKThread bool
+	PPID      int
+}
+
+// ProcReader enumerates and classifies processes from a procfs mount.
+type ProcReader interface {
+	// ListPIDs returns the set of numeric PIDs currently present.
+	ListPIDs() ([]int, error)
+	// ReadProc returns a ProcInfo for pid.
+	ReadProc(pid int) (ProcInfo, error)
+	// SchedSetaffinity pins pid to cpus via the sched_setaffinity(2) syscall.
+	SchedSetaffinity(pid int, cpus []int) error
+}
+
+type osProcReader struct {
+	fs       utilfs.FS
+	procRoot string
+}
+
+// NewProcReader returns a ProcReader rooted at procRoot.
+func NewProcReader(fs utilfs.FS, procRoot string) ProcReader {
+	return &osProcReader{fs: fs, procRoot: procRoot}
+}
+
+func (p *osProcReader) ListPIDs() ([]int, error) {
+	entries, err := p.fs.ReadDir(p.procRoot)
+	if err != nil {
+		return nil, fmt.Errorf("readdir %s: %w", p.procRoot, err)
+	}
+
+	out := make([]int, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		out = append(out, pid)
+	}
+	return out, nil
+}
+
+func (p *osProcReader) ReadProc(pid int) (ProcInfo, error) {
+	base := filepath.Join(p.procRoot, strconv.Itoa(pid))
+	comm, err := p.fs.ReadFile(filepath.Join(base, "comm"))
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("read comm: %w", err)
+	}
+	stat, err := p.fs.ReadFile(filepath.Join(base, "stat"))
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("read stat: %w", err)
+	}
+	ppid, err := parsePPIDFromStat(stat)
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("parse stat for pid %d: %w", pid, err)
+	}
+
+	return ProcInfo{
+		PID:       pid,
+		Comm:      strings.TrimSpace(string(comm)),
+		PPID:      ppid,
+		IsKThread: pid == 2 || ppid == 2,
+	}, nil
+}
+
+func (p *osProcReader) SchedSetaffinity(pid int, cpus []int) error {
+	if pid <= 0 {
+		return fmt.Errorf("sched_setaffinity: invalid pid %d", pid)
+	}
+	if len(cpus) == 0 {
+		return fmt.Errorf("sched_setaffinity: refusing to pin pid %d to empty cpuset", pid)
+	}
+	return schedSetaffinity(pid, cpus)
+}
+
+func parsePPIDFromStat(stat []byte) (int, error) {
+	s := string(stat)
+	rp := strings.LastIndexByte(s, ')')
+	if rp < 0 || rp+2 >= len(s) {
+		return 0, fmt.Errorf("invalid stat: missing closing paren or truncated tail")
+	}
+	rest := strings.Fields(s[rp+2:])
+	if len(rest) < 2 {
+		return 0, fmt.Errorf("invalid stat: only %d fields after paren, want >=2", len(rest))
+	}
+	ppid, err := strconv.Atoi(rest[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid stat ppid %q: %w", rest[1], err)
+	}
+	return ppid, nil
+}

--- a/pkg/util/procfs/common/proc_reader_linux.go
+++ b/pkg/util/procfs/common/proc_reader_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func schedSetaffinity(pid int, cpus []int) error {
+	var set unix.CPUSet
+	set.Zero()
+	for _, c := range cpus {
+		if c < 0 || c >= 1024 {
+			return fmt.Errorf("sched_setaffinity: cpu index %d out of range [0,1024)", c)
+		}
+		set.Set(c)
+	}
+	if err := unix.SchedSetaffinity(pid, &set); err != nil {
+		return fmt.Errorf("sched_setaffinity(pid=%d): %w", pid, err)
+	}
+	return nil
+}

--- a/pkg/util/procfs/common/proc_reader_other.go
+++ b/pkg/util/procfs/common/proc_reader_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "fmt"
+
+func schedSetaffinity(pid int, cpus []int) error {
+	return fmt.Errorf("sched_setaffinity is not supported on this platform (pid=%d, cpus=%v)", pid, cpus)
+}

--- a/pkg/util/procfs/common/proc_reader_test.go
+++ b/pkg/util/procfs/common/proc_reader_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"errors"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	utilfs "github.com/kubewharf/katalyst-core/pkg/util/fs"
+)
+
+type procfsFakeFS struct {
+	files   map[string][]byte
+	dirs    map[string][]iofs.DirEntry
+	readErr map[string]error
+}
+
+func newProcfsFakeFS() *procfsFakeFS {
+	return &procfsFakeFS{
+		files:   map[string][]byte{},
+		dirs:    map[string][]iofs.DirEntry{},
+		readErr: map[string]error{},
+	}
+}
+
+func (f *procfsFakeFS) ReadFile(path string) ([]byte, error) {
+	if err, ok := f.readErr[path]; ok {
+		return nil, err
+	}
+	b, ok := f.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), b...), nil
+}
+
+func (f *procfsFakeFS) WriteFile(path string, b []byte, _ os.FileMode) error {
+	f.files[path] = append([]byte(nil), b...)
+	return nil
+}
+
+func (f *procfsFakeFS) Exists(path string) bool {
+	_, ok := f.files[path]
+	return ok
+}
+
+func (f *procfsFakeFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
+	if err, ok := f.readErr[dir]; ok {
+		return nil, err
+	}
+	entries, ok := f.dirs[dir]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return entries, nil
+}
+
+var _ utilfs.FS = (*procfsFakeFS)(nil)
+
+type fakeDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (e fakeDirEntry) Name() string                 { return e.name }
+func (e fakeDirEntry) IsDir() bool                  { return e.dir }
+func (e fakeDirEntry) Type() iofs.FileMode          { return 0 }
+func (e fakeDirEntry) Info() (iofs.FileInfo, error) { return nil, errors.New("unsupported") }
+
+func TestParsePPIDFromStat_Table(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		stat    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "normal init line",
+			stat: "1 (systemd) S 0 1 1 0 -1 4194560 12345",
+			want: 0,
+		},
+		{
+			name: "kthreadd child",
+			stat: "42 (kworker/u8:1) I 2 0 0 0 -1 69238880 0",
+			want: 2,
+		},
+		{
+			name: "comm with spaces and parens",
+			stat: "17 (weird ) name)) S 1 17 17 0 -1 4194304 0",
+			want: 1,
+		},
+		{
+			name:    "missing closing paren",
+			stat:    "17 systemd S 1 17 17",
+			wantErr: true,
+		},
+		{
+			name:    "truncated after paren",
+			stat:    "17 (systemd)",
+			wantErr: true,
+		},
+		{
+			name:    "too few fields",
+			stat:    "17 (systemd) S",
+			wantErr: true,
+		},
+		{
+			name:    "ppid not numeric",
+			stat:    "17 (systemd) S bogus 17 17",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePPIDFromStat([]byte(tt.stat))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parsePPIDFromStat(%q) = (%d,nil), want error", tt.stat, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePPIDFromStat(%q): %v", tt.stat, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parsePPIDFromStat(%q) = %d, want %d", tt.stat, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOSProcReader_ListPIDsFiltersNonNumericDirs(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.dirs["/proc"] = []iofs.DirEntry{
+		fakeDirEntry{name: "1", dir: true},
+		fakeDirEntry{name: "42", dir: true},
+		fakeDirEntry{name: "self", dir: true},
+		fakeDirEntry{name: "sys", dir: true},
+		fakeDirEntry{name: "0", dir: true},
+		fakeDirEntry{name: "kmsg", dir: false},
+	}
+
+	pids, err := NewProcReader(f, "/proc").ListPIDs()
+	if err != nil {
+		t.Fatalf("ListPIDs: %v", err)
+	}
+
+	got := map[int]bool{}
+	for _, pid := range pids {
+		got[pid] = true
+	}
+	if !got[1] || !got[42] {
+		t.Fatalf("ListPIDs must include real pids; got %v", pids)
+	}
+	if len(pids) != 2 {
+		t.Fatalf("ListPIDs must skip non-pid entries; got %v", pids)
+	}
+}
+
+func TestOSProcReader_ListPIDsPropagatesReadDirError(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.readErr["/proc"] = errors.New("permission denied")
+
+	if _, err := NewProcReader(f, "/proc").ListPIDs(); err == nil {
+		t.Fatalf("ListPIDs must propagate ReadDir error")
+	}
+}
+
+func TestOSProcReader_ReadProc_ClassifiesKernelThread(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/42/comm"] = []byte("kworker/u8:1\n")
+	f.files["/proc/42/stat"] = []byte("42 (kworker/u8:1) I 2 0 0 0 -1 69238880 0")
+
+	info, err := NewProcReader(f, "/proc").ReadProc(42)
+	if err != nil {
+		t.Fatalf("ReadProc: %v", err)
+	}
+	if info.PID != 42 || info.PPID != 2 || !info.IsKThread {
+		t.Fatalf("ReadProc = %+v, want PID=42 PPID=2 IsKThread=true", info)
+	}
+	if info.Comm != "kworker/u8:1" {
+		t.Fatalf("Comm = %q, want %q", info.Comm, "kworker/u8:1")
+	}
+}
+
+func TestOSProcReader_ReadProc_ClassifiesKthreaddItself(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/2/comm"] = []byte("kthreadd\n")
+	f.files["/proc/2/stat"] = []byte("2 (kthreadd) S 0 0 0 0 -1 4194560 0")
+
+	info, err := NewProcReader(f, "/proc").ReadProc(2)
+	if err != nil {
+		t.Fatalf("ReadProc: %v", err)
+	}
+	if !info.IsKThread {
+		t.Fatalf("pid 2 must be classified as kthread: %+v", info)
+	}
+}
+
+func TestOSProcReader_ReadProc_ClassifiesUserspace(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/1000/comm"] = []byte("bash\n")
+	f.files["/proc/1000/stat"] = []byte("1000 (bash) S 999 1000 1000 0 -1 4194304 0")
+
+	info, err := NewProcReader(f, "/proc").ReadProc(1000)
+	if err != nil {
+		t.Fatalf("ReadProc: %v", err)
+	}
+	if info.IsKThread {
+		t.Fatalf("userspace PID must not be classified as kthread: %+v", info)
+	}
+	if info.PPID != 999 {
+		t.Fatalf("PPID = %d, want 999", info.PPID)
+	}
+}
+
+func TestOSProcReader_ReadProc_MissingCommOrStat(t *testing.T) {
+	t.Parallel()
+
+	fMissingComm := newProcfsFakeFS()
+	fMissingComm.files["/proc/7/stat"] = []byte("7 (foo) S 1 7 7 0 -1 4194304 0")
+	if _, err := NewProcReader(fMissingComm, "/proc").ReadProc(7); err == nil {
+		t.Fatalf("ReadProc must fail when comm is missing")
+	}
+
+	fMissingStat := newProcfsFakeFS()
+	fMissingStat.files["/proc/7/comm"] = []byte("foo\n")
+	if _, err := NewProcReader(fMissingStat, "/proc").ReadProc(7); err == nil {
+		t.Fatalf("ReadProc must fail when stat is missing")
+	}
+}
+
+func TestOSProcReader_ReadProc_MalformedStat(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/8/comm"] = []byte("x\n")
+	f.files["/proc/8/stat"] = []byte("no-parens-and-not-enough-fields")
+
+	_, err := NewProcReader(f, "/proc").ReadProc(8)
+	if err == nil {
+		t.Fatalf("ReadProc must fail on malformed stat")
+	}
+	if !strings.Contains(err.Error(), "parse stat") {
+		t.Fatalf("ReadProc error must wrap parse-stat context, got: %v", err)
+	}
+}
+
+func TestOSProcReader_SchedSetaffinityDefensiveGuards(t *testing.T) {
+	t.Parallel()
+
+	r := NewProcReader(newProcfsFakeFS(), "/proc")
+	if err := r.SchedSetaffinity(0, []int{1}); err == nil {
+		t.Fatalf("SchedSetaffinity must reject pid<=0")
+	}
+	if err := r.SchedSetaffinity(-5, []int{1}); err == nil {
+		t.Fatalf("SchedSetaffinity must reject negative pid")
+	}
+	if err := r.SchedSetaffinity(1, nil); err == nil {
+		t.Fatalf("SchedSetaffinity must reject empty cpuset")
+	}
+	if err := r.SchedSetaffinity(1, []int{}); err == nil {
+		t.Fatalf("SchedSetaffinity must reject empty cpuset slice")
+	}
+}
+
+func TestOSProcReader_ListPIDsWithTempDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "1"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "kmsg"), []byte{}, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	pids, err := NewProcReader(utilfs.NewOSFS(), dir).ListPIDs()
+	if err != nil {
+		t.Fatalf("ListPIDs: %v", err)
+	}
+	if len(pids) != 1 || pids[0] != 1 {
+		t.Fatalf("ListPIDs = %v, want [1]", pids)
+	}
+}


### PR DESCRIPTION
## Summary

- add reusable filesystem helpers under pkg/util/fs
- add procfs reader utilities under pkg/util/procfs/common
- add a cgroup client with write-if-change caching under pkg/util/cgroup/client
- add generic cgroup unsupported-operation sentinel and sched_load_balance helper

## Tests

- gofumpt -l pkg/util/cgroup/common pkg/util/cgroup/manager pkg/util/fs pkg/util/procfs/common pkg/util/cgroup/client
- go test ./pkg/util/fs/... ./pkg/util/procfs/common/... ./pkg/util/cgroup/client/... ./pkg/util/cgroup/manager/... -count=1
- go vet ./pkg/util/fs/... ./pkg/util/procfs/common/... ./pkg/util/cgroup/client/... ./pkg/util/cgroup/manager/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved cgroup and process management support, including cgroup version detection, CPU set handling, and process CPU affinity operations.

* **Bug Fixes**
  * Reduced redundant cgroup writes by skipping unchanged updates when settings are already in sync.
  * Improved handling of missing or unsupported cgroup features with clearer behavior and safer fallbacks.
  * Tightened validation for invalid inputs, such as empty CPU data and invalid process IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->