### PR TITLE
feat(cpu): add metrics for cpu weight and system exclusive pool

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuweight/manager.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuweight/manager.go
@@ -29,9 +29,11 @@ import (
 	resourceutil "k8s.io/kubernetes/pkg/api/v1/resource"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/finegrainedresource"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
 	cgroupmgr "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
@@ -43,6 +45,9 @@ const (
 	minCPUShares   = 2
 	sharesPerCPU   = 1024
 	milliCPUPerCPU = 1000
+
+	ruleTypeRestore  = "restore"
+	ruleTypeOverride = "override"
 )
 
 type Manager interface {
@@ -51,6 +56,7 @@ type Manager interface {
 
 type managerImpl struct {
 	metaServer *metaserver.MetaServer
+	emitter    metrics.MetricEmitter
 }
 
 var (
@@ -60,16 +66,17 @@ var (
 	BurstRatioAnnotationKey  = consts.PodAnnotationCPUWeightBurstRatioKey
 )
 
-func GetManager(metaServer *metaserver.MetaServer) Manager {
+func GetManager(metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter) Manager {
 	once.Do(func() {
-		instance = newManager(metaServer)
+		instance = newManager(metaServer, emitter)
 	})
 	return instance
 }
 
-func newManager(metaServer *metaserver.MetaServer) *managerImpl {
+func newManager(metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter) *managerImpl {
 	return &managerImpl{
 		metaServer: metaServer,
+		emitter:    emitter,
 	}
 }
 
@@ -77,6 +84,7 @@ func (m *managerImpl) UpdateCPUWeight(dynamicConfig *dynamic.DynamicAgentConfigu
 	if dynamicConfig == nil {
 		return nil
 	}
+
 	dynamicConf := dynamicConfig.GetDynamicConfiguration()
 	if dynamicConf == nil || dynamicConf.AdminQoSConfiguration == nil ||
 		dynamicConf.AdminQoSConfiguration.FineGrainedResourceConfiguration == nil {
@@ -112,32 +120,31 @@ func (m *managerImpl) processRestoreRule(rule finegrainedresource.CPUWeightResto
 	if err != nil {
 		return fmt.Errorf("failed to parse pod selector: %w", err)
 	}
-	pods, err := m.metaServer.GetPodList(context.Background(), func(pod *v1.Pod) bool {
+	matchedPods, err := m.metaServer.GetPodList(context.Background(), func(pod *v1.Pod) bool {
 		return podSelector.Matches(labels.Set(pod.Labels)) && native.PodIsActive(pod)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get pods: %w", err)
 	}
-	if len(pods) == 0 {
-		return nil
-	}
 
 	var errList []error
-	for _, pod := range pods {
-		cpuRequests := m.getPodOriginalCPURequests(pod)
-		cpuShares := milliCPUToShares(cpuRequests)
+	for _, matchedPod := range matchedPods {
+		podCPURequestMilli := m.getPodOriginalCPURequests(matchedPod)
+		targetShares := milliCPUToShares(podCPURequestMilli)
 
-		absCgroupPath, err := common.GetPodAbsCgroupPath(common.CgroupSubsysCPU, string(pod.UID))
+		absCgroupPath, err := common.GetPodAbsCgroupPath(common.CgroupSubsysCPU, string(matchedPod.UID))
 		if err != nil {
-			errList = append(errList, fmt.Errorf("failed to get the absolute path of pod %s: %w", pod.Name, err))
+			errList = append(errList, fmt.Errorf("failed to get the absolute path of pod %s: %w", matchedPod.Name, err))
 			continue
 		}
 
-		cpuData := &common.CPUData{Shares: cpuShares}
+		cpuData := &common.CPUData{Shares: targetShares}
 		if err := cgroupmgr.ApplyCPUWithAbsolutePath(absCgroupPath, cpuData); err != nil {
-			errList = append(errList, fmt.Errorf("failed to apply cpu weight for pod %s: %w", pod.Name, err))
+			errList = append(errList, fmt.Errorf("failed to apply cpu weight for pod %s: %w", matchedPod.Name, err))
 			continue
 		}
+
+		m.emitCPUWeightSucceededShares(ruleTypeRestore, rule.Name, matchedPod.Name, int64(targetShares))
 	}
 
 	return utilerrors.NewAggregate(errList)
@@ -151,35 +158,44 @@ func (m *managerImpl) processOverrideRule(rule finegrainedresource.CPUWeightOver
 	if err != nil {
 		return fmt.Errorf("failed to parse pod selector: %w", err)
 	}
-	pods, err := m.metaServer.GetPodList(context.Background(), func(pod *v1.Pod) bool {
+	matchedPods, err := m.metaServer.GetPodList(context.Background(), func(pod *v1.Pod) bool {
 		return podSelector.Matches(labels.Set(pod.Labels)) && native.PodIsActive(pod)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to get pods: %w", err)
 	}
-	if len(pods) == 0 {
-		return nil
-	}
-
-	cpuRequests := rule.PodCPUDemand * milliCPUPerCPU
-	cpuShares := milliCPUToShares(cpuRequests)
+	targetMilliCPU := rule.PodCPUDemand * milliCPUPerCPU
+	targetShares := milliCPUToShares(targetMilliCPU)
 
 	var errList []error
-	for _, pod := range pods {
-		absCgroupPath, err := common.GetPodAbsCgroupPath(common.CgroupSubsysCPU, string(pod.UID))
+	for _, matchedPod := range matchedPods {
+		absCgroupPath, err := common.GetPodAbsCgroupPath(common.CgroupSubsysCPU, string(matchedPod.UID))
 		if err != nil {
-			errList = append(errList, fmt.Errorf("failed to get the absolute path of pod %s: %w", pod.Name, err))
+			errList = append(errList, fmt.Errorf("failed to get the absolute path of pod %s: %w", matchedPod.Name, err))
 			continue
 		}
 
-		cpuData := &common.CPUData{Shares: cpuShares}
+		cpuData := &common.CPUData{Shares: targetShares}
 		if err := cgroupmgr.ApplyCPUWithAbsolutePath(absCgroupPath, cpuData); err != nil {
-			errList = append(errList, fmt.Errorf("failed to apply cpu weight for pod %s: %w", pod.Name, err))
+			errList = append(errList, fmt.Errorf("failed to apply cpu weight for pod %s: %w", matchedPod.Name, err))
 			continue
 		}
+
+		m.emitCPUWeightSucceededShares(ruleTypeOverride, rule.Name, matchedPod.Name, int64(targetShares))
 	}
 
 	return utilerrors.NewAggregate(errList)
+}
+
+func (m *managerImpl) emitCPUWeightSucceededShares(ruleType, ruleName, podName string, value int64) {
+	if m.emitter == nil {
+		return
+	}
+
+	_ = m.emitter.StoreInt64(util.MetricNameCPUWeightSucceedShares, value, metrics.MetricTypeNameRaw,
+		metrics.MetricTag{Key: "rule_type", Val: ruleType},
+		metrics.MetricTag{Key: "rule_name", Val: ruleName},
+		metrics.MetricTag{Key: "rule_pod", Val: podName})
 }
 
 func (m *managerImpl) getPodOriginalCPURequests(pod *v1.Pod) int64 {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuweight/manager_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuweight/manager_test.go
@@ -29,11 +29,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/finegrainedresource"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/cgroup/common"
 	cgroupmgr "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
 )
@@ -63,6 +65,55 @@ func (e *errPodFetcher) GetPodList(_ context.Context, _ func(*v1.Pod) bool) ([]*
 	return e.PodFetcherStub.GetPodList(context.Background(), nil)
 }
 
+type metricRecord struct {
+	name string
+	val  int64
+	tags map[string]string
+}
+
+type recordingEmitter struct {
+	records []metricRecord
+}
+
+func (r *recordingEmitter) StoreInt64(name string, val int64, _ metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	record := metricRecord{name: name, val: val, tags: map[string]string{}}
+	for _, tag := range tags {
+		record.tags[tag.Key] = tag.Val
+	}
+	r.records = append(r.records, record)
+	return nil
+}
+
+func (r *recordingEmitter) StoreFloat64(_ string, _ float64, _ metrics.MetricTypeName, _ ...metrics.MetricTag) error {
+	return nil
+}
+
+func (r *recordingEmitter) WithTags(_ string, _ ...metrics.MetricTag) metrics.MetricEmitter {
+	return r
+}
+
+func (r *recordingEmitter) Run(_ context.Context) {}
+
+func assertMetricRecord(t *testing.T, records []metricRecord, name string, value int64, tags map[string]string) {
+	t.Helper()
+	for _, record := range records {
+		if record.name == name && record.val == value && assert.ObjectsAreEqual(tags, record.tags) {
+			return
+		}
+	}
+	assert.Failf(t, "metric not found", "missing metric %s=%d with tags %+v in records %+v", name, value, tags, records)
+}
+
+func assertNoMetricRecord(t *testing.T, records []metricRecord, name string, tags map[string]string) {
+	t.Helper()
+	for _, record := range records {
+		if record.name == name && assert.ObjectsAreEqual(tags, record.tags) {
+			assert.Failf(t, "unexpected metric found", "unexpected metric %s with tags %+v in records %+v", name, tags, records)
+			return
+		}
+	}
+}
+
 func TestManager_GetManager(t *testing.T) {
 	t.Parallel()
 
@@ -76,8 +127,8 @@ func TestManager_GetManager(t *testing.T) {
 	metaServer1 := generateTestMetaServer(nil)
 	metaServer2 := generateTestMetaServer(nil)
 
-	manager1 := GetManager(metaServer1)
-	manager2 := GetManager(metaServer2)
+	manager1 := GetManager(metaServer1, nil)
+	manager2 := GetManager(metaServer2, nil)
 
 	assert.Same(t, manager1, manager2)
 	assert.Same(t, metaServer1, manager1.(*managerImpl).metaServer)
@@ -91,7 +142,7 @@ func TestManager_newManager(t *testing.T) {
 	}
 
 	metaServer := generateTestMetaServerWithPodFetcher(podFetcher)
-	manager := newManager(metaServer)
+	manager := newManager(metaServer, nil)
 
 	assert.NotNil(t, manager)
 	assert.Same(t, metaServer, manager.metaServer)
@@ -142,6 +193,9 @@ func TestManager_UpdateCPUWeight(t *testing.T) {
 		expectErrContains []string
 		mockPathErr       error
 		mockApplyErr      error
+		mockApplyErrs     []error
+		expectMetrics     []metricRecord
+		expectNoMetrics   []metricRecord
 	}{
 		{
 			name:         "nil cpu weight config",
@@ -282,6 +336,13 @@ func TestManager_UpdateCPUWeight(t *testing.T) {
 				},
 			}),
 			expectShares: []uint64{4096},
+			expectMetrics: []metricRecord{
+				{
+					name: util.MetricNameCPUWeightSucceedShares,
+					val:  4096,
+					tags: map[string]string{"rule_type": "override", "rule_name": "override-rule", "rule_pod": "override-pod"},
+				},
+			},
 		},
 		{
 			name: "override apply error",
@@ -303,12 +364,55 @@ func TestManager_UpdateCPUWeight(t *testing.T) {
 				"failed to process override rule override-rule: failed to apply cpu weight for pod override-pod: apply failed",
 			},
 			mockApplyErr: fmt.Errorf("apply failed"),
+			expectNoMetrics: []metricRecord{
+				{
+					name: util.MetricNameCPUWeightSucceedShares,
+					tags: map[string]string{"rule_type": "override", "rule_name": "override-rule", "rule_pod": "override-pod"},
+				},
+			},
+		},
+		{
+			name: "override partial failure emits metric only for successful pod",
+			metaServer: generateTestMetaServer([]*v1.Pod{
+				generateTestPod("override-pod-1", "override-pod-1", map[string]string{"app": "override-app"}, []v1.Container{
+					{Name: "c1"},
+				}),
+				generateTestPod("override-pod-2", "override-pod-2", map[string]string{"app": "override-app"}, []v1.Container{
+					{Name: "c1"},
+				}),
+			}),
+			config: generateTestDynamicConfig(&finegrainedresource.CPUWeightConfiguration{
+				OverrideRules: []finegrainedresource.CPUWeightOverride{
+					{
+						Name:         "override-rule",
+						PodSelector:  "app=override-app",
+						PodCPUDemand: 4,
+					},
+				},
+			}),
+			expectShares:      []uint64{4096, 4096},
+			expectErrContains: []string{"failed to process override rule override-rule: failed to apply cpu weight for pod override-pod-2: apply failed"},
+			mockApplyErrs:     []error{nil, fmt.Errorf("apply failed")},
+			expectMetrics: []metricRecord{
+				{
+					name: util.MetricNameCPUWeightSucceedShares,
+					val:  4096,
+					tags: map[string]string{"rule_type": "override", "rule_name": "override-rule", "rule_pod": "override-pod-1"},
+				},
+			},
+			expectNoMetrics: []metricRecord{
+				{
+					name: util.MetricNameCPUWeightSucceedShares,
+					tags: map[string]string{"rule_type": "override", "rule_name": "override-rule", "rule_pod": "override-pod-2"},
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		mockey.PatchConvey(tt.name, t, func() {
-			manager := &managerImpl{metaServer: tt.metaServer}
+			emitter := &recordingEmitter{}
+			manager := &managerImpl{metaServer: tt.metaServer, emitter: emitter}
 			if tt.expectShares == nil && tt.expectErrContains == nil && tt.mockPathErr == nil && tt.mockApplyErr == nil {
 				assert.NoError(t, manager.UpdateCPUWeight(tt.config))
 				return
@@ -341,14 +445,27 @@ func TestManager_UpdateCPUWeight(t *testing.T) {
 				pathMock.Return(podCgroupPath, nil).Build()
 			}
 
+			applyCallCount := 0
 			mockey.Mock(cgroupmgr.ApplyCPUWithAbsolutePath).IncludeCurrentGoRoutine().To(func(_ string, cpuData *common.CPUData) error {
 				gotShares = append(gotShares, cpuData.Shares)
+				if applyCallCount < len(tt.mockApplyErrs) {
+					err := tt.mockApplyErrs[applyCallCount]
+					applyCallCount++
+					return err
+				}
+				applyCallCount++
 				return tt.mockApplyErr
 			}).Build()
 
 			runAndAssert()
 			if len(tt.expectShares) > 0 {
 				assert.Equal(t, tt.expectShares, gotShares)
+			}
+			for _, expectedMetric := range tt.expectMetrics {
+				assertMetricRecord(t, emitter.records, expectedMetric.name, expectedMetric.val, expectedMetric.tags)
+			}
+			for _, expectedMetric := range tt.expectNoMetrics {
+				assertNoMetricRecord(t, emitter.records, expectedMetric.name, expectedMetric.tags)
 			}
 		})
 	}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler.go
@@ -526,8 +526,8 @@ func (p *DynamicPolicy) syncSystemExclusivePool(_ *coreconfig.Configuration,
 
 func (p *DynamicPolicy) reconcileSystemExclusivePools() error {
 	currentPools := p.listCurrentSystemExclusivePools()
-
 	expectedPools := p.getExpectedSystemExclusivePools()
+	p.emitSystemExclusivePoolSizes(currentPools, expectedPools)
 
 	toCreate, toUpdate, toDelete := p.calculateSystemExclusivePoolChanges(currentPools, expectedPools)
 
@@ -567,6 +567,47 @@ func (p *DynamicPolicy) getExpectedSystemExclusivePools() map[string]int {
 	}
 
 	return expectedPools
+}
+
+func (p *DynamicPolicy) emitSystemExclusivePoolSizes(currentPools map[string]*state.AllocationInfo, expectedPools map[string]int) {
+	if p.emitter == nil {
+		return
+	}
+
+	poolNames := sets.NewString()
+	for poolName := range expectedPools {
+		poolNames.Insert(poolName)
+	}
+	for poolName := range currentPools {
+		poolNames.Insert(poolName)
+	}
+
+	for _, poolName := range poolNames.List() {
+		poolSize, poolStatus := getSystemExclusivePoolMetricValueAndStatus(currentPools, expectedPools, poolName)
+		_ = p.emitter.StoreInt64(util.MetricNameSystemExclusivePoolSize, poolSize, metrics.MetricTypeNameRaw,
+			metrics.MetricTag{Key: "pool_name", Val: poolName},
+			metrics.MetricTag{Key: "status", Val: poolStatus})
+	}
+}
+
+func getSystemExclusivePoolMetricValueAndStatus(currentPools map[string]*state.AllocationInfo, expectedPools map[string]int, poolName string) (int64, string) {
+	expectedSize, expectedExists := expectedPools[poolName]
+	allocationInfo, actualExists := currentPools[poolName]
+	actualSize := 0
+	if actualExists {
+		actualSize = allocationInfo.AllocationResult.Size()
+	}
+
+	switch {
+	case expectedExists && actualExists && expectedSize == actualSize:
+		return int64(actualSize), "ready"
+	case expectedExists && !actualExists:
+		return 0, "absent"
+	case !expectedExists && actualExists:
+		return int64(actualSize), "stale"
+	default:
+		return int64(actualSize), "updating"
+	}
 }
 
 // calculateSystemExclusivePoolChanges calculates the system exclusive pool changes according to the current pools and expected pools
@@ -878,6 +919,6 @@ func (p *DynamicPolicy) syncCPUWeight(_ *coreconfig.Configuration,
 		_ = general.UpdateHealthzStateByError(cpuconsts.SyncCPUWeight, err)
 	}()
 
-	cpuWeightManager := cpuweight.GetManager(p.metaServer)
+	cpuWeightManager := cpuweight.GetManager(p.metaServer, p.emitter)
 	err = cpuWeightManager.UpdateCPUWeight(p.dynamicConfig)
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler_test.go
@@ -541,3 +541,65 @@ func TestApplySystemExclusivePoolChanges(t *testing.T) {
 	assert.Equal(t, 2, poolAllocationInfo.AllocationResult.Size())
 	assert.True(t, podAllocationInfo.AllocationResult.Equals(poolAllocationInfo.AllocationResult))
 }
+
+func TestGetSystemExclusivePoolMetricValueAndStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		currentPools  map[string]*state.AllocationInfo
+		expectedPools map[string]int
+		poolName      string
+		wantValue     int64
+		wantStatus    string
+	}{
+		{
+			name: "ready",
+			currentPools: map[string]*state.AllocationInfo{
+				"system-latency": {AllocationResult: newCPUSet(0, 2)},
+			},
+			expectedPools: map[string]int{"system-latency": 2},
+			poolName:      "system-latency",
+			wantValue:     2,
+			wantStatus:    "ready",
+		},
+		{
+			name:          "absent",
+			currentPools:  map[string]*state.AllocationInfo{},
+			expectedPools: map[string]int{"system-latency": 2},
+			poolName:      "system-latency",
+			wantValue:     0,
+			wantStatus:    "absent",
+		},
+		{
+			name: "stale",
+			currentPools: map[string]*state.AllocationInfo{
+				"system-latency": {AllocationResult: newCPUSet(0, 2)},
+			},
+			expectedPools: map[string]int{},
+			poolName:      "system-latency",
+			wantValue:     2,
+			wantStatus:    "stale",
+		},
+		{
+			name: "updating",
+			currentPools: map[string]*state.AllocationInfo{
+				"system-latency": {AllocationResult: newCPUSet(0, 4)},
+			},
+			expectedPools: map[string]int{"system-latency": 2},
+			poolName:      "system-latency",
+			wantValue:     4,
+			wantStatus:    "updating",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotValue, gotStatus := getSystemExclusivePoolMetricValueAndStatus(tc.currentPools, tc.expectedPools, tc.poolName)
+			assert.Equal(t, tc.wantValue, gotValue)
+			assert.Equal(t, tc.wantStatus, gotStatus)
+		})
+	}
+}

--- a/pkg/agent/qrm-plugins/util/consts.go
+++ b/pkg/agent/qrm-plugins/util/consts.go
@@ -52,6 +52,8 @@ const (
 	MetricNameGetMemBWPreferenceFailed    = "get_mem_bw_preference_failed"
 	MetricNameGetNUMAAllocatedMemBWFailed = "get_numa_allocated_mem_bw_failed"
 	MetricNameSetExclusiveIRQCPUSize      = "set_exclusive_irq_cpu_size"
+	MetricNameCPUWeightSucceedShares      = "cpu_weight_succeed_shares"
+	MetricNameSystemExclusivePoolSize     = "system_exclusive_pool_size"
 
 	// metrics for memory plugin
 	MetricNameMemSetInvalid                           = "memset_invalid"


### PR DESCRIPTION
#### What type of PR is this?

Enhancements


#### What this PR does / why we need it:

enhance observability of cpu weight and system exclusive pools

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics for successful CPU weight rule share applications, including rule and pod details.
  * Added system-exclusive pool size metrics with status states: ready, absent, stale, and updating.
* **Bug Fixes**
  * Improved CPU weight restore/override processing to evaluate all matched pods, aggregate per-pod errors, and emit success metrics for each successfully updated pod.
* **Tests**
  * Expanded unit tests to validate CPU weight metric emission and system-exclusive pool metric value/status logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->