### PR TITLE
fix(cpuburst): skip updating burst when cpu quota is max

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuburst/manager.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuburst/manager.go
@@ -19,6 +19,7 @@ package cpuburst
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
@@ -169,6 +170,12 @@ func (m *managerImpl) updateCPUBurstByPercent(percent float64, pod *v1.Pod, main
 		if err != nil {
 			general.Errorf("get container cpu stats failed, pod: %s, podName: %s, container: %s(%s), err: %v", podUID, podName, containerName, containerID, err)
 			errList = append(errList, err)
+			continue
+		}
+
+		// Skip setting of cpu quota when cpu quota is max
+		if cpuStats.CpuQuota == math.MaxInt64 {
+			general.Infof("skip updating container burst for max cpu quota, pod: %s, podName: %s, container: %s(%s)", podUID, podName, containerName, containerID)
 			continue
 		}
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuburst/manager_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpuburst/manager_test.go
@@ -18,6 +18,7 @@ package cpuburst
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -709,6 +710,48 @@ func TestManagerImpl_UpdateCPUBurst(t *testing.T) {
 					return "/sys/fs/cgroup/cpu/" + podUID + "/" + containerID, nil
 				}).Build()
 				mockey.Mock(manager.GetCPUWithAbsolutePath).Return(&common.CPUStats{CpuQuota: 200}, nil).Build()
+				mockey.Mock(manager.ApplyCPUWithAbsolutePath).
+					To(func(absPath string, cpuData *common.CPUData) error {
+						s[absPath] = *cpuData.CpuBurst
+						return nil
+					}).Build()
+			},
+			wantResults: make(resultState),
+		},
+		{
+			name: "cpu quota is max means that cpu burst value is skipped",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "test-pod-1",
+						Annotations: map[string]string{
+							consts.PodAnnotationQoSLevelKey:       consts.PodAnnotationQoSLevelDedicatedCores,
+							consts.PodAnnotationCPUEnhancementKey: `{"cpu_burst_policy":"static", "cpu_burst_percent":"50"}`,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "test-container-1",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:        "test-container-1",
+								ContainerID: "test-container-1-id",
+							},
+						},
+					},
+				},
+			},
+			mocks: func(s resultState) {
+				mockey.Mock(common.IsContainerCgroupExist).Return(true, nil).Build()
+				mockey.Mock(common.GetContainerAbsCgroupPath).To(func(_, podUID, containerID string) (string, error) {
+					return "/sys/fs/cgroup/cpu/" + podUID + "/" + containerID, nil
+				}).Build()
+				mockey.Mock(manager.GetCPUWithAbsolutePath).Return(&common.CPUStats{CpuQuota: math.MaxInt64}, nil).Build()
 				mockey.Mock(manager.ApplyCPUWithAbsolutePath).
 					To(func(absPath string, cpuData *common.CPUData) error {
 						s[absPath] = *cpuData.CpuBurst


### PR DESCRIPTION
Add check to skip applying cpu burst configuration when container's cpu quota is already math.MaxInt64, and add corresponding unit test to verify this behavior

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented CPU burst settings from being applied when a container’s CPU quota is unlimited.
  * Avoided incorrect burst behavior for “max/unlimited” CPU quota configurations.

* **Tests**
  * Added test coverage to confirm CPU burst updates are skipped when the CPU quota is unlimited, ensuring no burst changes are recorded in that scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->