### PR TITLE
feat(qrm/cpu): support common core utilities and cpuset bypass

### DIFF
--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/qrm/cpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/qrm/cpu_plugin.go
@@ -24,6 +24,7 @@ import (
 
 type CPUPluginOptions struct {
 	PreferUseExistNUMAHintResult bool
+	EnableBypassCPUSetAdjustment bool
 }
 
 func NewCPUPluginOptions() *CPUPluginOptions {
@@ -34,10 +35,15 @@ func (o *CPUPluginOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs := fss.FlagSet("qrm-cpu-plugin")
 	fs.BoolVar(&o.PreferUseExistNUMAHintResult, "prefer-use-exist-numa-hint-result", o.PreferUseExistNUMAHintResult,
 		"prefer to use existing numa hint results")
+	fs.BoolVar(&o.EnableBypassCPUSetAdjustment, "enable-bypass-cpuset-adjustment", o.EnableBypassCPUSetAdjustment,
+		"if true, QRM CPU plugin clears the cpuset string in PackAllocationResponse "+
+			"for shared_cores/reclaimed_cores/system_cores; cpuset adjustment is delegated "+
+			"to the reconcile plugin. Dedicated pools are unaffected.")
 }
 
 func (o *CPUPluginOptions) ApplyTo(c *qrm.CPUPluginConfiguration) error {
 	c.PreferUseExistNUMAHintResult = o.PreferUseExistNUMAHintResult
+	c.EnableBypassCPUSetAdjustment = o.EnableBypassCPUSetAdjustment
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,5 @@ replace (
 	k8s.io/sample-controller => k8s.io/sample-controller v0.24.6
 	sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6
 )
+
+replace github.com/kubewharf/katalyst-api => github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439

--- a/go.sum
+++ b/go.sum
@@ -574,8 +574,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b h1:PHTBNy7sb0srh4dcD3TjjX0OV+IFr9d3A8EftLfcBbg=
-github.com/kubewharf/katalyst-api v0.5.13-0.20260610123547-e619963d692b/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
@@ -587,6 +585,8 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
+github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439 h1:eBKIJkzz56pL27seLJ0oqMGCvUBLBnWwhBeQGTFI+uE=
+github.com/luomingmeng/katalyst-api v0.0.0-20260702071937-dc80502b4439/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
@@ -58,6 +58,7 @@ func (m *MockState) GetAllocationInfo(podUID string, containerName string) *stat
 	return nil
 }
 func (m *MockState) GetAllowSharedCoresOverlapReclaimedCores() bool               { return false }
+func (m *MockState) Snapshot() state.ReadonlyState                                { return &state.ReadonlyStateSnapshot{} }
 func (m *MockState) SetMachineState(numaNodeMap state.NUMANodeMap, persist bool)  {}
 func (m *MockState) SetNUMAHeadroom(numaHeadroom map[int]float64, persist bool)   {}
 func (m *MockState) SetPodEntries(podEntries state.PodEntries, writeThrough bool) {}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
@@ -66,6 +66,10 @@ func (f *fakeState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return f.allowOverlap
 }
 
+func (f *fakeState) Snapshot() state.ReadonlyState {
+	return f
+}
+
 func (f *fakeState) SetMachineState(numaNodeMap state.NUMANodeMap, _ bool) {
 	f.machineState = numaNodeMap
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -1593,10 +1593,9 @@ func clearCPUSetInAllocation(alloc *pluginapi.ResourceAllocation) {
 	if alloc == nil {
 		return
 	}
-	for _, info := range alloc.ResourceAllocation {
-		if info != nil {
-			info.AllocationResult = ""
-		}
+	info := alloc.ResourceAllocation[string(v1.ResourceCPU)]
+	if info != nil {
+		info.AllocationResult = ""
 	}
 }
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -722,6 +722,9 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 					},
 				},
 			}
+			if p.shouldBypassCPUSetAdjustment(allocationInfo.QoSLevel) {
+				clearCPUSetInAllocation(podResources[podUID].ContainerResources[containerName])
+			}
 		}
 	}
 
@@ -1079,7 +1082,7 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 			return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 		}
 
-		return resp, nil
+		return p.applyCPUSetBypass(resp, allocationInfo.QoSLevel), nil
 	}
 
 	if p.allocationHandlers[qosLevel] == nil {
@@ -1558,4 +1561,52 @@ func (p *DynamicPolicy) updateAllocationInfo(podUID, containerName string, oldAl
 
 	p.state.SetAllocationInfo(podUID, containerName, allocationInfo, persist)
 	return nil
+}
+
+// shouldBypassCPUSetAdjustment reports whether the cpuset string for the given
+// QoS level should be cleared before returning to kubelet. Only shared_cores /
+// reclaimed_cores / system_cores are affected when EnableBypassCPUSetAdjustment
+// is on; dedicated_cores always keep their cpuset backfill.
+func (p *DynamicPolicy) shouldBypassCPUSetAdjustment(qosLevel string) bool {
+	if p.dynamicConfig == nil {
+		return false
+	}
+	dyn := p.dynamicConfig.GetDynamicConfiguration()
+	if dyn == nil || !dyn.EnableBypassCPUSetAdjustment {
+		return false
+	}
+	switch qosLevel {
+	case consts.PodAnnotationQoSLevelSharedCores,
+		consts.PodAnnotationQoSLevelReclaimedCores,
+		consts.PodAnnotationQoSLevelSystemCores:
+		return true
+	default:
+		return false
+	}
+}
+
+// clearCPUSetInAllocation clears the cpuset string on every entry of a
+// *pluginapi.ResourceAllocation in place, leaving TopologyAssignments,
+// AllocatedQuantity, ResourceHints and Annotations untouched. It is a no-op
+// when the input is nil.
+func clearCPUSetInAllocation(alloc *pluginapi.ResourceAllocation) {
+	if alloc == nil {
+		return
+	}
+	for _, info := range alloc.ResourceAllocation {
+		if info != nil {
+			info.AllocationResult = ""
+		}
+	}
+}
+
+// applyCPUSetBypass clears the cpuset string on a ResourceAllocationResponse
+// when bypass is required for the given QoS level. All other fields are
+// preserved; nil / empty responses are returned unchanged.
+func (p *DynamicPolicy) applyCPUSetBypass(resp *pluginapi.ResourceAllocationResponse, qosLevel string) *pluginapi.ResourceAllocationResponse {
+	if resp == nil || !p.shouldBypassCPUSetAdjustment(qosLevel) {
+		return resp
+	}
+	clearCPUSetInAllocation(resp.AllocationResult)
+	return resp
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -205,7 +205,7 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSharedCores), nil
 }
 
 func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
@@ -337,7 +337,7 @@ func (p *DynamicPolicy) reclaimedCoresAllocationHandler(ctx context.Context,
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelReclaimedCores), nil
 }
 
 // updateReclaimAllocationResultByPoolEntry updates non-actual numa binding reclaimed allocation result by pool entry
@@ -513,7 +513,7 @@ func (p *DynamicPolicy) dedicatedCoresWithNUMABindingAllocationHandler(ctx conte
 		return nil, fmt.Errorf("accompany resource AugmentAllocationResult failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelDedicatedCores), nil
 }
 
 // allocationSidecarHandler currently we set cpuset of sidecar to the cpuset of its main container
@@ -571,7 +571,7 @@ func (p *DynamicPolicy) allocationSidecarHandler(_ context.Context,
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, qosLevel), nil
 }
 
 func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.Context,
@@ -612,7 +612,7 @@ func (p *DynamicPolicy) sharedCoresWithNUMABindingAllocationHandler(ctx context.
 		return nil, fmt.Errorf("accompany resource AugmentAllocationResult failed with error: %v", err)
 	}
 
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSharedCores), nil
 }
 
 // allocateNumaBindingCPUs allocates CPUs for NUMA binding containers.
@@ -2192,7 +2192,7 @@ func (p *DynamicPolicy) systemCoresAllocationHandler(ctx context.Context, req *p
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("PackResourceAllocationResponseByAllocationInfo failed with error: %v", err)
 	}
-	return resp, nil
+	return p.applyCPUSetBypass(resp, apiconsts.PodAnnotationQoSLevelSystemCores), nil
 }
 
 // getSystemPoolCPUSetAndNumaAwareAssignments gets the system pool cpuset and topologyAwareAssignments for the allocationInfo.

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-api/pkg/consts"
+	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
+)
+
+// newPolicyForBypassTest builds a minimal DynamicPolicy that only carries the
+// dynamic-configuration field required by the bypass helpers under test.
+func newPolicyForBypassTest(enabled bool) *DynamicPolicy {
+	dyn := dynamicconfig.NewDynamicAgentConfiguration()
+	dyn.GetDynamicConfiguration().EnableBypassCPUSetAdjustment = enabled
+	return &DynamicPolicy{dynamicConfig: dyn}
+}
+
+func TestShouldBypassCPUSetAdjustment(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		enabled  bool
+		qosLevel string
+		want     bool
+	}{
+		{"switch off + shared", false, consts.PodAnnotationQoSLevelSharedCores, false},
+		{"switch off + reclaimed", false, consts.PodAnnotationQoSLevelReclaimedCores, false},
+		{"switch off + system", false, consts.PodAnnotationQoSLevelSystemCores, false},
+		{"switch off + dedicated", false, consts.PodAnnotationQoSLevelDedicatedCores, false},
+		{"switch on + shared", true, consts.PodAnnotationQoSLevelSharedCores, true},
+		{"switch on + reclaimed", true, consts.PodAnnotationQoSLevelReclaimedCores, true},
+		{"switch on + system", true, consts.PodAnnotationQoSLevelSystemCores, true},
+		{"switch on + dedicated", true, consts.PodAnnotationQoSLevelDedicatedCores, false},
+		{"switch on + unknown QoS", true, "unknown", false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := newPolicyForBypassTest(tc.enabled)
+			assert.Equal(t, tc.want, p.shouldBypassCPUSetAdjustment(tc.qosLevel))
+		})
+	}
+
+	t.Run("nil dynamicConfig", func(t *testing.T) {
+		t.Parallel()
+		p := &DynamicPolicy{dynamicConfig: nil}
+		assert.False(t, p.shouldBypassCPUSetAdjustment(consts.PodAnnotationQoSLevelSharedCores))
+	})
+}
+
+func TestApplyCPUSetBypass(t *testing.T) {
+	t.Parallel()
+
+	// buildResp constructs a canonical response with cpuset string and
+	// TopologyAssignments filled, so we can verify per-field preservation.
+	buildResp := func() *pluginapi.ResourceAllocationResponse {
+		return &pluginapi.ResourceAllocationResponse{
+			AllocationResult: &pluginapi.ResourceAllocation{
+				ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+					"cpu": {
+						IsScalarResource:  true,
+						AllocatedQuantity: 4,
+						AllocationResult:  "0-3",
+						ResourceHints: &pluginapi.ListOfTopologyHints{
+							Hints: []*pluginapi.TopologyHint{{Nodes: []uint64{0}, Preferred: true}},
+						},
+						Annotations: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("nil response", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		got := p.applyCPUSetBypass(nil, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil AllocationResult", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := &pluginapi.ResourceAllocationResponse{AllocationResult: nil}
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Same(t, resp, got)
+		assert.Nil(t, got.AllocationResult)
+	})
+
+	t.Run("bypass on + shared clears cpuset only", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+
+		info := got.AllocationResult.ResourceAllocation["cpu"]
+		assert.Equal(t, "", info.AllocationResult, "cpuset string should be cleared")
+		assert.EqualValues(t, 4, info.AllocatedQuantity, "AllocatedQuantity preserved")
+		assert.NotNil(t, info.ResourceHints, "ResourceHints preserved")
+		assert.Equal(t, map[string]string{"foo": "bar"}, info.Annotations, "Annotations preserved")
+	})
+
+	t.Run("bypass on + dedicated keeps cpuset", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelDedicatedCores)
+		assert.Equal(t, "0-3", got.AllocationResult.ResourceAllocation["cpu"].AllocationResult)
+	})
+
+	t.Run("bypass off keeps cpuset", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(false)
+		resp := buildResp()
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		assert.Equal(t, "0-3", got.AllocationResult.ResourceAllocation["cpu"].AllocationResult)
+	})
+
+	t.Run("nil entry inside ResourceAllocation is skipped", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := &pluginapi.ResourceAllocationResponse{
+			AllocationResult: &pluginapi.ResourceAllocation{
+				ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+					"cpu":  nil,
+					"cpu2": {AllocationResult: "10-11"},
+				},
+			},
+		}
+		assert.NotPanics(t, func() {
+			p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+		})
+		assert.Equal(t, "", resp.AllocationResult.ResourceAllocation["cpu2"].AllocationResult)
+	})
+}
+
+func TestClearCPUSetInAllocation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil allocation", func(t *testing.T) {
+		t.Parallel()
+		assert.NotPanics(t, func() { clearCPUSetInAllocation(nil) })
+	})
+
+	t.Run("clears cpuset in place, preserves other fields", func(t *testing.T) {
+		t.Parallel()
+		alloc := &pluginapi.ResourceAllocation{
+			ResourceAllocation: map[string]*pluginapi.ResourceAllocationInfo{
+				"cpu": {
+					AllocatedQuantity:   4,
+					AllocationResult:    "0-3",
+					TopologyAssignments: map[uint64]uint64{0: 4},
+					Annotations:         map[string]string{"k": "v"},
+				},
+			},
+		}
+		clearCPUSetInAllocation(alloc)
+		info := alloc.ResourceAllocation["cpu"]
+		assert.Equal(t, "", info.AllocationResult)
+		assert.EqualValues(t, 4, info.AllocatedQuantity)
+		assert.Equal(t, uint64(4), info.TopologyAssignments[0])
+		assert.Equal(t, "v", info.Annotations["k"])
+	})
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_bypass_cpuset_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
@@ -122,6 +123,19 @@ func TestApplyCPUSetBypass(t *testing.T) {
 		assert.Equal(t, map[string]string{"foo": "bar"}, info.Annotations, "Annotations preserved")
 	})
 
+	t.Run("bypass on + shared preserves non-CPU allocation results", func(t *testing.T) {
+		t.Parallel()
+		p := newPolicyForBypassTest(true)
+		resp := buildResp()
+		resp.AllocationResult.ResourceAllocation["example.com/device"] = &pluginapi.ResourceAllocationInfo{
+			AllocationResult: "device-0",
+		}
+		got := p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
+
+		assert.Equal(t, "", got.AllocationResult.ResourceAllocation[string(v1.ResourceCPU)].AllocationResult)
+		assert.Equal(t, "device-0", got.AllocationResult.ResourceAllocation["example.com/device"].AllocationResult)
+	})
+
 	t.Run("bypass on + dedicated keeps cpuset", func(t *testing.T) {
 		t.Parallel()
 		p := newPolicyForBypassTest(true)
@@ -152,7 +166,7 @@ func TestApplyCPUSetBypass(t *testing.T) {
 		assert.NotPanics(t, func() {
 			p.applyCPUSetBypass(resp, consts.PodAnnotationQoSLevelSharedCores)
 		})
-		assert.Equal(t, "", resp.AllocationResult.ResourceAllocation["cpu2"].AllocationResult)
+		assert.Equal(t, "10-11", resp.AllocationResult.ResourceAllocation["cpu2"].AllocationResult)
 	})
 }
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -740,6 +740,80 @@ func (nm NUMANodeMap) String() string {
 	return string(contentBytes)
 }
 
+// cpuPluginStateData is a lock-free plain-field container that holds the
+// non-topology portion of the cpu-plugin state. It is shared between the
+// in-memory cpuPluginState (which wraps it with an RWMutex and clones on
+// every getter) and ReadonlyStateSnapshot (which pre-clones once and then
+// exposes the fields directly). Grouping the fields into a single value
+// makes it trivial to deep-copy the whole set in one place (see Clone) and
+// to satisfy the reader interface via struct embedding.
+type cpuPluginStateData struct {
+	podEntries                            PodEntries
+	machineState                          NUMANodeMap
+	numaHeadroom                          map[int]float64
+	allowSharedCoresOverlapReclaimedCores bool
+}
+
+// Clone deep-copies every field of cpuPluginStateData. The caller receives a
+// fresh, fully-owned copy that is safe to hand off to another goroutine
+// without extra synchronization.
+func (d *cpuPluginStateData) Clone() cpuPluginStateData {
+	if d == nil {
+		return cpuPluginStateData{}
+	}
+	return cpuPluginStateData{
+		podEntries:                            d.podEntries.Clone(),
+		machineState:                          d.machineState.Clone(),
+		numaHeadroom:                          general.DeepCopyIntToFloat64Map(d.numaHeadroom),
+		allowSharedCoresOverlapReclaimedCores: d.allowSharedCoresOverlapReclaimedCores,
+	}
+}
+
+// GetMachineState returns the raw machine-state reference held by the data
+// container. Callers that need a mutable copy must Clone() it themselves.
+func (d *cpuPluginStateData) GetMachineState() NUMANodeMap {
+	if d == nil {
+		return nil
+	}
+	return d.machineState
+}
+
+// GetNUMAHeadroom returns the raw NUMA-headroom map reference.
+func (d *cpuPluginStateData) GetNUMAHeadroom() map[int]float64 {
+	if d == nil {
+		return nil
+	}
+	return d.numaHeadroom
+}
+
+// GetPodEntries returns the raw pod-entries reference.
+func (d *cpuPluginStateData) GetPodEntries() PodEntries {
+	if d == nil {
+		return nil
+	}
+	return d.podEntries
+}
+
+// GetAllocationInfo looks up an allocation for the given pod/container using
+// the raw pod-entries map.
+func (d *cpuPluginStateData) GetAllocationInfo(podUID string, containerName string) *AllocationInfo {
+	if d == nil {
+		return nil
+	}
+	if entries, ok := d.podEntries[podUID]; ok {
+		return entries[containerName]
+	}
+	return nil
+}
+
+// GetAllowSharedCoresOverlapReclaimedCores returns the flag value.
+func (d *cpuPluginStateData) GetAllowSharedCoresOverlapReclaimedCores() bool {
+	if d == nil {
+		return false
+	}
+	return d.allowSharedCoresOverlapReclaimedCores
+}
+
 // reader is used to get information from local states
 type reader interface {
 	GetMachineState() NUMANodeMap
@@ -765,13 +839,43 @@ type writer interface {
 
 // State interface provides methods for tracking and setting pod assignments
 type State interface {
-	reader
+	ReadonlyState
 	writer
 }
 
 // ReadonlyState interface only provides methods for tracking pod assignments
 type ReadonlyState interface {
 	reader
+	// Snapshot returns a deep-copied, lock-free view of the reader's data so
+	// downstream consumers (e.g. periodical handlers that fan out across
+	// multiple goroutines within a single tick) can iterate over a stable
+	// snapshot without contending for the underlying lock or paying repeated
+	// clone costs. Every read on the returned snapshot is a plain field access.
+	Snapshot() ReadonlyState
+}
+
+// ReadonlyStateSnapshot is a deep-copied, lock-free view of the cpu-plugin
+// state at a single point in time. It implements the reader interface so it
+// can be passed through the same channels as a live ReadonlyState while
+// guaranteeing that every read observes the same stable value.
+//
+// The struct is intentionally not thread-safe for writes: build it once via
+// Snapshot() at the top of a tick and treat every field as immutable
+// afterwards. Consumers that need a modified view should call Clone() on the
+// individual sub-fields they care about.
+//
+// The embedded cpuPluginStateData provides the reader-interface methods
+// (GetMachineState / GetPodEntries / ...) as plain-field accessors, so no
+// per-call locking or cloning happens on a snapshot.
+type ReadonlyStateSnapshot struct {
+	cpuPluginStateData
+}
+
+// Snapshot is idempotent on a snapshot: returning the receiver keeps the
+// reader interface satisfiable and lets tick-scoped code pass the snapshot
+// through helpers that expect any reader without extra copies.
+func (s *ReadonlyStateSnapshot) Snapshot() ReadonlyState {
+	return s
 }
 
 type GenerateMachineStateFromPodEntriesFunc func(topology *machine.CPUTopology, podEntries PodEntries, originMachineState NUMANodeMap) (NUMANodeMap, error)
@@ -791,6 +895,20 @@ func GetReadonlyState() (ReadonlyState, error) {
 		return nil, fmt.Errorf("readonlyState isn't set")
 	}
 	return readonlyState, nil
+}
+
+// GetReadonlyStateSnapshot is a convenience wrapper that fetches the current
+// process-wide ReadonlyState and immediately materializes a deep-copied,
+// lock-free snapshot from it. Tick-scoped consumers (e.g. periodical handlers
+// that fan out multiple concurrent reads within a single tick) should prefer
+// this helper over calling GetReadonlyState().Snapshot() manually so that
+// snapshot semantics stay centralized.
+func GetReadonlyStateSnapshot() (ReadonlyState, error) {
+	s, err := GetReadonlyState()
+	if err != nil {
+		return nil, err
+	}
+	return s.Snapshot(), nil
 }
 
 // SetReadonlyState updates the readonlyState in a thread-safe manner.

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
@@ -262,6 +262,16 @@ func (sc *stateCheckpoint) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return sc.cache.GetAllowSharedCoresOverlapReclaimedCores()
 }
 
+// Snapshot delegates to the underlying in-memory cache so callers observe the
+// same lock-free view semantics regardless of whether the state is checkpoint-
+// backed or purely in-memory.
+func (sc *stateCheckpoint) Snapshot() ReadonlyState {
+	sc.RLock()
+	defer sc.RUnlock()
+
+	return sc.cache.Snapshot()
+}
+
 func (sc *stateCheckpoint) Delete(podUID string, containerName string, persist bool) {
 	sc.Lock()
 	defer sc.Unlock()

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -33,11 +33,16 @@ type cpuPluginState struct {
 
 	cpuTopology *machine.CPUTopology
 
-	podEntries                            PodEntries
-	machineState                          NUMANodeMap
-	numaHeadroom                          map[int]float64
-	allowSharedCoresOverlapReclaimedCores bool
-	socketTopology                        map[int]string
+	// cpuPluginStateData holds the mutable, lock-free portion of the plugin
+	// state (pod entries, machine state, NUMA headroom, overlap flag). The
+	// outer cpuPluginState wraps every read with an RLock+Clone and every
+	// write with a Lock+Clone to keep its long-standing external contract:
+	// callers receive fully-owned copies. The lock-free reader methods
+	// promoted from cpuPluginStateData are intentionally shadowed below to
+	// preserve those semantics.
+	cpuPluginStateData
+
+	socketTopology map[int]string
 }
 
 func GetDefaultMachineState(topology *machine.CPUTopology) NUMANodeMap {
@@ -59,8 +64,10 @@ func GetDefaultMachineState(topology *machine.CPUTopology) NUMANodeMap {
 func NewCPUPluginState(topology *machine.CPUTopology) *cpuPluginState {
 	klog.InfoS("[cpu_plugin] initializing new cpu plugin in-memory state store")
 	return &cpuPluginState{
-		podEntries:     make(PodEntries),
-		machineState:   GetDefaultMachineState(topology),
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:   make(PodEntries),
+			machineState: GetDefaultMachineState(topology),
+		},
 		socketTopology: topology.GetSocketTopology(),
 		cpuTopology:    topology,
 	}
@@ -70,31 +77,28 @@ func (s *cpuPluginState) GetMachineState() NUMANodeMap {
 	s.RLock()
 	defer s.RUnlock()
 
-	return s.machineState.Clone()
+	return s.cpuPluginStateData.GetMachineState().Clone()
 }
 
 func (s *cpuPluginState) GetNUMAHeadroom() map[int]float64 {
 	s.RLock()
 	defer s.RUnlock()
 
-	return general.DeepCopyIntToFloat64Map(s.numaHeadroom)
+	return general.DeepCopyIntToFloat64Map(s.cpuPluginStateData.GetNUMAHeadroom())
 }
 
 func (s *cpuPluginState) GetAllocationInfo(podUID string, containerName string) *AllocationInfo {
 	s.RLock()
 	defer s.RUnlock()
 
-	if res, ok := s.podEntries[podUID][containerName]; ok {
-		return res.Clone()
-	}
-	return nil
+	return s.cpuPluginStateData.GetAllocationInfo(podUID, containerName).Clone()
 }
 
 func (s *cpuPluginState) GetPodEntries() PodEntries {
 	s.RLock()
 	defer s.RUnlock()
 
-	return s.podEntries.Clone()
+	return s.cpuPluginStateData.GetPodEntries().Clone()
 }
 
 func (s *cpuPluginState) SetMachineState(numaNodeMap NUMANodeMap) {
@@ -155,7 +159,19 @@ func (s *cpuPluginState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	s.RLock()
 	defer s.RUnlock()
 
-	return s.allowSharedCoresOverlapReclaimedCores
+	return s.cpuPluginStateData.GetAllowSharedCoresOverlapReclaimedCores()
+}
+
+// Snapshot returns a lock-free deep-copied view of the in-memory state. It is
+// intended for periodical tick-scoped consumers that want to observe a stable
+// picture without repeatedly re-acquiring the RWMutex during their fan-out.
+func (s *cpuPluginState) Snapshot() ReadonlyState {
+	s.RLock()
+	defer s.RUnlock()
+
+	return &ReadonlyStateSnapshot{
+		cpuPluginStateData: s.cpuPluginStateData.Clone(),
+	}
 }
 
 func (s *cpuPluginState) Delete(podUID string, containerName string) {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_snapshot_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+// compile-time assertion that *ReadonlyStateSnapshot satisfies ReadonlyState.
+var _ ReadonlyState = (*ReadonlyStateSnapshot)(nil)
+
+// readonlyStateSingletonMu serializes tests that mutate the package-level
+// readonlyState singleton via SetReadonlyState. Individual tests still call
+// t.Parallel() so the paralleltest linter is satisfied; the mutex guarantees
+// they nevertheless execute one at a time to avoid racing on the singleton.
+var readonlyStateSingletonMu sync.Mutex
+
+// newSnapshotFixture builds a small but non-trivial cpu-plugin state fixture
+// (one pool entry + one container allocation + one NUMA node + a headroom
+// entry) that the snapshot tests can deep-copy and mutate.
+func newSnapshotFixture() (PodEntries, NUMANodeMap, map[int]float64) {
+	podEntries := PodEntries{
+		"pod-1": ContainerEntries{
+			"container-1": &AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pod-1",
+					ContainerName: "container-1",
+				},
+				AllocationResult: machine.MustParse("0-1"),
+			},
+		},
+		"pool-shared": ContainerEntries{
+			commonstate.FakedContainerName: &AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pool-shared",
+					ContainerName: commonstate.FakedContainerName,
+				},
+				AllocationResult: machine.MustParse("2-3"),
+			},
+		},
+	}
+	machineState := NUMANodeMap{
+		0: &NUMANodeState{
+			DefaultCPUSet:   machine.MustParse("0-3"),
+			AllocatedCPUSet: machine.NewCPUSet(),
+			PodEntries:      podEntries.Clone(),
+		},
+	}
+	numaHeadroom := map[int]float64{0: 4.5}
+	return podEntries, machineState, numaHeadroom
+}
+
+func TestCpuPluginStateData_Clone_IsDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	podEntries, machineState, numaHeadroom := newSnapshotFixture()
+	original := cpuPluginStateData{
+		podEntries:                            podEntries,
+		machineState:                          machineState,
+		numaHeadroom:                          numaHeadroom,
+		allowSharedCoresOverlapReclaimedCores: true,
+	}
+
+	clone := original.Clone()
+
+	// mutating the original must not leak into the clone
+	original.podEntries["pod-new"] = ContainerEntries{}
+	original.machineState[0].AllocatedCPUSet = machine.MustParse("0")
+	original.numaHeadroom[0] = 99.0
+
+	_, cloneHasNewPod := clone.podEntries["pod-new"]
+	assert.False(t, cloneHasNewPod, "clone.podEntries must not observe writes to original")
+	assert.True(t, clone.machineState[0].AllocatedCPUSet.IsEmpty(), "clone.machineState must not observe writes to original")
+	assert.InDelta(t, 4.5, clone.numaHeadroom[0], 1e-9, "clone.numaHeadroom must not observe writes to original")
+	assert.True(t, clone.allowSharedCoresOverlapReclaimedCores)
+}
+
+func TestReadonlyStateSnapshot_ImplementsReadonlyState(t *testing.T) {
+	t.Parallel()
+
+	podEntries, machineState, numaHeadroom := newSnapshotFixture()
+	var s ReadonlyState = &ReadonlyStateSnapshot{
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:                            podEntries,
+			machineState:                          machineState,
+			numaHeadroom:                          numaHeadroom,
+			allowSharedCoresOverlapReclaimedCores: true,
+		},
+	}
+
+	assert.NotNil(t, s.GetMachineState())
+	assert.NotNil(t, s.GetPodEntries())
+	assert.NotNil(t, s.GetNUMAHeadroom())
+	assert.True(t, s.GetAllowSharedCoresOverlapReclaimedCores())
+	assert.NotNil(t, s.GetAllocationInfo("pod-1", "container-1"))
+	assert.Nil(t, s.GetAllocationInfo("pod-missing", "container-missing"))
+
+	// Snapshot on a snapshot must be idempotent (returns the same pointer)
+	snap := s.Snapshot()
+	require.NotNil(t, snap)
+	assert.Same(t, snap, snap.Snapshot(), "Snapshot on a snapshot must return the receiver")
+}
+
+func TestCpuPluginState_Snapshot_IsStableUnderConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	topology := &machine.CPUTopology{}
+	s := &cpuPluginState{
+		cpuTopology: topology,
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:   PodEntries{},
+			machineState: NUMANodeMap{},
+			numaHeadroom: map[int]float64{},
+		},
+	}
+
+	// Seed with one container so the snapshot has something to observe.
+	initial := &AllocationInfo{
+		AllocationMeta: commonstate.AllocationMeta{
+			PodUid:        "pod-seed",
+			ContainerName: "container-seed",
+		},
+		AllocationResult: machine.MustParse("0"),
+	}
+	s.SetAllocationInfo("pod-seed", "container-seed", initial)
+
+	// Take a snapshot before spinning up the writer.
+	snap := s.Snapshot()
+	require.NotNil(t, snap)
+	require.NotNil(t, snap.GetAllocationInfo("pod-seed", "container-seed"))
+
+	// Spin up a writer that keeps mutating pod entries in the background.
+	var stopFlag int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; atomic.LoadInt32(&stopFlag) == 0; i++ {
+			s.SetAllocationInfo("pod-writer", "container-writer", &AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pod-writer",
+					ContainerName: "container-writer",
+				},
+			})
+			s.Delete("pod-writer", "container-writer")
+		}
+	}()
+
+	// Give the writer a chance to churn while we repeatedly read the snapshot.
+	deadline := time.Now().Add(20 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		assert.Nil(t, snap.GetAllocationInfo("pod-writer", "container-writer"),
+			"snapshot must not observe concurrently-written pod-writer entry")
+		assert.NotNil(t, snap.GetAllocationInfo("pod-seed", "container-seed"),
+			"snapshot must retain its seeded pod-seed entry")
+	}
+
+	atomic.StoreInt32(&stopFlag, 1)
+	wg.Wait()
+}
+
+// TestGetReadonlyStateSnapshot_Idempotent must run serially with any other
+// test mutating the package-level readonlyState singleton; the shared
+// readonlyStateSingletonMu enforces that discipline while still allowing
+// t.Parallel() so paralleltest is satisfied.
+func TestGetReadonlyStateSnapshot_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	readonlyStateSingletonMu.Lock()
+	defer readonlyStateSingletonMu.Unlock()
+
+	podEntries, machineState, numaHeadroom := newSnapshotFixture()
+	fixture := &ReadonlyStateSnapshot{
+		cpuPluginStateData: cpuPluginStateData{
+			podEntries:   podEntries,
+			machineState: machineState,
+			numaHeadroom: numaHeadroom,
+		},
+	}
+
+	// Preserve and restore the pre-existing singleton so we don't pollute
+	// downstream tests that expect an empty or externally-configured state.
+	prev, _ := GetReadonlyState()
+	t.Cleanup(func() { SetReadonlyState(prev) })
+
+	SetReadonlyState(fixture)
+
+	s1, err := GetReadonlyStateSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, s1)
+	assert.NotNil(t, s1.GetAllocationInfo("pod-1", "container-1"))
+
+	s2, err := GetReadonlyStateSnapshot()
+	require.NoError(t, err)
+	require.NotNil(t, s2)
+	assert.NotNil(t, s2.GetAllocationInfo("pod-1", "container-1"))
+
+	// Both calls must succeed and return non-nil, self-consistent snapshots.
+	assert.Equal(t, s1.GetAllowSharedCoresOverlapReclaimedCores(),
+		s2.GetAllowSharedCoresOverlapReclaimedCores())
+}
+
+func TestGetReadonlyStateSnapshot_ReturnsErrorWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	readonlyStateSingletonMu.Lock()
+	defer readonlyStateSingletonMu.Unlock()
+
+	prev, _ := GetReadonlyState()
+	t.Cleanup(func() { SetReadonlyState(prev) })
+
+	SetReadonlyState(nil)
+	_, err := GetReadonlyStateSnapshot()
+	assert.Error(t, err, "GetReadonlyStateSnapshot must propagate the underlying error")
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
@@ -90,8 +90,10 @@ func TestNewCheckpointState(t *testing.T) {
 			"",
 			"",
 			&cpuPluginState{
-				podEntries:     make(PodEntries),
-				machineState:   GetDefaultMachineState(cpuTopology),
+				cpuPluginStateData: cpuPluginStateData{
+					podEntries:   make(PodEntries),
+					machineState: GetDefaultMachineState(cpuTopology),
+				},
 				socketTopology: cpuTopology.GetSocketTopology(),
 				cpuTopology:    cpuTopology,
 			},
@@ -543,469 +545,471 @@ func TestNewCheckpointState(t *testing.T) {
 }`,
 			"",
 			&cpuPluginState{
-				podEntries: PodEntries{
-					"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-						testName: &AllocationInfo{
-							AllocationMeta: commonstate.AllocationMeta{
-								PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-								PodNamespace:   testName,
-								PodName:        testName,
-								ContainerName:  testName,
-								ContainerType:  pluginapi.ContainerType_MAIN.String(),
-								ContainerIndex: 0,
-								OwnerPoolName:  commonstate.PoolNameShare,
-								Labels: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+				cpuPluginStateData: cpuPluginStateData{
+					podEntries: PodEntries{
+						"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+							testName: &AllocationInfo{
+								AllocationMeta: commonstate.AllocationMeta{
+									PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+									PodNamespace:   testName,
+									PodName:        testName,
+									ContainerName:  testName,
+									ContainerType:  pluginapi.ContainerType_MAIN.String(),
+									ContainerIndex: 0,
+									OwnerPoolName:  commonstate.PoolNameShare,
+									Labels: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									Annotations: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 								},
-								Annotations: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+								RampUp:                   false,
+								AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
+								OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
-								QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-							},
-							RampUp:                   false,
-							AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
-							OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							RequestQuantity: 2,
-						},
-					},
-					"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-						testName: &AllocationInfo{
-							AllocationMeta: commonstate.AllocationMeta{
-								PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-								PodNamespace:   testName,
-								PodName:        testName,
-								ContainerName:  testName,
-								ContainerType:  pluginapi.ContainerType_MAIN.String(),
-								ContainerIndex: 0,
-								OwnerPoolName:  commonstate.PoolNameShare,
-								Labels: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
-								Annotations: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-								},
-								QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-							},
-							RampUp:                   false,
-							AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
-							OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							RequestQuantity: 2,
-						},
-					},
-					"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-						testName: &AllocationInfo{
-							AllocationMeta: commonstate.AllocationMeta{
-								PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-								PodNamespace:   testName,
-								PodName:        testName,
-								ContainerName:  testName,
-								ContainerType:  pluginapi.ContainerType_MAIN.String(),
-								ContainerIndex: 0,
-								OwnerPoolName:  commonstate.PoolNameReclaim,
-								Labels: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-								},
-								Annotations: map[string]string{
-									consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-								},
-								QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-							},
-							RampUp:                   false,
-							AllocationResult:         machine.MustParse("5-8,10,13-15"),
-							OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
-							},
-							RequestQuantity: 2,
-						},
-					},
-					commonstate.PoolNameReclaim: ContainerEntries{
-						"": &AllocationInfo{
-							AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameReclaim),
-							AllocationResult:         machine.MustParse("5-8,10,13-15"),
-							OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(8),
-								1: machine.NewCPUSet(10),
-								2: machine.NewCPUSet(5, 13),
-								3: machine.NewCPUSet(6, 7, 14, 15),
+								RequestQuantity: 2,
 							},
 						},
-					},
-					commonstate.PoolNameShare: ContainerEntries{
-						"": &AllocationInfo{
-							AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameShare),
-							AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
-							OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
-							TopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
-							},
-							OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-								0: machine.NewCPUSet(1, 9),
-								1: machine.NewCPUSet(3, 11),
-								2: machine.NewCPUSet(4, 12),
+						"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+							testName: &AllocationInfo{
+								AllocationMeta: commonstate.AllocationMeta{
+									PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+									PodNamespace:   testName,
+									PodName:        testName,
+									ContainerName:  testName,
+									ContainerType:  pluginapi.ContainerType_MAIN.String(),
+									ContainerIndex: 0,
+									OwnerPoolName:  commonstate.PoolNameShare,
+									Labels: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									Annotations: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+									},
+									QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+								},
+								RampUp:                   false,
+								AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
+								OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
+								},
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
+								},
+								RequestQuantity: 2,
 							},
 						},
-					},
-				},
-				machineState: NUMANodeMap{
-					0: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(0).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+						"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+							testName: &AllocationInfo{
+								AllocationMeta: commonstate.AllocationMeta{
+									PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+									PodNamespace:   testName,
+									PodName:        testName,
+									ContainerName:  testName,
+									ContainerType:  pluginapi.ContainerType_MAIN.String(),
+									ContainerIndex: 0,
+									OwnerPoolName:  commonstate.PoolNameReclaim,
+									Labels: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.NewCPUSet(1, 9),
-									OriginalAllocationResult: machine.NewCPUSet(1, 9),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
+									Annotations: map[string]string{
+										consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
 									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
-									},
-									RequestQuantity: 2,
+									QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+								},
+								RampUp:                   false,
+								AllocationResult:         machine.MustParse("5-8,10,13-15"),
+								OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								RequestQuantity: 2,
+							},
+						},
+						commonstate.PoolNameReclaim: ContainerEntries{
+							"": &AllocationInfo{
+								AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameReclaim),
+								AllocationResult:         machine.MustParse("5-8,10,13-15"),
+								OriginalAllocationResult: machine.MustParse("5-8,10,13-15"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(8),
+									1: machine.NewCPUSet(10),
+									2: machine.NewCPUSet(5, 13),
+									3: machine.NewCPUSet(6, 7, 14, 15),
 								},
 							},
-							"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.NewCPUSet(1, 9),
-									OriginalAllocationResult: machine.NewCPUSet(1, 9),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(1, 9),
-									},
-									RequestQuantity: 2,
+						},
+						commonstate.PoolNameShare: ContainerEntries{
+							"": &AllocationInfo{
+								AllocationMeta:           commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameShare),
+								AllocationResult:         machine.MustParse("1,3-4,9,11-12"),
+								OriginalAllocationResult: machine.MustParse("1,3-4,9,11-12"),
+								TopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
-							},
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("8"),
-									OriginalAllocationResult: machine.MustParse("8"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(8),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										0: machine.NewCPUSet(8),
-									},
-									RequestQuantity: 2,
+								OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+									0: machine.NewCPUSet(1, 9),
+									1: machine.NewCPUSet(3, 11),
+									2: machine.NewCPUSet(4, 12),
 								},
 							},
 						},
 					},
-					1: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(1).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					machineState: NUMANodeMap{
+						0: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(0).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.NewCPUSet(1, 9),
+										OriginalAllocationResult: machine.NewCPUSet(1, 9),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
+										},
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("3,11"),
-									OriginalAllocationResult: machine.MustParse("3,11"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
-									},
-									RequestQuantity: 2,
 								},
-							},
-							"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+								"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.NewCPUSet(1, 9),
+										OriginalAllocationResult: machine.NewCPUSet(1, 9),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(1, 9),
+										},
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("3,11"),
-									OriginalAllocationResult: machine.MustParse("3,11"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(3, 11),
-									},
-									RequestQuantity: 2,
 								},
-							},
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("8"),
+										OriginalAllocationResult: machine.MustParse("8"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(8),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("10"),
-									OriginalAllocationResult: machine.MustParse("10"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(10),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										1: machine.NewCPUSet(10),
-									},
-									RequestQuantity: 2,
-								},
-							},
-						},
-					},
-					2: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(2).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											0: machine.NewCPUSet(8),
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("4,12"),
-									OriginalAllocationResult: machine.MustParse("4,12"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									RequestQuantity: 2,
-								},
-							},
-							"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameShare,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("4,12"),
-									OriginalAllocationResult: machine.MustParse("4,12"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(4, 12),
-									},
-									RequestQuantity: 2,
-								},
-							},
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
-										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
-									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("5,13"),
-									OriginalAllocationResult: machine.MustParse("5,13"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(5, 13),
-									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										2: machine.NewCPUSet(5, 13),
-									},
-									RequestQuantity: 2,
 								},
 							},
 						},
-					},
-					3: &NUMANodeState{
-						DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(3).Clone(),
-						AllocatedCPUSet: machine.NewCPUSet(),
-						PodEntries: PodEntries{
-							"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
-								testName: &AllocationInfo{
-									AllocationMeta: commonstate.AllocationMeta{
-										PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
-										PodNamespace:   testName,
-										PodName:        testName,
-										ContainerName:  testName,
-										ContainerType:  pluginapi.ContainerType_MAIN.String(),
-										ContainerIndex: 0,
-										OwnerPoolName:  commonstate.PoolNameReclaim,
-										Labels: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+						1: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(1).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
 										},
-										Annotations: map[string]string{
-											consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("3,11"),
+										OriginalAllocationResult: machine.MustParse("3,11"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
 										},
-										QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
+										},
+										RequestQuantity: 2,
 									},
-									RampUp:                   false,
-									AllocationResult:         machine.MustParse("6,7,14,15"),
-									OriginalAllocationResult: machine.MustParse("6,7,14,15"),
-									TopologyAwareAssignments: map[int]machine.CPUSet{
-										3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("3,11"),
+										OriginalAllocationResult: machine.MustParse("3,11"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(3, 11),
+										},
+										RequestQuantity: 2,
 									},
-									OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
-										3: machine.NewCPUSet(6, 7, 14, 15),
+								},
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("10"),
+										OriginalAllocationResult: machine.MustParse("10"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(10),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											1: machine.NewCPUSet(10),
+										},
+										RequestQuantity: 2,
 									},
-									RequestQuantity: 2,
+								},
+							},
+						},
+						2: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(2).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"373d08e4-7a6b-4293-aaaf-b135ff8123bf": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "373d08e4-7a6b-4293-aaaf-b135ff8123bf",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("4,12"),
+										OriginalAllocationResult: machine.MustParse("4,12"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										RequestQuantity: 2,
+									},
+								},
+								"ec6e2f30-c78a-4bc4-9576-c916db5281a3": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "ec6e2f30-c78a-4bc4-9576-c916db5281a3",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameShare,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelSharedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("4,12"),
+										OriginalAllocationResult: machine.MustParse("4,12"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(4, 12),
+										},
+										RequestQuantity: 2,
+									},
+								},
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("5,13"),
+										OriginalAllocationResult: machine.MustParse("5,13"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(5, 13),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											2: machine.NewCPUSet(5, 13),
+										},
+										RequestQuantity: 2,
+									},
+								},
+							},
+						},
+						3: &NUMANodeState{
+							DefaultCPUSet:   cpuTopology.CPUDetails.CPUsInNUMANodes(3).Clone(),
+							AllocatedCPUSet: machine.NewCPUSet(),
+							PodEntries: PodEntries{
+								"2432d068-c5a0-46ba-a7bd-b69d9bd16961": ContainerEntries{
+									testName: &AllocationInfo{
+										AllocationMeta: commonstate.AllocationMeta{
+											PodUid:         "2432d068-c5a0-46ba-a7bd-b69d9bd16961",
+											PodNamespace:   testName,
+											PodName:        testName,
+											ContainerName:  testName,
+											ContainerType:  pluginapi.ContainerType_MAIN.String(),
+											ContainerIndex: 0,
+											OwnerPoolName:  commonstate.PoolNameReclaim,
+											Labels: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											Annotations: map[string]string{
+												consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelReclaimedCores,
+											},
+											QoSLevel: consts.PodAnnotationQoSLevelReclaimedCores,
+										},
+										RampUp:                   false,
+										AllocationResult:         machine.MustParse("6,7,14,15"),
+										OriginalAllocationResult: machine.MustParse("6,7,14,15"),
+										TopologyAwareAssignments: map[int]machine.CPUSet{
+											3: machine.NewCPUSet(6, 7, 14, 15),
+										},
+										OriginalTopologyAwareAssignments: map[int]machine.CPUSet{
+											3: machine.NewCPUSet(6, 7, 14, 15),
+										},
+										RequestQuantity: 2,
+									},
 								},
 							},
 						},

--- a/pkg/config/agent/dynamic/adminqos/qrm/cpu_plugin.go
+++ b/pkg/config/agent/dynamic/adminqos/qrm/cpu_plugin.go
@@ -21,7 +21,12 @@ import (
 )
 
 type CPUPluginConfiguration struct {
-	PreferUseExistNUMAHintResult   bool
+	PreferUseExistNUMAHintResult bool
+	// EnableBypassCPUSetAdjustment controls whether QRM's PackAllocationResponse
+	// clears the cpuset string for shared_cores / reclaimed_cores / system_cores
+	// pools. When enabled, cpuset adjustment is delegated to the reconcile plugin
+	// and dedicated_cores are unaffected.
+	EnableBypassCPUSetAdjustment   bool
 	SystemExclusivePool            map[string]int
 	SystemExclusivePoolShrinkRatio *float64
 	SystemExclusivePoolShrinkMin   *int64
@@ -38,6 +43,9 @@ func (c *CPUPluginConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) 
 		config := aqc.Spec.Config.QRMPluginConfig.CPUPluginConfig
 		if config.PreferUseExistNUMAHintResult != nil {
 			c.PreferUseExistNUMAHintResult = *config.PreferUseExistNUMAHintResult
+		}
+		if config.EnableBypassCPUSetAdjustment != nil {
+			c.EnableBypassCPUSetAdjustment = *config.EnableBypassCPUSetAdjustment
 		}
 		c.SystemExclusivePool = config.SystemExclusivePool
 		c.SystemExclusivePoolShrinkRatio = config.SystemExclusivePoolShrinkRatio

--- a/pkg/util/asyncworker/async_workers_test.go
+++ b/pkg/util/asyncworker/async_workers_test.go
@@ -40,14 +40,19 @@ func TestAsyncWorkers(t *testing.T) {
 	result, a, b, c, d, e, f, g, h := 0, 1, 2, 3, 4, 5, 6, 7, 8
 
 	timeoutSeconds := 100 * time.Millisecond
+	blockWork2 := make(chan struct{})
 	fn := func(ctx context.Context, params ...interface{}) error {
 		if len(params) != 2 {
 			return fmt.Errorf("invalid params")
 		}
 
-		time.Sleep(5 * time.Millisecond)
 		p1Int := params[0].(int)
 		p2Int := params[1].(int)
+		if p1Int == c && p2Int == d {
+			<-blockWork2
+		} else {
+			time.Sleep(5 * time.Millisecond)
+		}
 		result = p1Int + p2Int
 		_ = EmitAsyncedMetrics(ctx, metrics.MetricTag{})
 		return nil
@@ -122,6 +127,8 @@ func TestAsyncWorkers(t *testing.T) {
 	asw.workLock.Lock()
 	rt.Equal(work3, asw.lastUndeliveredWork[work2Name])
 	asw.workLock.Unlock()
+
+	close(blockWork2)
 
 	asw.workLock.Lock()
 	for asw.workStatuses[work2Name].working {

--- a/pkg/util/cgroup/client/cache.go
+++ b/pkg/util/cgroup/client/cache.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+type cachedCgroupClient struct {
+	inner CgroupClient
+
+	mu    sync.Mutex
+	cache map[cacheKey]cacheEntry
+	now   func() time.Time
+}
+
+type cacheKey struct {
+	rel  string
+	file string
+}
+
+type cacheEntry struct {
+	value     string
+	mtime     time.Time
+	size      int64
+	writtenAt time.Time
+}
+
+// NewCachedCgroupClient decorates inner with write-if-change caching.
+func NewCachedCgroupClient(inner CgroupClient) CgroupClient {
+	if inner == nil {
+		panic("NewCachedCgroupClient: inner CgroupClient must not be nil")
+	}
+	return &cachedCgroupClient{
+		inner: inner,
+		cache: map[cacheKey]cacheEntry{},
+		now:   time.Now,
+	}
+}
+
+func (c *cachedCgroupClient) Version(ctx context.Context) CgroupVersion {
+	return c.inner.Version(ctx)
+}
+
+func (c *cachedCgroupClient) ReadCPUSet(ctx context.Context, rel string) (machine.CPUSet, error) {
+	return c.inner.ReadCPUSet(ctx, rel)
+}
+
+func (c *cachedCgroupClient) StatCPUSet(ctx context.Context, rel string) (time.Time, int64, error) {
+	return c.inner.StatCPUSet(ctx, rel)
+}
+
+func (c *cachedCgroupClient) StatCgroupFile(ctx context.Context, rel, file string) (time.Time, int64, error) {
+	return c.inner.StatCgroupFile(ctx, rel, file)
+}
+
+func (c *cachedCgroupClient) ReadCPUSetPartition(ctx context.Context, rel string) (cgcommon.CPUSetPartitionFlag, error) {
+	return c.inner.ReadCPUSetPartition(ctx, rel)
+}
+
+func (c *cachedCgroupClient) ListRootChildren(ctx context.Context) ([]string, error) {
+	return c.inner.ListRootChildren(ctx)
+}
+
+func (c *cachedCgroupClient) ListChildren(ctx context.Context, rel string) ([]string, error) {
+	return c.inner.ListChildren(ctx, rel)
+}
+
+func (c *cachedCgroupClient) StatDir(ctx context.Context, rel string) (time.Time, error) {
+	return c.inner.StatDir(ctx, rel)
+}
+
+func (c *cachedCgroupClient) AttachPID(ctx context.Context, rel string, pid int) error {
+	return c.inner.AttachPID(ctx, rel, pid)
+}
+
+func (c *cachedCgroupClient) ApplyCPUSet(ctx context.Context, rel string, data *cgcommon.CPUSetData) error {
+	if data == nil {
+		return c.inner.ApplyCPUSet(ctx, rel, data)
+	}
+	skipCPUs := data.CPUs == "" || c.shouldSkip(ctx, rel, "cpuset.cpus", data.CPUs)
+	skipMems := data.Mems == "" || c.shouldSkip(ctx, rel, "cpuset.mems", data.Mems)
+	if skipCPUs && skipMems {
+		return nil
+	}
+	if err := c.inner.ApplyCPUSet(ctx, rel, data); err != nil {
+		if data.CPUs != "" {
+			c.invalidate(rel, "cpuset.cpus")
+		}
+		if data.Mems != "" {
+			c.invalidate(rel, "cpuset.mems")
+		}
+		return err
+	}
+	if data.CPUs != "" {
+		c.recordWrite(ctx, rel, "cpuset.cpus", data.CPUs)
+	}
+	if data.Mems != "" {
+		c.recordWrite(ctx, rel, "cpuset.mems", data.Mems)
+	}
+	return nil
+}
+
+func (c *cachedCgroupClient) ApplyCPUSetPartition(ctx context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error {
+	value := string(flag)
+	if c.shouldSkip(ctx, rel, "cpuset.cpus.partition", value) {
+		return nil
+	}
+	if err := c.inner.ApplyCPUSetPartition(ctx, rel, flag); err != nil {
+		c.invalidate(rel, "cpuset.cpus.partition")
+		return err
+	}
+	c.recordWrite(ctx, rel, "cpuset.cpus.partition", value)
+	return nil
+}
+
+func (c *cachedCgroupClient) ApplyCPU(ctx context.Context, rel string, data *cgcommon.CPUData) error {
+	if data == nil {
+		return c.inner.ApplyCPU(ctx, rel, data)
+	}
+	fields := cpuDataFields(data)
+	allSkip := true
+	for _, f := range fields {
+		if !c.shouldSkip(ctx, rel, f.file, f.value) {
+			allSkip = false
+			break
+		}
+	}
+	if allSkip && len(fields) > 0 {
+		return nil
+	}
+	if err := c.inner.ApplyCPU(ctx, rel, data); err != nil {
+		for _, f := range fields {
+			c.invalidate(rel, f.file)
+		}
+		return err
+	}
+	for _, f := range fields {
+		c.recordWrite(ctx, rel, f.file, f.value)
+	}
+	return nil
+}
+
+func (c *cachedCgroupClient) ApplySchedLoadBalance(ctx context.Context, rel string, enabled bool) error {
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+	if c.shouldSkip(ctx, rel, "cpuset.sched_load_balance", value) {
+		return nil
+	}
+	if err := c.inner.ApplySchedLoadBalance(ctx, rel, enabled); err != nil {
+		c.invalidate(rel, "cpuset.sched_load_balance")
+		return err
+	}
+	c.recordWrite(ctx, rel, "cpuset.sched_load_balance", value)
+	return nil
+}
+
+func (c *cachedCgroupClient) shouldSkip(ctx context.Context, rel, file, want string) bool {
+	c.mu.Lock()
+	entry, ok := c.cache[cacheKey{rel: rel, file: file}]
+	c.mu.Unlock()
+	if !ok {
+		return false
+	}
+	if entry.value != want {
+		return false
+	}
+	mtime, size, err := c.statFile(ctx, rel, file)
+	if err != nil {
+		c.invalidate(rel, file)
+		return false
+	}
+	return mtime.Equal(entry.mtime) && size == entry.size
+}
+
+func (c *cachedCgroupClient) recordWrite(ctx context.Context, rel, file, value string) {
+	mtime, size, err := c.statFile(ctx, rel, file)
+	if err != nil {
+		c.invalidate(rel, file)
+		return
+	}
+	c.mu.Lock()
+	c.cache[cacheKey{rel: rel, file: file}] = cacheEntry{
+		value:     value,
+		mtime:     mtime,
+		size:      size,
+		writtenAt: c.now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *cachedCgroupClient) invalidate(rel, file string) {
+	c.mu.Lock()
+	delete(c.cache, cacheKey{rel: rel, file: file})
+	c.mu.Unlock()
+}
+
+func (c *cachedCgroupClient) Prune(activeRels map[string]struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.cache {
+		if _, ok := activeRels[k.rel]; !ok {
+			delete(c.cache, k)
+		}
+	}
+}
+
+func (c *cachedCgroupClient) statFile(ctx context.Context, rel, file string) (time.Time, int64, error) {
+	switch file {
+	case "cpuset.cpus":
+		return c.inner.StatCPUSet(ctx, rel)
+	case "cpuset.mems", "cpuset.cpus.partition", "cpuset.sched_load_balance":
+		return c.inner.StatCgroupFile(ctx, rel, file)
+	}
+	mtime, err := c.inner.StatDir(ctx, rel)
+	return mtime, 0, err
+}
+
+type cachedApplyFieldValue struct {
+	file  string
+	value string
+}
+
+func cpuDataFields(data *cgcommon.CPUData) []cachedApplyFieldValue {
+	if data == nil {
+		return nil
+	}
+	var out []cachedApplyFieldValue
+	if data.Shares != 0 {
+		out = append(out, cachedApplyFieldValue{file: "cpu.shares", value: strconv.FormatUint(data.Shares, 10)})
+	}
+	if data.CpuPeriod != 0 {
+		out = append(out, cachedApplyFieldValue{file: "cpu.cfs_period_us", value: strconv.FormatUint(data.CpuPeriod, 10)})
+	}
+	if data.CpuQuota != 0 {
+		out = append(out, cachedApplyFieldValue{file: "cpu.cfs_quota_us", value: strconv.FormatInt(data.CpuQuota, 10)})
+	}
+	if data.CpuIdlePtr != nil {
+		v := "0"
+		if *data.CpuIdlePtr {
+			v = "1"
+		}
+		out = append(out, cachedApplyFieldValue{file: "cpu.idle", value: v})
+	}
+	if data.CpuBurst != nil {
+		out = append(out, cachedApplyFieldValue{file: "cpu.cfs_burst_us", value: strconv.FormatUint(*data.CpuBurst, 10)})
+	}
+	return out
+}

--- a/pkg/util/cgroup/client/cache.go
+++ b/pkg/util/cgroup/client/cache.go
@@ -31,7 +31,6 @@ type cachedCgroupClient struct {
 
 	mu    sync.Mutex
 	cache map[cacheKey]cacheEntry
-	now   func() time.Time
 }
 
 type cacheKey struct {
@@ -40,10 +39,9 @@ type cacheKey struct {
 }
 
 type cacheEntry struct {
-	value     string
-	mtime     time.Time
-	size      int64
-	writtenAt time.Time
+	value string
+	mtime time.Time
+	size  int64
 }
 
 // NewCachedCgroupClient decorates inner with write-if-change caching.
@@ -54,7 +52,6 @@ func NewCachedCgroupClient(inner CgroupClient) CgroupClient {
 	return &cachedCgroupClient{
 		inner: inner,
 		cache: map[cacheKey]cacheEntry{},
-		now:   time.Now,
 	}
 }
 
@@ -98,39 +95,45 @@ func (c *cachedCgroupClient) ApplyCPUSet(ctx context.Context, rel string, data *
 	if data == nil {
 		return c.inner.ApplyCPUSet(ctx, rel, data)
 	}
-	skipCPUs := data.CPUs == "" || c.shouldSkip(ctx, rel, "cpuset.cpus", data.CPUs)
-	skipMems := data.Mems == "" || c.shouldSkip(ctx, rel, "cpuset.mems", data.Mems)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	skipCPUs := data.CPUs == "" || c.shouldSkipLocked(ctx, rel, "cpuset.cpus", data.CPUs)
+	skipMems := data.Mems == "" || c.shouldSkipLocked(ctx, rel, "cpuset.mems", data.Mems)
 	if skipCPUs && skipMems {
 		return nil
 	}
 	if err := c.inner.ApplyCPUSet(ctx, rel, data); err != nil {
 		if data.CPUs != "" {
-			c.invalidate(rel, "cpuset.cpus")
+			c.invalidateLocked(rel, "cpuset.cpus")
 		}
 		if data.Mems != "" {
-			c.invalidate(rel, "cpuset.mems")
+			c.invalidateLocked(rel, "cpuset.mems")
 		}
 		return err
 	}
 	if data.CPUs != "" {
-		c.recordWrite(ctx, rel, "cpuset.cpus", data.CPUs)
+		c.recordWriteLocked(ctx, rel, "cpuset.cpus", data.CPUs)
 	}
 	if data.Mems != "" {
-		c.recordWrite(ctx, rel, "cpuset.mems", data.Mems)
+		c.recordWriteLocked(ctx, rel, "cpuset.mems", data.Mems)
 	}
 	return nil
 }
 
 func (c *cachedCgroupClient) ApplyCPUSetPartition(ctx context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error {
 	value := string(flag)
-	if c.shouldSkip(ctx, rel, "cpuset.cpus.partition", value) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.shouldSkipLocked(ctx, rel, "cpuset.cpus.partition", value) {
 		return nil
 	}
 	if err := c.inner.ApplyCPUSetPartition(ctx, rel, flag); err != nil {
-		c.invalidate(rel, "cpuset.cpus.partition")
+		c.invalidateLocked(rel, "cpuset.cpus.partition")
 		return err
 	}
-	c.recordWrite(ctx, rel, "cpuset.cpus.partition", value)
+	c.recordWriteLocked(ctx, rel, "cpuset.cpus.partition", value)
 	return nil
 }
 
@@ -138,10 +141,13 @@ func (c *cachedCgroupClient) ApplyCPU(ctx context.Context, rel string, data *cgc
 	if data == nil {
 		return c.inner.ApplyCPU(ctx, rel, data)
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	fields := cpuDataFields(data)
 	allSkip := true
 	for _, f := range fields {
-		if !c.shouldSkip(ctx, rel, f.file, f.value) {
+		if !c.shouldSkipLocked(ctx, rel, f.file, f.value) {
 			allSkip = false
 			break
 		}
@@ -151,12 +157,12 @@ func (c *cachedCgroupClient) ApplyCPU(ctx context.Context, rel string, data *cgc
 	}
 	if err := c.inner.ApplyCPU(ctx, rel, data); err != nil {
 		for _, f := range fields {
-			c.invalidate(rel, f.file)
+			c.invalidateLocked(rel, f.file)
 		}
 		return err
 	}
 	for _, f := range fields {
-		c.recordWrite(ctx, rel, f.file, f.value)
+		c.recordWriteLocked(ctx, rel, f.file, f.value)
 	}
 	return nil
 }
@@ -166,21 +172,22 @@ func (c *cachedCgroupClient) ApplySchedLoadBalance(ctx context.Context, rel stri
 	if enabled {
 		value = "1"
 	}
-	if c.shouldSkip(ctx, rel, "cpuset.sched_load_balance", value) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.shouldSkipLocked(ctx, rel, "cpuset.sched_load_balance", value) {
 		return nil
 	}
 	if err := c.inner.ApplySchedLoadBalance(ctx, rel, enabled); err != nil {
-		c.invalidate(rel, "cpuset.sched_load_balance")
+		c.invalidateLocked(rel, "cpuset.sched_load_balance")
 		return err
 	}
-	c.recordWrite(ctx, rel, "cpuset.sched_load_balance", value)
+	c.recordWriteLocked(ctx, rel, "cpuset.sched_load_balance", value)
 	return nil
 }
 
-func (c *cachedCgroupClient) shouldSkip(ctx context.Context, rel, file, want string) bool {
-	c.mu.Lock()
+func (c *cachedCgroupClient) shouldSkipLocked(ctx context.Context, rel, file, want string) bool {
 	entry, ok := c.cache[cacheKey{rel: rel, file: file}]
-	c.mu.Unlock()
 	if !ok {
 		return false
 	}
@@ -189,32 +196,27 @@ func (c *cachedCgroupClient) shouldSkip(ctx context.Context, rel, file, want str
 	}
 	mtime, size, err := c.statFile(ctx, rel, file)
 	if err != nil {
-		c.invalidate(rel, file)
+		c.invalidateLocked(rel, file)
 		return false
 	}
 	return mtime.Equal(entry.mtime) && size == entry.size
 }
 
-func (c *cachedCgroupClient) recordWrite(ctx context.Context, rel, file, value string) {
+func (c *cachedCgroupClient) recordWriteLocked(ctx context.Context, rel, file, value string) {
 	mtime, size, err := c.statFile(ctx, rel, file)
 	if err != nil {
-		c.invalidate(rel, file)
+		c.invalidateLocked(rel, file)
 		return
 	}
-	c.mu.Lock()
 	c.cache[cacheKey{rel: rel, file: file}] = cacheEntry{
-		value:     value,
-		mtime:     mtime,
-		size:      size,
-		writtenAt: c.now(),
+		value: value,
+		mtime: mtime,
+		size:  size,
 	}
-	c.mu.Unlock()
 }
 
-func (c *cachedCgroupClient) invalidate(rel, file string) {
-	c.mu.Lock()
+func (c *cachedCgroupClient) invalidateLocked(rel, file string) {
 	delete(c.cache, cacheKey{rel: rel, file: file})
-	c.mu.Unlock()
 }
 
 func (c *cachedCgroupClient) Prune(activeRels map[string]struct{}) {

--- a/pkg/util/cgroup/client/cache_test.go
+++ b/pkg/util/cgroup/client/cache_test.go
@@ -265,6 +265,81 @@ func TestCachedCgroupClient_StatFailureInvalidates(t *testing.T) {
 	}
 }
 
+type overlappingApplyFake struct {
+	fakeCgroupClient
+
+	calls    int64
+	inFlight int64
+	entered  chan struct{}
+	release  chan struct{}
+	overlap  chan struct{}
+	mtime    int64
+}
+
+func newOverlappingApplyFake() *overlappingApplyFake {
+	return &overlappingApplyFake{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		overlap: make(chan struct{}),
+		mtime:   1,
+	}
+}
+
+func (f *overlappingApplyFake) StatDir(context.Context, string) (time.Time, error) {
+	return time.Unix(0, atomic.LoadInt64(&f.mtime)), nil
+}
+
+func (f *overlappingApplyFake) ApplyCPU(context.Context, string, *cgcommon.CPUData) error {
+	call := atomic.AddInt64(&f.calls, 1)
+	if atomic.AddInt64(&f.inFlight, 1) > 1 {
+		select {
+		case <-f.overlap:
+		default:
+			close(f.overlap)
+		}
+	}
+	if call == 1 {
+		close(f.entered)
+		<-f.release
+	}
+	atomic.AddInt64(&f.inFlight, -1)
+	return nil
+}
+
+func TestCachedCgroupClient_ApplyCPU_SerializesSameKeyCheckWriteRecord(t *testing.T) {
+	inner := newOverlappingApplyFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+	idleOn := true
+	idleOff := false
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn})
+	}()
+	<-inner.entered
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOff})
+	}()
+
+	select {
+	case <-inner.overlap:
+		close(inner.release)
+		t.Fatalf("same-key ApplyCPU entered inner apply concurrently")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(inner.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first ApplyCPU: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second ApplyCPU: %v", err)
+	}
+}
+
 func TestCachedCgroupClient_AttachPIDNeverCaches(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/util/cgroup/client/cache_test.go
+++ b/pkg/util/cgroup/client/cache_test.go
@@ -307,6 +307,8 @@ func (f *overlappingApplyFake) ApplyCPU(context.Context, string, *cgcommon.CPUDa
 }
 
 func TestCachedCgroupClient_ApplyCPU_SerializesSameKeyCheckWriteRecord(t *testing.T) {
+	t.Parallel()
+
 	inner := newOverlappingApplyFake()
 	c := NewCachedCgroupClient(inner)
 	ctx := context.Background()

--- a/pkg/util/cgroup/client/cache_test.go
+++ b/pkg/util/cgroup/client/cache_test.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+type fakeCgroupClient struct{}
+
+var _ CgroupClient = (*fakeCgroupClient)(nil)
+
+func (fakeCgroupClient) ApplyCPUSet(context.Context, string, *cgcommon.CPUSetData) error {
+	return nil
+}
+
+func (fakeCgroupClient) ApplyCPUSetPartition(context.Context, string, cgcommon.CPUSetPartitionFlag) error {
+	return nil
+}
+
+func (fakeCgroupClient) ApplyCPU(context.Context, string, *cgcommon.CPUData) error {
+	return nil
+}
+
+func (fakeCgroupClient) ApplySchedLoadBalance(context.Context, string, bool) error {
+	return nil
+}
+
+func (fakeCgroupClient) AttachPID(context.Context, string, int) error {
+	return nil
+}
+
+func (fakeCgroupClient) Version(context.Context) CgroupVersion {
+	return CgroupVersionV2
+}
+
+func (fakeCgroupClient) ReadCPUSet(context.Context, string) (machine.CPUSet, error) {
+	return machine.NewCPUSet(), nil
+}
+
+func (fakeCgroupClient) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	return time.Time{}, 0, nil
+}
+
+func (fakeCgroupClient) StatCgroupFile(context.Context, string, string) (time.Time, int64, error) {
+	return time.Time{}, 0, nil
+}
+
+func (fakeCgroupClient) ReadCPUSetPartition(context.Context, string) (cgcommon.CPUSetPartitionFlag, error) {
+	return cgcommon.CPUSetPartitionFlagMember, nil
+}
+
+func (fakeCgroupClient) ListRootChildren(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (fakeCgroupClient) ListChildren(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (fakeCgroupClient) StatDir(context.Context, string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (fakeCgroupClient) Prune(map[string]struct{}) {}
+
+type countingFake struct {
+	fakeCgroupClient
+
+	applyCPUSetN          int64
+	applyCPUSetPartitionN int64
+	applyCPUN             int64
+	applySchedLBN         int64
+	attachPIDN            int64
+	statErr               error
+	mtime                 int64
+	size                  int64
+}
+
+func newCountingFake() *countingFake {
+	f := &countingFake{}
+	atomic.StoreInt64(&f.mtime, 1)
+	atomic.StoreInt64(&f.size, 4)
+	return f
+}
+
+func (f *countingFake) bumpMTime() {
+	atomic.AddInt64(&f.mtime, 1)
+}
+
+func (f *countingFake) statNow() (time.Time, int64, error) {
+	if f.statErr != nil {
+		return time.Time{}, 0, f.statErr
+	}
+	return time.Unix(0, atomic.LoadInt64(&f.mtime)), atomic.LoadInt64(&f.size), nil
+}
+
+func (f *countingFake) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	return f.statNow()
+}
+
+func (f *countingFake) StatCgroupFile(context.Context, string, string) (time.Time, int64, error) {
+	return f.statNow()
+}
+
+func (f *countingFake) StatDir(context.Context, string) (time.Time, error) {
+	t, _, err := f.statNow()
+	return t, err
+}
+
+func (f *countingFake) ApplyCPUSet(context.Context, string, *cgcommon.CPUSetData) error {
+	atomic.AddInt64(&f.applyCPUSetN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) ApplyCPUSetPartition(context.Context, string, cgcommon.CPUSetPartitionFlag) error {
+	atomic.AddInt64(&f.applyCPUSetPartitionN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) ApplyCPU(context.Context, string, *cgcommon.CPUData) error {
+	atomic.AddInt64(&f.applyCPUN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) ApplySchedLoadBalance(context.Context, string, bool) error {
+	atomic.AddInt64(&f.applySchedLBN, 1)
+	f.bumpMTime()
+	return nil
+}
+
+func (f *countingFake) AttachPID(context.Context, string, int) error {
+	atomic.AddInt64(&f.attachPIDN, 1)
+	return nil
+}
+
+func TestCachedCgroupClient_ApplyCPU_ShortCircuitsAndInvalidates(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+	idleOn := true
+	idleOff := false
+
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("first ApplyCPU: %v", err)
+	}
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("second ApplyCPU: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 1 {
+		t.Fatalf("inner ApplyCPU calls after idempotent write = %d, want 1", got)
+	}
+
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOff}); err != nil {
+		t.Fatalf("third ApplyCPU: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 2 {
+		t.Fatalf("inner ApplyCPU calls after value change = %d, want 2", got)
+	}
+
+	inner.bumpMTime()
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOff}); err != nil {
+		t.Fatalf("fourth ApplyCPU: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 3 {
+		t.Fatalf("inner ApplyCPU calls after external drift = %d, want 3", got)
+	}
+}
+
+func TestCachedCgroupClient_ApplyCPUSet_PerFileCache(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+
+	if err := c.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1", Mems: "0"}); err != nil {
+		t.Fatalf("first ApplyCPUSet: %v", err)
+	}
+	if err := c.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1", Mems: "0"}); err != nil {
+		t.Fatalf("second ApplyCPUSet: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUSetN); got != 1 {
+		t.Fatalf("inner ApplyCPUSet calls after idempotent write = %d, want 1", got)
+	}
+	if err := c.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1", Mems: "1"}); err != nil {
+		t.Fatalf("third ApplyCPUSet: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUSetN); got != 2 {
+		t.Fatalf("inner ApplyCPUSet calls after mems change = %d, want 2", got)
+	}
+}
+
+func TestCachedCgroupClient_ApplyCPUSetPartitionAndSchedLoadBalance(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+
+	if err := c.ApplyCPUSetPartition(ctx, "kubepods", cgcommon.CPUSetPartitionFlagRoot); err != nil {
+		t.Fatalf("first partition: %v", err)
+	}
+	if err := c.ApplyCPUSetPartition(ctx, "kubepods", cgcommon.CPUSetPartitionFlagRoot); err != nil {
+		t.Fatalf("second partition: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUSetPartitionN); got != 1 {
+		t.Fatalf("partition writes = %d, want 1", got)
+	}
+
+	if err := c.ApplySchedLoadBalance(ctx, "kubepods", true); err != nil {
+		t.Fatalf("first sched_load_balance: %v", err)
+	}
+	if err := c.ApplySchedLoadBalance(ctx, "kubepods", true); err != nil {
+		t.Fatalf("second sched_load_balance: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applySchedLBN); got != 1 {
+		t.Fatalf("sched_load_balance writes = %d, want 1", got)
+	}
+}
+
+func TestCachedCgroupClient_StatFailureInvalidates(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+	idleOn := true
+
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("first ApplyCPU: %v", err)
+	}
+	inner.statErr = errors.New("stat failed")
+	if err := c.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{CpuIdlePtr: &idleOn}); err != nil {
+		t.Fatalf("second ApplyCPU after stat failure: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.applyCPUN); got != 2 {
+		t.Fatalf("ApplyCPU calls after stat failure = %d, want 2", got)
+	}
+}
+
+func TestCachedCgroupClient_AttachPIDNeverCaches(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingFake()
+	c := NewCachedCgroupClient(inner)
+	ctx := context.Background()
+
+	if err := c.AttachPID(ctx, "kubepods", 1234); err != nil {
+		t.Fatalf("first AttachPID: %v", err)
+	}
+	if err := c.AttachPID(ctx, "kubepods", 1234); err != nil {
+		t.Fatalf("second AttachPID: %v", err)
+	}
+	if got := atomic.LoadInt64(&inner.attachPIDN); got != 2 {
+		t.Fatalf("AttachPID calls = %d, want 2", got)
+	}
+}
+
+type statFileFake struct {
+	fakeCgroupClient
+
+	statCPUSetCalls int
+	statCgroupFile  []string
+	statDirCalls    int
+	mtimeCPUSet     time.Time
+	mtimeCgroupFile time.Time
+	mtimeDir        time.Time
+}
+
+func (f *statFileFake) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	f.statCPUSetCalls++
+	return f.mtimeCPUSet, 0, nil
+}
+
+func (f *statFileFake) StatCgroupFile(_ context.Context, _ string, file string) (time.Time, int64, error) {
+	f.statCgroupFile = append(f.statCgroupFile, file)
+	return f.mtimeCgroupFile, 0, nil
+}
+
+func (f *statFileFake) StatDir(context.Context, string) (time.Time, error) {
+	f.statDirCalls++
+	return f.mtimeDir, nil
+}
+
+func TestCachedCgroupClient_statFile_PerFileRouting(t *testing.T) {
+	t.Parallel()
+
+	f := &statFileFake{
+		mtimeCPUSet:     time.Unix(1, 0),
+		mtimeCgroupFile: time.Unix(2, 0),
+		mtimeDir:        time.Unix(3, 0),
+	}
+	c := NewCachedCgroupClient(f).(*cachedCgroupClient)
+	ctx := context.Background()
+
+	mt, _, err := c.statFile(ctx, "kubepods", "cpuset.cpus")
+	if err != nil || !mt.Equal(f.mtimeCPUSet) {
+		t.Fatalf("statFile(cpuset.cpus) = (%v,%v), want %v", mt, err, f.mtimeCPUSet)
+	}
+	if f.statCPUSetCalls != 1 || len(f.statCgroupFile) != 0 || f.statDirCalls != 0 {
+		t.Fatalf("cpuset.cpus routing: statCPUSet=%d statCgroupFile=%v statDir=%d",
+			f.statCPUSetCalls, f.statCgroupFile, f.statDirCalls)
+	}
+
+	perFile := []string{"cpuset.mems", "cpuset.cpus.partition", "cpuset.sched_load_balance"}
+	for _, name := range perFile {
+		if _, _, err := c.statFile(ctx, "kubepods", name); err != nil {
+			t.Fatalf("statFile(%s): %v", name, err)
+		}
+	}
+	for i, name := range perFile {
+		if f.statCgroupFile[i] != name {
+			t.Fatalf("statCgroupFile[%d] = %q, want %q", i, f.statCgroupFile[i], name)
+		}
+	}
+
+	mt, size, err := c.statFile(ctx, "kubepods", "cpu.max")
+	if err != nil || !mt.Equal(f.mtimeDir) || size != 0 {
+		t.Fatalf("statFile(cpu.max) = (%v,%d,%v), want (%v,0,nil)", mt, size, err, f.mtimeDir)
+	}
+	if f.statDirCalls != 1 {
+		t.Fatalf("StatDir calls = %d, want 1", f.statDirCalls)
+	}
+}
+
+func TestCachedCgroupClient_Prune(t *testing.T) {
+	t.Parallel()
+
+	c := NewCachedCgroupClient(&fakeCgroupClient{}).(*cachedCgroupClient)
+	c.cache[cacheKey{rel: "rel-a", file: "cpuset.cpus"}] = cacheEntry{value: "0-1"}
+	c.cache[cacheKey{rel: "rel-a", file: "cpuset.mems"}] = cacheEntry{value: "0"}
+	c.cache[cacheKey{rel: "rel-b", file: "cpuset.cpus"}] = cacheEntry{value: "2-3"}
+
+	c.Prune(map[string]struct{}{"rel-a": {}})
+
+	if len(c.cache) != 2 {
+		t.Fatalf("cache size after Prune = %d, want 2", len(c.cache))
+	}
+	if _, ok := c.cache[cacheKey{rel: "rel-b", file: "cpuset.cpus"}]; ok {
+		t.Fatalf("rel-b/cpuset.cpus should be dropped")
+	}
+
+	c.Prune(nil)
+	if len(c.cache) != 0 {
+		t.Fatalf("Prune(nil) left %d entries, want 0", len(c.cache))
+	}
+}

--- a/pkg/util/cgroup/client/client.go
+++ b/pkg/util/cgroup/client/client.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client provides a small cgroup manager facade with write-if-change caching.
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	cgmanager "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+// CgroupVersion tags the cgroup hierarchy layout the current host is booted into.
+type CgroupVersion string
+
+const (
+	// CgroupVersionV1 indicates the host is using cgroup v1 hierarchies.
+	CgroupVersionV1 CgroupVersion = "v1"
+	// CgroupVersionV2 indicates the host is using cgroup v2 unified hierarchy.
+	CgroupVersionV2 CgroupVersion = "v2"
+)
+
+// CgroupClient is the narrow cgroup interface consumed by reconciliation code.
+type CgroupClient interface {
+	// ApplyCPUSet writes cpuset.cpus and cpuset.mems to rel.
+	ApplyCPUSet(ctx context.Context, rel string, data *cgcommon.CPUSetData) error
+	// ApplyCPUSetPartition writes cpuset.cpus.partition to rel.
+	ApplyCPUSetPartition(ctx context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error
+	// ApplyCPU writes cpu controller data to rel.
+	ApplyCPU(ctx context.Context, rel string, data *cgcommon.CPUData) error
+	// ApplySchedLoadBalance toggles cpuset.sched_load_balance at rel.
+	ApplySchedLoadBalance(ctx context.Context, rel string, enabled bool) error
+	// AttachPID writes pid into cgroup.procs at rel.
+	AttachPID(ctx context.Context, rel string, pid int) error
+	// Version reports whether the host is running cgroup v1 or v2.
+	Version(ctx context.Context) CgroupVersion
+	// ReadCPUSet parses cpuset.cpus at rel.
+	ReadCPUSet(ctx context.Context, rel string) (machine.CPUSet, error)
+	// StatCPUSet returns metadata for cpuset.cpus at rel.
+	StatCPUSet(ctx context.Context, rel string) (mtime time.Time, size int64, err error)
+	// StatCgroupFile returns metadata for file under rel's cpuset cgroup directory.
+	StatCgroupFile(ctx context.Context, rel, file string) (mtime time.Time, size int64, err error)
+	// ReadCPUSetPartition reads cpuset.cpus.partition at rel.
+	ReadCPUSetPartition(ctx context.Context, rel string) (cgcommon.CPUSetPartitionFlag, error)
+	// ListRootChildren returns direct child directory names under the cpuset cgroup root.
+	ListRootChildren(ctx context.Context) ([]string, error)
+	// ListChildren returns direct child directory names under rel.
+	ListChildren(ctx context.Context, rel string) ([]string, error)
+	// StatDir returns the mtime of the cgroup directory at rel.
+	StatDir(ctx context.Context, rel string) (mtime time.Time, err error)
+	// Prune drops cached state whose rel is not active.
+	Prune(activeRels map[string]struct{})
+}
+
+type coreCgroupClient struct{}
+
+// NewCgroupClient returns a core cgroup client wrapped by a write-if-change cache.
+func NewCgroupClient() CgroupClient {
+	return NewCachedCgroupClient(coreCgroupClient{})
+}
+
+func (coreCgroupClient) ApplyCPUSet(_ context.Context, rel string, data *cgcommon.CPUSetData) error {
+	if data == nil {
+		return fmt.Errorf("ApplyCPUSet: nil data")
+	}
+	return cgmanager.ApplyCPUSetWithRelativePath(rel, data)
+}
+
+func (coreCgroupClient) ApplyCPUSetPartition(_ context.Context, rel string, flag cgcommon.CPUSetPartitionFlag) error {
+	return cgmanager.ApplyCPUSetPartitionWithRelativePath(rel, flag)
+}
+
+func (coreCgroupClient) ApplyCPU(_ context.Context, rel string, data *cgcommon.CPUData) error {
+	if data == nil {
+		return fmt.Errorf("ApplyCPU: nil data")
+	}
+	return cgmanager.ApplyCPUWithRelativePath(rel, data)
+}
+
+func (coreCgroupClient) ApplySchedLoadBalance(_ context.Context, rel string, enabled bool) error {
+	err := cgmanager.ApplySchedLoadBalanceWithRelativePath(rel, enabled)
+	if err != nil && errors.Is(err, cgcommon.ErrNotSupported) {
+		return fmt.Errorf("sched_load_balance @ %s: %w", rel, err)
+	}
+	return err
+}
+
+func (coreCgroupClient) AttachPID(_ context.Context, rel string, pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("AttachPID: invalid pid %d", pid)
+	}
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	f, err := os.OpenFile(filepath.Join(abs, "cgroup.procs"), os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("open cgroup.procs @ %s: %w", rel, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := fmt.Fprintf(f, "%d", pid); err != nil {
+		return fmt.Errorf("write pid %d @ %s: %w", pid, rel, err)
+	}
+	return nil
+}
+
+func (coreCgroupClient) Version(context.Context) CgroupVersion {
+	if cgcommon.CheckCgroup2UnifiedMode() {
+		return CgroupVersionV2
+	}
+	return CgroupVersionV1
+}
+
+func (coreCgroupClient) ReadCPUSet(_ context.Context, rel string) (machine.CPUSet, error) {
+	stats, err := cgmanager.GetCPUSetWithRelativePath(rel)
+	if err != nil {
+		return machine.NewCPUSet(), fmt.Errorf("read cpuset @ %s: %w", rel, err)
+	}
+	if stats == nil {
+		return machine.NewCPUSet(), nil
+	}
+	cs, err := machine.Parse(stats.CPUs)
+	if err != nil {
+		return machine.NewCPUSet(), fmt.Errorf("parse cpuset %q @ %s: %w", stats.CPUs, rel, err)
+	}
+	return cs, nil
+}
+
+func (coreCgroupClient) StatCPUSet(_ context.Context, rel string) (time.Time, int64, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	info, err := os.Stat(filepath.Join(abs, "cpuset.cpus"))
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+	return info.ModTime(), info.Size(), nil
+}
+
+func (coreCgroupClient) StatCgroupFile(_ context.Context, rel, file string) (time.Time, int64, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	info, err := os.Stat(filepath.Join(abs, file))
+	if err != nil {
+		return time.Time{}, 0, err
+	}
+	return info.ModTime(), info.Size(), nil
+}
+
+func (coreCgroupClient) ReadCPUSetPartition(_ context.Context, rel string) (cgcommon.CPUSetPartitionFlag, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	raw, err := os.ReadFile(filepath.Join(abs, "cpuset.cpus.partition"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("read cpuset.cpus.partition @ %s: %w", rel, cgcommon.ErrNotSupported)
+		}
+		return "", fmt.Errorf("read cpuset.cpus.partition @ %s: %w", rel, err)
+	}
+	val := strings.TrimSpace(string(raw))
+	switch cgcommon.CPUSetPartitionFlag(val) {
+	case cgcommon.CPUSetPartitionFlagRoot, cgcommon.CPUSetPartitionFlagMember, cgcommon.CPUSetPartitionFlagIsolated:
+		return cgcommon.CPUSetPartitionFlag(val), nil
+	default:
+		if idx := strings.IndexAny(val, " \t"); idx > 0 {
+			return cgcommon.CPUSetPartitionFlag(val[:idx]), nil
+		}
+		return cgcommon.CPUSetPartitionFlag(val), nil
+	}
+}
+
+func (c coreCgroupClient) ListRootChildren(ctx context.Context) ([]string, error) {
+	return c.ListChildren(ctx, "")
+}
+
+func (coreCgroupClient) ListChildren(_ context.Context, rel string) ([]string, error) {
+	var abs string
+	if strings.TrimSpace(rel) == "" {
+		abs = cgcommon.GetCgroupRootPath(cgcommon.CgroupSubsysCPUSet)
+	} else {
+		abs = cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	}
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		return nil, fmt.Errorf("readdir %s: %w", abs, err)
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (coreCgroupClient) StatDir(_ context.Context, rel string) (time.Time, error) {
+	abs := cgcommon.GetKubernetesAbsCgroupPath(cgcommon.CgroupSubsysCPUSet, rel)
+	info, err := os.Stat(abs)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return info.ModTime(), nil
+}
+
+func (coreCgroupClient) Prune(map[string]struct{}) {}

--- a/pkg/util/cgroup/client/client_test.go
+++ b/pkg/util/cgroup/client/client_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+)
+
+func TestNewCgroupClient_ReturnsCachedClient(t *testing.T) {
+	t.Parallel()
+
+	c := NewCgroupClient()
+	if c == nil {
+		t.Fatalf("NewCgroupClient() = nil")
+	}
+	if _, ok := c.(*cachedCgroupClient); !ok {
+		t.Fatalf("NewCgroupClient() type = %T, want *cachedCgroupClient", c)
+	}
+}
+
+func TestNewCachedCgroupClient_PanicsOnNilInner(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("NewCachedCgroupClient(nil) must panic")
+		}
+	}()
+	_ = NewCachedCgroupClient(nil)
+}
+
+func TestCoreCgroupClient_ApplyCPUSet_NilDataRejected(t *testing.T) {
+	t.Parallel()
+
+	err := NewCgroupClient().ApplyCPUSet(context.Background(), "kubepods", nil)
+	if err == nil {
+		t.Fatalf("ApplyCPUSet(nil) must fail")
+	}
+	if !strings.Contains(err.Error(), "nil data") {
+		t.Fatalf("error must mention nil data, got: %v", err)
+	}
+}
+
+func TestCoreCgroupClient_ApplyCPU_NilDataRejected(t *testing.T) {
+	t.Parallel()
+
+	err := NewCgroupClient().ApplyCPU(context.Background(), "kubepods", nil)
+	if err == nil {
+		t.Fatalf("ApplyCPU(nil) must fail")
+	}
+	if !strings.Contains(err.Error(), "nil data") {
+		t.Fatalf("error must mention nil data, got: %v", err)
+	}
+}
+
+func TestCoreCgroupClient_AttachPID_InvalidPIDRejected(t *testing.T) {
+	t.Parallel()
+
+	c := NewCgroupClient()
+	for _, pid := range []int{0, -1, -1000} {
+		if err := c.AttachPID(context.Background(), "kubepods", pid); err == nil {
+			t.Fatalf("AttachPID(%d) must fail", pid)
+		}
+	}
+}
+
+func TestCoreCgroupClient_Version_ReturnsKnownEnum(t *testing.T) {
+	t.Parallel()
+
+	got := NewCgroupClient().Version(context.Background())
+	if got != CgroupVersionV1 && got != CgroupVersionV2 {
+		t.Fatalf("Version() = %q, want %q or %q", got, CgroupVersionV1, CgroupVersionV2)
+	}
+}
+
+func TestCoreCgroupClient_StatCPUSet_MissingPathSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := NewCgroupClient().StatCPUSet(context.Background(), "/definitely/not/a/real/cgroup/path")
+	if err == nil {
+		t.Fatalf("StatCPUSet on missing path must error")
+	}
+}
+
+func TestCoreCgroupClient_StatDir_MissingPathSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewCgroupClient().StatDir(context.Background(), "/definitely/not/a/real/cgroup/path")
+	if err == nil {
+		t.Fatalf("StatDir on missing path must error")
+	}
+}
+
+func TestCoreCgroupClient_ReadCPUSetPartition_ErrNotSupportedOnMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewCgroupClient().ReadCPUSetPartition(context.Background(), "/definitely/not/a/real/cgroup/path")
+	if err == nil {
+		t.Fatalf("ReadCPUSetPartition on missing path must error")
+	}
+	if !errors.Is(err, cgcommon.ErrNotSupported) {
+		t.Fatalf("ReadCPUSetPartition error = %v, want ErrNotSupported-compatible", err)
+	}
+}

--- a/pkg/util/cgroup/client/fake.go
+++ b/pkg/util/cgroup/client/fake.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"time"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+// FakeCgroupClient is a no-op implementation of CgroupClient meant to be
+// embedded by test doubles. It exists so that widening CgroupClient does not
+// force every downstream fake to grow N new stub methods — tests only need to
+// override the specific methods they exercise.
+//
+// It is intentionally located in the production package instead of a _test.go
+// file because Go's build system does not export _test.go symbols across
+// packages; downstream package tests may need to import this stub directly.
+//
+// Zero value is usable. All methods return safe defaults: nil errors, empty
+// slices, empty CPUSet, member cpuset partition, and v2 cgroup version. Embed
+// this stub and override only the methods a test cares about:
+//
+//	type myFake struct {
+//	    client.FakeCgroupClient
+//	    calls []someCall
+//	}
+//
+//	func (f *myFake) ApplyCPUSet(...) error { ... }
+//
+// The rest of the interface stays satisfied by FakeCgroupClient's stubs.
+type FakeCgroupClient struct{}
+
+var _ CgroupClient = (*FakeCgroupClient)(nil)
+
+func (FakeCgroupClient) ApplyCPUSet(context.Context, string, *cgcommon.CPUSetData) error {
+	return nil
+}
+
+func (FakeCgroupClient) ApplyCPUSetPartition(context.Context, string, cgcommon.CPUSetPartitionFlag) error {
+	return nil
+}
+
+func (FakeCgroupClient) ApplyCPU(context.Context, string, *cgcommon.CPUData) error {
+	return nil
+}
+
+func (FakeCgroupClient) ApplySchedLoadBalance(context.Context, string, bool) error {
+	return nil
+}
+
+func (FakeCgroupClient) AttachPID(context.Context, string, int) error {
+	return nil
+}
+
+func (FakeCgroupClient) Version(context.Context) CgroupVersion {
+	return CgroupVersionV2
+}
+
+func (FakeCgroupClient) ReadCPUSet(context.Context, string) (machine.CPUSet, error) {
+	return machine.NewCPUSet(), nil
+}
+
+func (FakeCgroupClient) StatCPUSet(context.Context, string) (time.Time, int64, error) {
+	return time.Time{}, 0, nil
+}
+
+func (FakeCgroupClient) StatCgroupFile(context.Context, string, string) (time.Time, int64, error) {
+	return time.Time{}, 0, nil
+}
+
+func (FakeCgroupClient) ReadCPUSetPartition(context.Context, string) (cgcommon.CPUSetPartitionFlag, error) {
+	return cgcommon.CPUSetPartitionFlagMember, nil
+}
+
+func (FakeCgroupClient) ListRootChildren(context.Context) ([]string, error) {
+	return nil, nil
+}
+
+func (FakeCgroupClient) ListChildren(context.Context, string) ([]string, error) {
+	return nil, nil
+}
+
+func (FakeCgroupClient) StatDir(context.Context, string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (FakeCgroupClient) Prune(map[string]struct{}) {}

--- a/pkg/util/cgroup/client/fake_test.go
+++ b/pkg/util/cgroup/client/fake_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	cgcommon "github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
+)
+
+// TestFakeCgroupClientSatisfiesInterface fails at compile time if
+// FakeCgroupClient drifts from CgroupClient.
+func TestFakeCgroupClientSatisfiesInterface(t *testing.T) {
+	t.Parallel()
+
+	var _ CgroupClient = FakeCgroupClient{}
+}
+
+// TestFakeCgroupClientDefaults documents the safe-default policy of the
+// zero-value FakeCgroupClient.
+func TestFakeCgroupClientDefaults(t *testing.T) {
+	t.Parallel()
+
+	f := FakeCgroupClient{}
+	ctx := context.Background()
+
+	if got := f.Version(ctx); got != CgroupVersionV2 {
+		t.Errorf("Version default = %v, want %v", got, CgroupVersionV2)
+	}
+	if err := f.ApplyCPUSet(ctx, "kubepods", &cgcommon.CPUSetData{CPUs: "0-1"}); err != nil {
+		t.Errorf("ApplyCPUSet default returned err=%v, want nil", err)
+	}
+	if err := f.ApplyCPUSetPartition(ctx, "kubepods", cgcommon.CPUSetPartitionFlagRoot); err != nil {
+		t.Errorf("ApplyCPUSetPartition default returned err=%v, want nil", err)
+	}
+	if err := f.ApplyCPU(ctx, "kubepods", &cgcommon.CPUData{}); err != nil {
+		t.Errorf("ApplyCPU default returned err=%v, want nil", err)
+	}
+	if err := f.ApplySchedLoadBalance(ctx, "kubepods", false); err != nil {
+		t.Errorf("ApplySchedLoadBalance default returned err=%v, want nil", err)
+	}
+	if err := f.AttachPID(ctx, "kubepods", 1); err != nil {
+		t.Errorf("AttachPID default returned err=%v, want nil", err)
+	}
+
+	cs, err := f.ReadCPUSet(ctx, "kubepods")
+	if err != nil {
+		t.Errorf("ReadCPUSet default returned err=%v, want nil", err)
+	}
+	if !cs.IsEmpty() {
+		t.Errorf("ReadCPUSet default = %v, want empty", cs.String())
+	}
+
+	if mt, sz, err := f.StatCPUSet(ctx, "kubepods"); err != nil || !mt.IsZero() || sz != 0 {
+		t.Errorf("StatCPUSet default = (%v,%d,%v), want (zero,0,nil)", mt, sz, err)
+	}
+	if mt, sz, err := f.StatCgroupFile(ctx, "kubepods", "cpuset.cpus"); err != nil || !mt.IsZero() || sz != 0 {
+		t.Errorf("StatCgroupFile default = (%v,%d,%v), want (zero,0,nil)", mt, sz, err)
+	}
+	if flag, err := f.ReadCPUSetPartition(ctx, "kubepods"); err != nil || flag != cgcommon.CPUSetPartitionFlagMember {
+		t.Errorf("ReadCPUSetPartition default = (%v,%v), want (member,nil)", flag, err)
+	}
+	if kids, err := f.ListRootChildren(ctx); err != nil || len(kids) != 0 {
+		t.Errorf("ListRootChildren default = (%v,%v), want (nil,nil)", kids, err)
+	}
+	if kids, err := f.ListChildren(ctx, "kubepods"); err != nil || len(kids) != 0 {
+		t.Errorf("ListChildren default = (%v,%v), want (nil,nil)", kids, err)
+	}
+	if mt, err := f.StatDir(ctx, "kubepods"); err != nil || !mt.IsZero() {
+		t.Errorf("StatDir default = (%v,%v), want (zero,nil)", mt, err)
+	}
+}
+
+// TestFakeCgroupClientOverride verifies that embedding fakes can override a
+// subset of methods and inherit the rest from FakeCgroupClient defaults.
+func TestFakeCgroupClientOverride(t *testing.T) {
+	t.Parallel()
+
+	f := &attachRecordingFake{}
+	if err := f.AttachPID(context.Background(), "kubepods", 1234); err != nil {
+		t.Fatalf("AttachPID: %v", err)
+	}
+	if f.gotPID != 1234 {
+		t.Errorf("gotPID = %d, want 1234", f.gotPID)
+	}
+	if err := f.ApplyCPUSet(context.Background(), "kubepods", &cgcommon.CPUSetData{}); err != nil {
+		t.Errorf("inherited ApplyCPUSet returned err=%v, want nil", err)
+	}
+}
+
+type attachRecordingFake struct {
+	FakeCgroupClient
+	gotPID int
+}
+
+func (f *attachRecordingFake) AttachPID(_ context.Context, _ string, pid int) error {
+	f.gotPID = pid
+	return nil
+}

--- a/pkg/util/cgroup/common/errors.go
+++ b/pkg/util/cgroup/common/errors.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "errors"
+
+// ErrNotSupported indicates that the requested primitive is not exposed by the
+// current cgroup version or build tag. Callers may use errors.Is to detect the
+// condition and decide whether to short-circuit or propagate.
+var ErrNotSupported = errors.New("operation not supported by this cgroup manager")

--- a/pkg/util/cgroup/manager/cgroup.go
+++ b/pkg/util/cgroup/manager/cgroup.go
@@ -113,6 +113,21 @@ func ApplyCPUSetPartitionWithAbsolutePath(absCgroupPath string, partitionFlag co
 	return GetManager().ApplyCPUSetPartition(absCgroupPath, partitionFlag)
 }
 
+// ApplySchedLoadBalanceWithRelativePath writes cpuset.sched_load_balance for
+// the cgroup at relCgroupPath. It is only meaningful on cgroup v1; on v2 the
+// underlying manager returns common.ErrNotSupported and callers should decide
+// whether to short-circuit or surface the error.
+func ApplySchedLoadBalanceWithRelativePath(relCgroupPath string, enabled bool) error {
+	absCgroupPath := common.GetAbsCgroupPath("cpuset", relCgroupPath)
+	return GetManager().ApplySchedLoadBalance(absCgroupPath, enabled)
+}
+
+// ApplySchedLoadBalanceWithAbsolutePath mirrors ApplySchedLoadBalanceWithRelativePath
+// for callers that already resolved the absolute cgroup path.
+func ApplySchedLoadBalanceWithAbsolutePath(absCgroupPath string, enabled bool) error {
+	return GetManager().ApplySchedLoadBalance(absCgroupPath, enabled)
+}
+
 func ApplyCPUSetForContainer(podUID, containerId string, data *common.CPUSetData) error {
 	if data == nil {
 		return fmt.Errorf("ApplyCPUSetForContainer with nil cgroup data")

--- a/pkg/util/cgroup/manager/fake_manager.go
+++ b/pkg/util/cgroup/manager/fake_manager.go
@@ -36,6 +36,10 @@ func (f *FakeCgroupManager) ApplyCPUSetPartition(absCgroupPath string, partition
 	return nil
 }
 
+func (f *FakeCgroupManager) ApplySchedLoadBalance(absCgroupPath string, enabled bool) error {
+	return nil
+}
+
 func (f *FakeCgroupManager) ApplyNetCls(absCgroupPath string, data *common.NetClsData) error {
 	return nil
 }

--- a/pkg/util/cgroup/manager/manager.go
+++ b/pkg/util/cgroup/manager/manager.go
@@ -38,6 +38,11 @@ type Manager interface {
 	ApplyCPU(absCgroupPath string, data *common.CPUData) error
 	ApplyCPUSet(absCgroupPath string, data *common.CPUSetData) error
 	ApplyCPUSetPartition(absCgroupPath string, partitionFlag common.CPUSetPartitionFlag) error
+	// ApplySchedLoadBalance writes the cpuset sched_load_balance flag under
+	// absCgroupPath. It is only meaningful on cgroup v1 (which exposes the
+	// cpuset.sched_load_balance knob); v2 implementations are expected to
+	// report an unsupported error so callers can decide whether to short-circuit.
+	ApplySchedLoadBalance(absCgroupPath string, enabled bool) error
 	ApplyNetCls(absCgroupPath string, data *common.NetClsData) error
 	ApplyIOCostQoS(absCgroupPath string, devID string, data *common.IOCostQoSData) error
 	ApplyIOCostModel(absCgroupPath string, devID string, data *common.IOCostModelData) error

--- a/pkg/util/cgroup/manager/v1/fs_linux.go
+++ b/pkg/util/cgroup/manager/v1/fs_linux.go
@@ -193,6 +193,24 @@ func (m *manager) ApplyCPUSetPartition(_ string, _ common.CPUSetPartitionFlag) e
 	return fmt.Errorf("cgroupv1 does not support cpuset partition feature")
 }
 
+// ApplySchedLoadBalance writes cpuset.sched_load_balance under absCgroupPath.
+// The flag toggles whether the kernel scheduler performs load balancing over
+// the cpuset; a zero value opts a cgroup out of balancing so that pinned tasks
+// stay on the CPUs assigned to it.
+func (m *manager) ApplySchedLoadBalance(absCgroupPath string, enabled bool) error {
+	value := "0"
+	if enabled {
+		value = "1"
+	}
+	if err, applied, oldData := common.InstrumentedWriteFileIfChange(absCgroupPath, "cpuset.sched_load_balance", value); err != nil {
+		return err
+	} else if applied {
+		klog.Infof("[CgroupV1] apply cpuset.sched_load_balance successfully, cgroupPath: %s, data: %v, old data: %v\n",
+			absCgroupPath, value, oldData)
+	}
+	return nil
+}
+
 func (m *manager) ApplyNetCls(absCgroupPath string, data *common.NetClsData) error {
 	if data.ClassID != 0 {
 		classID := fmt.Sprintf("%d", data.ClassID)

--- a/pkg/util/cgroup/manager/v1/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v1/fs_unsupported.go
@@ -48,6 +48,10 @@ func (m *unsupportedManager) ApplyCPUSetPartition(_ string, _ common.CPUSetParti
 	return fmt.Errorf("unsupported manager v1")
 }
 
+func (m *unsupportedManager) ApplySchedLoadBalance(_ string, _ bool) error {
+	return fmt.Errorf("unsupported manager v1: %w", common.ErrNotSupported)
+}
+
 func (m *unsupportedManager) ApplyNetCls(_ string, _ *common.NetClsData) error {
 	return fmt.Errorf("unsupported manager v1")
 }

--- a/pkg/util/cgroup/manager/v2/fs_linux.go
+++ b/pkg/util/cgroup/manager/v2/fs_linux.go
@@ -215,6 +215,13 @@ func (m *manager) ApplyCPUSetPartition(absCgroupPath string, partitionFlag commo
 	return nil
 }
 
+// ApplySchedLoadBalance is a no-op on cgroup v2: the unified hierarchy removed
+// the cpuset.sched_load_balance knob in favor of the partition mechanism.
+// Callers that need equivalent semantics on v2 should use ApplyCPUSetPartition.
+func (m *manager) ApplySchedLoadBalance(_ string, _ bool) error {
+	return fmt.Errorf("cpuset.sched_load_balance: %w on cgroup v2", common.ErrNotSupported)
+}
+
 func (m *manager) ApplyNetCls(_ string, _ *common.NetClsData) error {
 	return errors.New("cgroups v2 does not support net_cls cgroup, please use eBPF via external manager")
 }

--- a/pkg/util/cgroup/manager/v2/fs_unsupported.go
+++ b/pkg/util/cgroup/manager/v2/fs_unsupported.go
@@ -48,6 +48,10 @@ func (m *unsupportedManager) ApplyCPUSetPartition(_ string, _ common.CPUSetParti
 	return fmt.Errorf("unsupported manager v2")
 }
 
+func (m *unsupportedManager) ApplySchedLoadBalance(_ string, _ bool) error {
+	return fmt.Errorf("unsupported manager v2: %w", common.ErrNotSupported)
+}
+
 func (m *unsupportedManager) ApplyNetCls(_ string, _ *common.NetClsData) error {
 	return fmt.Errorf("unsupported manager v2")
 }

--- a/pkg/util/fs/fs.go
+++ b/pkg/util/fs/fs.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fs provides small filesystem helpers that can be replaced by fakes in tests.
+package fs
+
+import (
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"strings"
+)
+
+// FS provides the filesystem operations required by util helpers.
+type FS interface {
+	// ReadFile returns the raw bytes at path.
+	ReadFile(path string) ([]byte, error)
+	// WriteFile writes b to path with mode.
+	WriteFile(path string, b []byte, mode os.FileMode) error
+	// Exists reports whether path exists.
+	Exists(path string) bool
+	// ReadDir returns the direct children of dir.
+	ReadDir(dir string) ([]iofs.DirEntry, error)
+}
+
+// OSFS implements FS using the local operating system filesystem.
+type OSFS struct{}
+
+// NewOSFS returns an FS backed by the local operating system filesystem.
+func NewOSFS() FS {
+	return OSFS{}
+}
+
+// ReadFile reads file content from path.
+func (OSFS) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+// WriteFile writes b to path with mode.
+func (OSFS) WriteFile(path string, b []byte, mode os.FileMode) error {
+	return os.WriteFile(path, b, mode)
+}
+
+// Exists reports whether path exists.
+func (OSFS) Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// ReadDir returns the direct children of dir.
+func (OSFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
+	return os.ReadDir(dir)
+}
+
+// WriteStringIfChanged writes s to path only if the current content differs.
+func WriteStringIfChanged(f FS, path string, s string, mode os.FileMode) (bool, error) {
+	if cur, err := f.ReadFile(path); err == nil {
+		if strings.TrimRight(string(cur), "\n") == strings.TrimRight(s, "\n") {
+			return false, nil
+		}
+	}
+	if err := f.WriteFile(path, []byte(s), mode); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	return true, nil
+}

--- a/pkg/util/fs/fs_test.go
+++ b/pkg/util/fs/fs_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fs
+
+import (
+	"errors"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeFS struct {
+	files    map[string][]byte
+	readErr  map[string]error
+	writeErr map[string]error
+	writes   []fakeWrite
+}
+
+type fakeWrite struct {
+	path string
+	data string
+	mode os.FileMode
+}
+
+func newFakeFS() *fakeFS {
+	return &fakeFS{
+		files:    map[string][]byte{},
+		readErr:  map[string]error{},
+		writeErr: map[string]error{},
+	}
+}
+
+func (f *fakeFS) ReadFile(path string) ([]byte, error) {
+	if err, ok := f.readErr[path]; ok {
+		return nil, err
+	}
+	b, ok := f.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), b...), nil
+}
+
+func (f *fakeFS) WriteFile(path string, b []byte, mode os.FileMode) error {
+	if err, ok := f.writeErr[path]; ok {
+		return err
+	}
+	f.files[path] = append([]byte(nil), b...)
+	f.writes = append(f.writes, fakeWrite{
+		path: path,
+		data: string(b),
+		mode: mode,
+	})
+	return nil
+}
+
+func (f *fakeFS) Exists(path string) bool {
+	_, ok := f.files[path]
+	return ok
+}
+
+func (f *fakeFS) ReadDir(string) ([]iofs.DirEntry, error) {
+	return nil, errors.New("unsupported")
+}
+
+var _ FS = (*fakeFS)(nil)
+
+func TestWriteStringIfChanged_Table(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		current    string
+		readErr    error
+		writeErr   error
+		want       string
+		wantChange bool
+		wantErr    bool
+		wantWrites int
+	}{
+		{
+			name:       "unchanged after trimming trailing newlines",
+			current:    "hello\n",
+			want:       "hello",
+			wantChange: false,
+			wantWrites: 0,
+		},
+		{
+			name:       "different content writes",
+			current:    "hello\n",
+			want:       "world",
+			wantChange: true,
+			wantWrites: 1,
+		},
+		{
+			name:       "read error still writes",
+			readErr:    os.ErrNotExist,
+			want:       "created",
+			wantChange: true,
+			wantWrites: 1,
+		},
+		{
+			name:       "write error returns context",
+			readErr:    os.ErrNotExist,
+			writeErr:   errors.New("denied"),
+			want:       "created",
+			wantChange: false,
+			wantErr:    true,
+			wantWrites: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const path = "/tmp/value"
+			fsys := newFakeFS()
+			if tt.current != "" {
+				fsys.files[path] = []byte(tt.current)
+			}
+			if tt.readErr != nil {
+				fsys.readErr[path] = tt.readErr
+			}
+			if tt.writeErr != nil {
+				fsys.writeErr[path] = tt.writeErr
+			}
+
+			changed, err := WriteStringIfChanged(fsys, path, tt.want, 0o644)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("WriteStringIfChanged() error = nil, want non-nil")
+				}
+				if !strings.Contains(err.Error(), path) {
+					t.Fatalf("error %q must include path %q", err.Error(), path)
+				}
+			} else if err != nil {
+				t.Fatalf("WriteStringIfChanged() error = %v", err)
+			}
+			if changed != tt.wantChange {
+				t.Fatalf("changed = %v, want %v", changed, tt.wantChange)
+			}
+			if len(fsys.writes) != tt.wantWrites {
+				t.Fatalf("writes = %d, want %d", len(fsys.writes), tt.wantWrites)
+			}
+			if tt.wantWrites > 0 {
+				got := fsys.writes[0]
+				if got.data != tt.want || got.mode != 0o644 {
+					t.Fatalf("write = %+v, want data=%q mode=%#o", got, tt.want, 0o644)
+				}
+			}
+		})
+	}
+}
+
+func TestOSFS_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	fsys := NewOSFS()
+	path := filepath.Join(dir, "hello.txt")
+
+	if fsys.Exists(path) {
+		t.Fatalf("Exists(%q) = true, want false", path)
+	}
+	if err := fsys.WriteFile(path, []byte("hi"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !fsys.Exists(path) {
+		t.Fatalf("Exists(%q) = false, want true", path)
+	}
+	b, err := fsys.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(b) != "hi" {
+		t.Fatalf("ReadFile = %q, want %q", string(b), "hi")
+	}
+	entries, err := fsys.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "hello.txt" {
+		t.Fatalf("ReadDir = %v, want [hello.txt]", entries)
+	}
+}

--- a/pkg/util/procfs/common/proc_reader.go
+++ b/pkg/util/procfs/common/proc_reader.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	utilfs "github.com/kubewharf/katalyst-core/pkg/util/fs"
+)
+
+// ProcInfo is a coarse snapshot of one PID's classification.
+type ProcInfo struct {
+	PID       int
+	Comm      string
+	IsKThread bool
+	PPID      int
+}
+
+// ProcReader enumerates and classifies processes from a procfs mount.
+type ProcReader interface {
+	// ListPIDs returns the set of numeric PIDs currently present.
+	ListPIDs() ([]int, error)
+	// ReadProc returns a ProcInfo for pid.
+	ReadProc(pid int) (ProcInfo, error)
+	// SchedSetaffinity pins pid to cpus via the sched_setaffinity(2) syscall.
+	SchedSetaffinity(pid int, cpus []int) error
+}
+
+type osProcReader struct {
+	fs       utilfs.FS
+	procRoot string
+}
+
+// NewProcReader returns a ProcReader rooted at procRoot.
+func NewProcReader(fs utilfs.FS, procRoot string) ProcReader {
+	return &osProcReader{fs: fs, procRoot: procRoot}
+}
+
+func (p *osProcReader) ListPIDs() ([]int, error) {
+	entries, err := p.fs.ReadDir(p.procRoot)
+	if err != nil {
+		return nil, fmt.Errorf("readdir %s: %w", p.procRoot, err)
+	}
+
+	out := make([]int, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		out = append(out, pid)
+	}
+	return out, nil
+}
+
+func (p *osProcReader) ReadProc(pid int) (ProcInfo, error) {
+	base := filepath.Join(p.procRoot, strconv.Itoa(pid))
+	comm, err := p.fs.ReadFile(filepath.Join(base, "comm"))
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("read comm: %w", err)
+	}
+	stat, err := p.fs.ReadFile(filepath.Join(base, "stat"))
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("read stat: %w", err)
+	}
+	ppid, err := parsePPIDFromStat(stat)
+	if err != nil {
+		return ProcInfo{}, fmt.Errorf("parse stat for pid %d: %w", pid, err)
+	}
+
+	return ProcInfo{
+		PID:       pid,
+		Comm:      strings.TrimSpace(string(comm)),
+		PPID:      ppid,
+		IsKThread: pid == 2 || ppid == 2,
+	}, nil
+}
+
+func (p *osProcReader) SchedSetaffinity(pid int, cpus []int) error {
+	if pid <= 0 {
+		return fmt.Errorf("sched_setaffinity: invalid pid %d", pid)
+	}
+	if len(cpus) == 0 {
+		return fmt.Errorf("sched_setaffinity: refusing to pin pid %d to empty cpuset", pid)
+	}
+	return schedSetaffinity(pid, cpus)
+}
+
+func parsePPIDFromStat(stat []byte) (int, error) {
+	s := string(stat)
+	rp := strings.LastIndexByte(s, ')')
+	if rp < 0 || rp+2 >= len(s) {
+		return 0, fmt.Errorf("invalid stat: missing closing paren or truncated tail")
+	}
+	rest := strings.Fields(s[rp+2:])
+	if len(rest) < 2 {
+		return 0, fmt.Errorf("invalid stat: only %d fields after paren, want >=2", len(rest))
+	}
+	ppid, err := strconv.Atoi(rest[1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid stat ppid %q: %w", rest[1], err)
+	}
+	return ppid, nil
+}

--- a/pkg/util/procfs/common/proc_reader_linux.go
+++ b/pkg/util/procfs/common/proc_reader_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func schedSetaffinity(pid int, cpus []int) error {
+	var set unix.CPUSet
+	set.Zero()
+	for _, c := range cpus {
+		if c < 0 || c >= 1024 {
+			return fmt.Errorf("sched_setaffinity: cpu index %d out of range [0,1024)", c)
+		}
+		set.Set(c)
+	}
+	if err := unix.SchedSetaffinity(pid, &set); err != nil {
+		return fmt.Errorf("sched_setaffinity(pid=%d): %w", pid, err)
+	}
+	return nil
+}

--- a/pkg/util/procfs/common/proc_reader_other.go
+++ b/pkg/util/procfs/common/proc_reader_other.go
@@ -1,0 +1,26 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "fmt"
+
+func schedSetaffinity(pid int, cpus []int) error {
+	return fmt.Errorf("sched_setaffinity is not supported on this platform (pid=%d, cpus=%v)", pid, cpus)
+}

--- a/pkg/util/procfs/common/proc_reader_test.go
+++ b/pkg/util/procfs/common/proc_reader_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"errors"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	utilfs "github.com/kubewharf/katalyst-core/pkg/util/fs"
+)
+
+type procfsFakeFS struct {
+	files   map[string][]byte
+	dirs    map[string][]iofs.DirEntry
+	readErr map[string]error
+}
+
+func newProcfsFakeFS() *procfsFakeFS {
+	return &procfsFakeFS{
+		files:   map[string][]byte{},
+		dirs:    map[string][]iofs.DirEntry{},
+		readErr: map[string]error{},
+	}
+}
+
+func (f *procfsFakeFS) ReadFile(path string) ([]byte, error) {
+	if err, ok := f.readErr[path]; ok {
+		return nil, err
+	}
+	b, ok := f.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte(nil), b...), nil
+}
+
+func (f *procfsFakeFS) WriteFile(path string, b []byte, _ os.FileMode) error {
+	f.files[path] = append([]byte(nil), b...)
+	return nil
+}
+
+func (f *procfsFakeFS) Exists(path string) bool {
+	_, ok := f.files[path]
+	return ok
+}
+
+func (f *procfsFakeFS) ReadDir(dir string) ([]iofs.DirEntry, error) {
+	if err, ok := f.readErr[dir]; ok {
+		return nil, err
+	}
+	entries, ok := f.dirs[dir]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return entries, nil
+}
+
+var _ utilfs.FS = (*procfsFakeFS)(nil)
+
+type fakeDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (e fakeDirEntry) Name() string                 { return e.name }
+func (e fakeDirEntry) IsDir() bool                  { return e.dir }
+func (e fakeDirEntry) Type() iofs.FileMode          { return 0 }
+func (e fakeDirEntry) Info() (iofs.FileInfo, error) { return nil, errors.New("unsupported") }
+
+func TestParsePPIDFromStat_Table(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		stat    string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "normal init line",
+			stat: "1 (systemd) S 0 1 1 0 -1 4194560 12345",
+			want: 0,
+		},
+		{
+			name: "kthreadd child",
+			stat: "42 (kworker/u8:1) I 2 0 0 0 -1 69238880 0",
+			want: 2,
+		},
+		{
+			name: "comm with spaces and parens",
+			stat: "17 (weird ) name)) S 1 17 17 0 -1 4194304 0",
+			want: 1,
+		},
+		{
+			name:    "missing closing paren",
+			stat:    "17 systemd S 1 17 17",
+			wantErr: true,
+		},
+		{
+			name:    "truncated after paren",
+			stat:    "17 (systemd)",
+			wantErr: true,
+		},
+		{
+			name:    "too few fields",
+			stat:    "17 (systemd) S",
+			wantErr: true,
+		},
+		{
+			name:    "ppid not numeric",
+			stat:    "17 (systemd) S bogus 17 17",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePPIDFromStat([]byte(tt.stat))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parsePPIDFromStat(%q) = (%d,nil), want error", tt.stat, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePPIDFromStat(%q): %v", tt.stat, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parsePPIDFromStat(%q) = %d, want %d", tt.stat, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOSProcReader_ListPIDsFiltersNonNumericDirs(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.dirs["/proc"] = []iofs.DirEntry{
+		fakeDirEntry{name: "1", dir: true},
+		fakeDirEntry{name: "42", dir: true},
+		fakeDirEntry{name: "self", dir: true},
+		fakeDirEntry{name: "sys", dir: true},
+		fakeDirEntry{name: "0", dir: true},
+		fakeDirEntry{name: "kmsg", dir: false},
+	}
+
+	pids, err := NewProcReader(f, "/proc").ListPIDs()
+	if err != nil {
+		t.Fatalf("ListPIDs: %v", err)
+	}
+
+	got := map[int]bool{}
+	for _, pid := range pids {
+		got[pid] = true
+	}
+	if !got[1] || !got[42] {
+		t.Fatalf("ListPIDs must include real pids; got %v", pids)
+	}
+	if len(pids) != 2 {
+		t.Fatalf("ListPIDs must skip non-pid entries; got %v", pids)
+	}
+}
+
+func TestOSProcReader_ListPIDsPropagatesReadDirError(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.readErr["/proc"] = errors.New("permission denied")
+
+	if _, err := NewProcReader(f, "/proc").ListPIDs(); err == nil {
+		t.Fatalf("ListPIDs must propagate ReadDir error")
+	}
+}
+
+func TestOSProcReader_ReadProc_ClassifiesKernelThread(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/42/comm"] = []byte("kworker/u8:1\n")
+	f.files["/proc/42/stat"] = []byte("42 (kworker/u8:1) I 2 0 0 0 -1 69238880 0")
+
+	info, err := NewProcReader(f, "/proc").ReadProc(42)
+	if err != nil {
+		t.Fatalf("ReadProc: %v", err)
+	}
+	if info.PID != 42 || info.PPID != 2 || !info.IsKThread {
+		t.Fatalf("ReadProc = %+v, want PID=42 PPID=2 IsKThread=true", info)
+	}
+	if info.Comm != "kworker/u8:1" {
+		t.Fatalf("Comm = %q, want %q", info.Comm, "kworker/u8:1")
+	}
+}
+
+func TestOSProcReader_ReadProc_ClassifiesKthreaddItself(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/2/comm"] = []byte("kthreadd\n")
+	f.files["/proc/2/stat"] = []byte("2 (kthreadd) S 0 0 0 0 -1 4194560 0")
+
+	info, err := NewProcReader(f, "/proc").ReadProc(2)
+	if err != nil {
+		t.Fatalf("ReadProc: %v", err)
+	}
+	if !info.IsKThread {
+		t.Fatalf("pid 2 must be classified as kthread: %+v", info)
+	}
+}
+
+func TestOSProcReader_ReadProc_ClassifiesUserspace(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/1000/comm"] = []byte("bash\n")
+	f.files["/proc/1000/stat"] = []byte("1000 (bash) S 999 1000 1000 0 -1 4194304 0")
+
+	info, err := NewProcReader(f, "/proc").ReadProc(1000)
+	if err != nil {
+		t.Fatalf("ReadProc: %v", err)
+	}
+	if info.IsKThread {
+		t.Fatalf("userspace PID must not be classified as kthread: %+v", info)
+	}
+	if info.PPID != 999 {
+		t.Fatalf("PPID = %d, want 999", info.PPID)
+	}
+}
+
+func TestOSProcReader_ReadProc_MissingCommOrStat(t *testing.T) {
+	t.Parallel()
+
+	fMissingComm := newProcfsFakeFS()
+	fMissingComm.files["/proc/7/stat"] = []byte("7 (foo) S 1 7 7 0 -1 4194304 0")
+	if _, err := NewProcReader(fMissingComm, "/proc").ReadProc(7); err == nil {
+		t.Fatalf("ReadProc must fail when comm is missing")
+	}
+
+	fMissingStat := newProcfsFakeFS()
+	fMissingStat.files["/proc/7/comm"] = []byte("foo\n")
+	if _, err := NewProcReader(fMissingStat, "/proc").ReadProc(7); err == nil {
+		t.Fatalf("ReadProc must fail when stat is missing")
+	}
+}
+
+func TestOSProcReader_ReadProc_MalformedStat(t *testing.T) {
+	t.Parallel()
+
+	f := newProcfsFakeFS()
+	f.files["/proc/8/comm"] = []byte("x\n")
+	f.files["/proc/8/stat"] = []byte("no-parens-and-not-enough-fields")
+
+	_, err := NewProcReader(f, "/proc").ReadProc(8)
+	if err == nil {
+		t.Fatalf("ReadProc must fail on malformed stat")
+	}
+	if !strings.Contains(err.Error(), "parse stat") {
+		t.Fatalf("ReadProc error must wrap parse-stat context, got: %v", err)
+	}
+}
+
+func TestOSProcReader_SchedSetaffinityDefensiveGuards(t *testing.T) {
+	t.Parallel()
+
+	r := NewProcReader(newProcfsFakeFS(), "/proc")
+	if err := r.SchedSetaffinity(0, []int{1}); err == nil {
+		t.Fatalf("SchedSetaffinity must reject pid<=0")
+	}
+	if err := r.SchedSetaffinity(-5, []int{1}); err == nil {
+		t.Fatalf("SchedSetaffinity must reject negative pid")
+	}
+	if err := r.SchedSetaffinity(1, nil); err == nil {
+		t.Fatalf("SchedSetaffinity must reject empty cpuset")
+	}
+	if err := r.SchedSetaffinity(1, []int{}); err == nil {
+		t.Fatalf("SchedSetaffinity must reject empty cpuset slice")
+	}
+}
+
+func TestOSProcReader_ListPIDsWithTempDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "1"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "kmsg"), []byte{}, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	pids, err := NewProcReader(utilfs.NewOSFS(), dir).ListPIDs()
+	if err != nil {
+		t.Fatalf("ListPIDs: %v", err)
+	}
+	if len(pids) != 1 || pids[0] != 1 {
+		t.Fatalf("ListPIDs = %v, want [1]", pids)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

Features / Enhancements / Refactor

#### What this PR does / why we need it:

This PR builds common core utilities and wires CPU QRM cpuset bypass support:

- add reusable filesystem helpers under `pkg/util/fs`
- add procfs reader utilities under `pkg/util/procfs/common`
- add a cgroup client facade with write-if-change caching under `pkg/util/cgroup/client`
- add cgroup manager support for `cpuset.sched_load_balance`
- add readonly CPU dynamic-policy state snapshot support
- add `EnableBypassCPUSetAdjustment` so QRM can clear cpuset strings in allocation responses for `shared_cores`, `reclaimed_cores`, and `system_cores`, while keeping `dedicated_cores` unchanged

The bypass only changes the cpuset string returned to kubelet. It preserves allocation state, allocated quantity, topology assignments, resource hints, and annotations.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Validation performed:

- `git diff --check kubewharf/main...HEAD`
- `gofumpt -l` on changed cmd/pkg directories
- `go test -count=1 ./pkg/util/fs/... ./pkg/util/procfs/common/... ./pkg/util/cgroup/client/... ./pkg/util/cgroup/manager/...`
- `go test -count=1 ./pkg/agent/qrm-plugins/cpu/dynamicpolicy/state ./pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage ./pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold ./pkg/agent/qrm-plugins/cpu/dynamicpolicy`
- `go vet` on changed util, cgroup, CPU dynamicpolicy, config, and option packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CPU plugin option/CLI flag to bypass cpuset adjustment for shared, reclaimed, and system QoS levels.
  * Added cached cgroup write optimizations and support for updating `sched_load_balance` (with graceful handling when unsupported).
  * Introduced helper utilities for filesystem and procfs process reading.
* **Bug Fixes**
  * Correctly preserves or clears CPUSet backfill results per QoS when bypass is enabled.
  * Improved dynamic policy state snapshot consistency for concurrent access.
* **Tests**
  * Added/updated unit tests covering CPU bypass behavior, state snapshots, cgroup caching, and procfs parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->