### PR TITLE
fix: guard NodeResourceTopology score strategies against divide-by-zero

### DIFF
--- a/pkg/scheduler/plugins/noderesourcetopology/least_allocated.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/least_allocated.go
@@ -39,6 +39,9 @@ func leastAllocatedScoreStrategy(requested, allocatable v1.ResourceList, resourc
 		weightSum += weight
 	}
 
+	if weightSum == 0 {
+		return 0
+	}
 	return score / weightSum
 }
 

--- a/pkg/scheduler/plugins/noderesourcetopology/most_allocated.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/most_allocated.go
@@ -41,6 +41,9 @@ func mostAllocatedScoreStrategy(requested, allocatable v1.ResourceList, resource
 		weightSum += weight
 	}
 
+	if weightSum == 0 {
+		return 0
+	}
 	return score / weightSum
 }
 

--- a/pkg/scheduler/plugins/noderesourcetopology/score_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/score_test.go
@@ -597,3 +597,57 @@ func TestScore(t *testing.T) {
 		}
 	}
 }
+
+// TestScoreDedicatedNumaBindingEmptyInitContainerDoesNotPanic drives the real
+// TopologyMatch.Score path (not the leaf strategy) for a dedicated_cores +
+// numa_binding pod under the dynamic resource policy. Score iterates every
+// container, init containers included, and an init container with no resource
+// requests makes weightSum == 0 in the score strategies. Before the guard this
+// divides by zero and panics the scheduler; here Score must return a valid score.
+func TestScoreDedicatedNumaBindingEmptyInitContainerDoesNotPanic(t *testing.T) {
+	pod := makePodByResourceList(&v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("2"),
+		v1.ResourceMemory: resource.MustParse("4Gi"),
+	}, map[string]string{
+		consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+		consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+	})
+	// An init container with no resource requests contributes no aligned resource.
+	pod.Spec.InitContainers = []v1.Container{{Name: "init"}}
+
+	c := cache.GetCache()
+	for _, strategy := range []config.ScoringStrategyType{config.MostAllocated, config.LeastAllocated} {
+		util.SetQoSConfig(generic.NewQoSConfiguration())
+		cnrs, nodeNames, pods := makeTestScoreNodes(v1alpha1.TopologyPolicySingleNUMANodeContainerLevel)
+		for _, cnr := range cnrs {
+			c.AddOrUpdateCNR(cnr)
+		}
+
+		nodes := make([]*v1.Node, 0)
+		for _, node := range nodeNames {
+			n := &v1.Node{}
+			n.SetName(node)
+			nodes = append(nodes, n)
+		}
+		f, err := runtime.NewFramework(nil, nil,
+			runtime.WithSnapshotSharedLister(newTestSharedLister(pods, nodes)))
+		assert.NoError(t, err)
+		tm, err := MakeTestTm(MakeTestArgs(strategy, []string{"cpu", "memory"}, "dynamic"), f)
+		assert.NoError(t, err)
+
+		for _, node := range nodeNames {
+			var score int64
+			var status *framework.Status
+			assert.NotPanics(t, func() {
+				score, status = tm.(*TopologyMatch).Score(context.TODO(), nil, pod, node)
+			}, "strategy %v node %s", strategy, node)
+			assert.True(t, status.IsSuccess(), "strategy %v node %s status %v", strategy, node, status)
+			assert.GreaterOrEqual(t, score, int64(0))
+			assert.LessOrEqual(t, score, framework.MaxNodeScore)
+		}
+
+		for _, cnr := range cnrs {
+			c.RemoveCNR(cnr)
+		}
+	}
+}

--- a/pkg/scheduler/plugins/noderesourcetopology/score_weightsum_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/score_weightsum_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesourcetopology
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestScoreStrategyWeightSumZeroDoesNotPanic verifies that the most/least
+// allocated score strategies return 0 instead of dividing by zero when no
+// requested resource contributes to weightSum. This happens when a scored
+// container has an empty resource request, or a request whose resources are
+// all outside alignedResource (both reachable for a dedicated_cores +
+// numa_binding pod under the dynamic resource plugin policy).
+func TestScoreStrategyWeightSumZeroDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	weightMap := resourceToWeightMap{}
+	tests := []struct {
+		name            string
+		requested       v1.ResourceList
+		allocatable     v1.ResourceList
+		alignedResource sets.String
+	}{
+		{
+			name:      "empty request",
+			requested: v1.ResourceList{},
+		},
+		{
+			name:            "request only has resources outside alignedResource",
+			requested:       v1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+			allocatable:     v1.ResourceList{"nvidia.com/gpu": resource.MustParse("4")},
+			alignedResource: sets.NewString(v1.ResourceCPU.String(), v1.ResourceMemory.String()),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var most, least int64
+			assert.NotPanics(t, func() {
+				most = mostAllocatedScoreStrategy(tt.requested, tt.allocatable, weightMap, tt.alignedResource)
+			})
+			assert.NotPanics(t, func() {
+				least = leastAllocatedScoreStrategy(tt.requested, tt.allocatable, weightMap, tt.alignedResource)
+			})
+			assert.Equal(t, int64(0), most)
+			assert.Equal(t, int64(0), least)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1214

### What type of PR is this?

/kind bug

### What this PR does / why we need it

`mostAllocatedScoreStrategy` and `leastAllocatedScoreStrategy` end with `return score / weightSum` without checking for zero. When a scored container contributes no aligned resource (an empty request, or a request whose resources are all outside `alignedResource`), `weightSum` is 0 and the score strategy divides by zero. Score runs in parallel workqueue workers whose panic handler logs and re-panics by default (`utilruntime.HandleCrash` with `ReallyCrash = true`), so the divide-by-zero terminates the scheduler process. A `dedicated_cores` + `numa_binding` pod with an init container that has no resource requests reaches this under the dynamic resource policy.

This adds `if weightSum == 0 { return 0 }` to both strategies, matching the existing guard in `pkg/scheduler/plugins/qosawarenoderesources/{most,least}_allocated.go`.

### Test

- `TestScoreStrategyWeightSumZeroDoesNotPanic` drives both strategies to `weightSum == 0` directly (empty request, and a request whose resources are all outside `alignedResource`).
- `TestScoreDedicatedNumaBindingEmptyInitContainerDoesNotPanic` drives the real `TopologyMatch.Score` path for a `dedicated_cores` + `numa_binding` pod with an empty-request init container under the dynamic policy, asserting each node returns a success status and a score in `[0, MaxNodeScore]`.

Both fail before the guard (the production-path test panics with `integer divide by zero` inside `TopologyMatch.Score`) and pass after. `make test` in CI excludes `pkg/scheduler`, so these were verified locally, including with the race detector:

```
go test -race ./pkg/scheduler/plugins/noderesourcetopology -count=1
```

`balanced_allocation.go` has a related edge (an empty aligned request makes `Variance([])` return `NaN`, and `int64((1-NaN)*100)` yields `MinInt64`), which is a wrong score rather than a panic and is left for a separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scheduler scoring errors when no eligible resources contribute to a score.
  * Improved handling of empty resource requests and resources excluded by alignment settings.
  * Ensured dedicated-core scheduling with empty init-container requests completes without panics.
* **Tests**
  * Added coverage confirming valid zero scores and successful scheduling results in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->