### PR TITLE
feat(gpu-qrm): add support for multiple weight env variables

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
@@ -38,7 +38,9 @@ type GPUOptions struct {
 	VirtualGPUVisibleDevicesEnvNames            []string
 	VirtualGPUUUIDEnvName                       string
 	VirtualGPUMemoryWeightEnvName               string
+	VirtualGPUMemoryWeightEnvNames              []string
 	VirtualGPUComputeWeightEnvName              string
+	VirtualGPUComputeWeightEnvNames             []string
 	VirtualGPUTimesliceEnvName                  string
 	VirtualGPUComputePolicyEnvName              string
 	GPUSelectionResultAnnotationKey             string
@@ -93,8 +95,18 @@ func (o *GPUOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		o.VirtualGPUUUIDEnvName, "The environment variable name for the Virtual GPU pod UID")
 	fs.StringVar(&o.VirtualGPUMemoryWeightEnvName, "virtual-gpu-memory-weight-env-name",
 		o.VirtualGPUMemoryWeightEnvName, "The environment variable name for Virtual GPU memory weight")
+	fs.StringSliceVar(&o.VirtualGPUMemoryWeightEnvNames, "virtual-gpu-memory-weight-env-names",
+		o.VirtualGPUMemoryWeightEnvNames,
+		"List of environment variable names to inject with the Virtual GPU memory weight "+
+			"('<deviceID>:<percentage>'). Every name in this list receives the same value. "+
+			"When empty, falls back to --virtual-gpu-memory-weight-env-name.")
 	fs.StringVar(&o.VirtualGPUComputeWeightEnvName, "virtual-gpu-compute-weight-env-name",
 		o.VirtualGPUComputeWeightEnvName, "The environment variable name for Virtual GPU compute weight")
+	fs.StringSliceVar(&o.VirtualGPUComputeWeightEnvNames, "virtual-gpu-compute-weight-env-names",
+		o.VirtualGPUComputeWeightEnvNames,
+		"List of environment variable names to inject with the Virtual GPU compute weight "+
+			"('<deviceID>:<percentage>'). Every name in this list receives the same value. "+
+			"When empty, falls back to --virtual-gpu-compute-weight-env-name.")
 	fs.StringVar(&o.VirtualGPUTimesliceEnvName, "virtual-gpu-timeslice-env-name",
 		o.VirtualGPUTimesliceEnvName, "The environment variable name for Virtual GPU timeslice")
 	fs.StringVar(&o.VirtualGPUComputePolicyEnvName, "virtual-gpu-compute-policy-env-name",
@@ -132,7 +144,9 @@ func (o *GPUOptions) ApplyTo(conf *qrmconfig.GPUQRMPluginConfig) error {
 	conf.VirtualGPUVisibleDevicesEnvNames = o.VirtualGPUVisibleDevicesEnvNames
 	conf.VirtualGPUUUIDEnvName = o.VirtualGPUUUIDEnvName
 	conf.VirtualGPUMemoryWeightEnvName = o.VirtualGPUMemoryWeightEnvName
+	conf.VirtualGPUMemoryWeightEnvNames = o.VirtualGPUMemoryWeightEnvNames
 	conf.VirtualGPUComputeWeightEnvName = o.VirtualGPUComputeWeightEnvName
+	conf.VirtualGPUComputeWeightEnvNames = o.VirtualGPUComputeWeightEnvNames
 	conf.VirtualGPUTimesliceEnvName = o.VirtualGPUTimesliceEnvName
 	conf.VirtualGPUComputePolicyEnvName = o.VirtualGPUComputePolicyEnvName
 	conf.VirtualGPUTimesliceEnvValue = o.VirtualGPUTimesliceEnvValue

--- a/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu.go
+++ b/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu.go
@@ -962,30 +962,51 @@ func (p *VirtualGPUPlugin) calculateEnvVariables(resName v1.ResourceName, alloca
 	return nil
 }
 
-// injectWeightEnvVariable calculates the allocated percentage of the given GPU resource and injects it as an environment variable.
-// It only applies when a single GPU device is allocated and the corresponding environment name is configured.
-func (p *VirtualGPUPlugin) injectWeightEnvVariable(envs map[string]string, resName v1.ResourceName, envName string, allocatedDevices []string, resQuantityPerGPU float64) {
-	if envName == "" || len(allocatedDevices) != 1 {
+// injectWeightEnvVariable calculates the allocated percentage of the given GPU resource and injects it as one or more
+// environment variables. The target env-var names are resolved as follows:
+//  1. If envNames is non-empty, every name in envNames receives the value.
+//  2. Otherwise, fall back to defaultEnvName (may be empty, in which case nothing is injected).
+//
+// It only applies when exactly one GPU device is allocated.
+func (p *VirtualGPUPlugin) injectWeightEnvVariable(envs map[string]string, resName v1.ResourceName, defaultEnvName string, envNames []string, allocatedDevices []string, resQuantityPerGPU float64) {
+	if len(allocatedDevices) != 1 {
 		return
 	}
 
+	targets := envNames
+	if len(targets) == 0 {
+		// Fallback to the default env name if list of env names is empty
+		if defaultEnvName == "" {
+			return
+		}
+		targets = []string{defaultEnvName}
+	}
+
 	allocatableQuantity := p.getResourceAllocatableQuantity(resName)
-	if !allocatableQuantity.IsZero() {
-		// Calculate the allocated percentage of the GPU resource (minimum 1, max 100)
-		fraction := (resQuantityPerGPU / float64(allocatableQuantity.Value())) * 100
-		envs[envName] = fmt.Sprintf("%s:%.0f", allocatedDevices[0], fraction)
+	if allocatableQuantity.IsZero() {
+		return
+	}
+
+	// Calculate the allocated percentage of the GPU resource (minimum 1, max 100)
+	fraction := (resQuantityPerGPU / float64(allocatableQuantity.Value())) * 100
+	value := fmt.Sprintf("%s:%.0f", allocatedDevices[0], fraction)
+	for _, envName := range targets {
+		if envName == "" {
+			continue
+		}
+		envs[envName] = value
 	}
 }
 
 // injectGPUMemoryEnvVariables injects the GPU memory allocation weight environment variable.
 func (p *VirtualGPUPlugin) injectGPUMemoryEnvVariables(envs map[string]string, allocatedDevices []string, resQuantityPerGPU float64) {
-	p.injectWeightEnvVariable(envs, consts.ResourceGPUMemory, p.Conf.VirtualGPUMemoryWeightEnvName, allocatedDevices, resQuantityPerGPU)
+	p.injectWeightEnvVariable(envs, consts.ResourceGPUMemory, p.Conf.VirtualGPUMemoryWeightEnvName, p.Conf.VirtualGPUMemoryWeightEnvNames, allocatedDevices, resQuantityPerGPU)
 }
 
 // injectMilliGPUEnvVariables injects the compute allocation weight, timeslice configuration, compute policy,
 // pod UID, and visible devices environment variables.
 func (p *VirtualGPUPlugin) injectMilliGPUEnvVariables(envs map[string]string, allocatedDevices []string, resQuantityPerGPU float64, podUID string) {
-	p.injectWeightEnvVariable(envs, consts.ResourceMilliGPU, p.Conf.VirtualGPUComputeWeightEnvName, allocatedDevices, resQuantityPerGPU)
+	p.injectWeightEnvVariable(envs, consts.ResourceMilliGPU, p.Conf.VirtualGPUComputeWeightEnvName, p.Conf.VirtualGPUComputeWeightEnvNames, allocatedDevices, resQuantityPerGPU)
 
 	// Inject timeslice configuration for Virtual GPU isolation if the environment name is configured
 	if p.Conf.VirtualGPUTimesliceEnvName != "" {

--- a/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu_test.go
+++ b/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu_test.go
@@ -2673,3 +2673,197 @@ func TestVirtualGPUPlugin_Allocate_DisableEnvInjectionAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestVirtualGPUPlugin_injectWeightEnvVariable(t *testing.T) {
+	t.Parallel()
+
+	basePlugin := makeTestBasePlugin(t)
+	resourcePlugin := NewVirtualGPUPlugin(basePlugin)
+	plugin, ok := resourcePlugin.(*VirtualGPUPlugin)
+	if !assert.True(t, ok) {
+		return
+	}
+
+	tests := []struct {
+		name              string
+		resName           v1.ResourceName
+		defaultEnvName    string
+		envNames          []string
+		allocatedDevices  []string
+		resQuantityPerGPU float64
+		expected          map[string]string
+	}{
+		{
+			name:              "single list entry receives value",
+			resName:           consts.ResourceGPUMemory,
+			defaultEnvName:    "LEGACY_MEM",
+			envNames:          []string{"FOO"},
+			allocatedDevices:  []string{"gpu-0"},
+			resQuantityPerGPU: 5, // 5 / 10 = 50%
+			expected:          map[string]string{"FOO": "gpu-0:50"},
+		},
+		{
+			name:              "multiple list entries all receive same value",
+			resName:           consts.ResourceMilliGPU,
+			defaultEnvName:    "LEGACY_COMP",
+			envNames:          []string{"FOO", "BAR"},
+			allocatedDevices:  []string{"gpu-0"},
+			resQuantityPerGPU: 250, // 250 / 1000 = 25%
+			expected: map[string]string{
+				"FOO": "gpu-0:25",
+				"BAR": "gpu-0:25",
+			},
+		},
+		{
+			name:              "non-empty list overrides default env name",
+			resName:           consts.ResourceGPUMemory,
+			defaultEnvName:    "LEGACY_MEM",
+			envNames:          []string{"FOO"},
+			allocatedDevices:  []string{"gpu-0"},
+			resQuantityPerGPU: 5,
+			expected:          map[string]string{"FOO": "gpu-0:50"},
+		},
+		{
+			name:              "empty list falls back to default env name",
+			resName:           consts.ResourceGPUMemory,
+			defaultEnvName:    "LEGACY_MEM",
+			envNames:          nil,
+			allocatedDevices:  []string{"gpu-0"},
+			resQuantityPerGPU: 5,
+			expected:          map[string]string{"LEGACY_MEM": "gpu-0:50"},
+		},
+		{
+			name:              "empty list and empty default injects nothing",
+			resName:           consts.ResourceGPUMemory,
+			defaultEnvName:    "",
+			envNames:          nil,
+			allocatedDevices:  []string{"gpu-0"},
+			resQuantityPerGPU: 5,
+			expected:          map[string]string{},
+		},
+		{
+			name:              "empty entries in list are skipped",
+			resName:           consts.ResourceMilliGPU,
+			defaultEnvName:    "LEGACY_COMP",
+			envNames:          []string{"FOO", "", "BAR"},
+			allocatedDevices:  []string{"gpu-0"},
+			resQuantityPerGPU: 250,
+			expected: map[string]string{
+				"FOO": "gpu-0:25",
+				"BAR": "gpu-0:25",
+			},
+		},
+		{
+			name:              "multiple allocated devices skips injection",
+			resName:           consts.ResourceGPUMemory,
+			defaultEnvName:    "LEGACY_MEM",
+			envNames:          []string{"FOO"},
+			allocatedDevices:  []string{"gpu-0", "gpu-1"},
+			resQuantityPerGPU: 5,
+			expected:          map[string]string{},
+		},
+		{
+			name:              "zero allocated devices skips injection",
+			resName:           consts.ResourceGPUMemory,
+			defaultEnvName:    "LEGACY_MEM",
+			envNames:          []string{"FOO"},
+			allocatedDevices:  nil,
+			resQuantityPerGPU: 5,
+			expected:          map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			envs := map[string]string{}
+			plugin.injectWeightEnvVariable(envs, tt.resName, tt.defaultEnvName, tt.envNames, tt.allocatedDevices, tt.resQuantityPerGPU)
+			assert.Equal(t, tt.expected, envs)
+		})
+	}
+}
+
+func TestVirtualGPUPlugin_injectMemoryAndComputeEnvNamesLists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		memoryEnvName   string
+		memoryEnvNames  []string
+		computeEnvName  string
+		computeEnvNames []string
+		expectedMemory  map[string]string
+		expectedCompute map[string]string
+	}{
+		{
+			name:            "lists take precedence and inject every entry",
+			memoryEnvName:   "LEGACY_MEM",
+			memoryEnvNames:  []string{"MEM_A", "MEM_B"},
+			computeEnvName:  "LEGACY_COMP",
+			computeEnvNames: []string{"COMP_A", "COMP_B"},
+			expectedMemory: map[string]string{
+				"MEM_A": "gpu-0:50",
+				"MEM_B": "gpu-0:50",
+			},
+			expectedCompute: map[string]string{
+				"COMP_A": "gpu-0:25",
+				"COMP_B": "gpu-0:25",
+			},
+		},
+		{
+			name:            "empty lists fall back to legacy single env names",
+			memoryEnvName:   "LEGACY_MEM",
+			memoryEnvNames:  nil,
+			computeEnvName:  "LEGACY_COMP",
+			computeEnvNames: nil,
+			expectedMemory: map[string]string{
+				"LEGACY_MEM": "gpu-0:50",
+			},
+			expectedCompute: map[string]string{
+				"LEGACY_COMP": "gpu-0:25",
+			},
+		},
+		{
+			name:            "memory uses list; compute falls back to legacy",
+			memoryEnvName:   "LEGACY_MEM",
+			memoryEnvNames:  []string{"MEM_A"},
+			computeEnvName:  "LEGACY_COMP",
+			computeEnvNames: nil,
+			expectedMemory: map[string]string{
+				"MEM_A": "gpu-0:50",
+			},
+			expectedCompute: map[string]string{
+				"LEGACY_COMP": "gpu-0:25",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			basePlugin := makeTestBasePlugin(t)
+			basePlugin.Conf.VirtualGPUMemoryWeightEnvName = tt.memoryEnvName
+			basePlugin.Conf.VirtualGPUMemoryWeightEnvNames = tt.memoryEnvNames
+			basePlugin.Conf.VirtualGPUComputeWeightEnvName = tt.computeEnvName
+			basePlugin.Conf.VirtualGPUComputeWeightEnvNames = tt.computeEnvNames
+
+			resourcePlugin := NewVirtualGPUPlugin(basePlugin)
+			plugin, ok := resourcePlugin.(*VirtualGPUPlugin)
+			if !assert.True(t, ok) {
+				return
+			}
+
+			memoryEnvs := map[string]string{}
+			plugin.injectGPUMemoryEnvVariables(memoryEnvs, []string{"gpu-0"}, 5)
+			assert.Equal(t, tt.expectedMemory, memoryEnvs)
+
+			computeEnvs := map[string]string{}
+			plugin.injectMilliGPUEnvVariables(computeEnvs, []string{"gpu-0"}, 250, "test-pod-uid")
+			assert.Equal(t, tt.expectedCompute, computeEnvs)
+		})
+	}
+}

--- a/pkg/config/agent/qrm/gpu_plugin.go
+++ b/pkg/config/agent/qrm/gpu_plugin.go
@@ -54,10 +54,18 @@ type GPUQRMPluginConfig struct {
 	// the allocated GPU memory percentage. The format will be "<deviceID>:<percentage>",
 	// where the percentage is an integer from 1 to 100.
 	VirtualGPUMemoryWeightEnvName string
+	// VirtualGPUMemoryWeightEnvNames is the list of environment variable names injected into the pod
+	// with the allocated GPU memory percentage. Every name in this list receives the same
+	// "<deviceID>:<percentage>" value. When empty, falls back to VirtualGPUMemoryWeightEnvName.
+	VirtualGPUMemoryWeightEnvNames []string
 	// VirtualGPUComputeWeightEnvName is the environment variable name injected into the pod to specify
 	// the allocated Virtual GPU compute percentage. The format will be "<deviceID>:<percentage>",
 	// where the percentage is an integer from 1 to 100.
 	VirtualGPUComputeWeightEnvName string
+	// VirtualGPUComputeWeightEnvNames is the list of environment variable names injected into the pod
+	// with the allocated Virtual GPU compute percentage. Every name in this list receives the same
+	// "<deviceID>:<percentage>" value. When empty, falls back to VirtualGPUComputeWeightEnvName.
+	VirtualGPUComputeWeightEnvNames []string
 	// VirtualGPUTimesliceEnvName is the environment variable name injected into the pod to specify
 	// the timeslice configuration for Virtual GPU isolation.
 	VirtualGPUTimesliceEnvName string


### PR DESCRIPTION
Add new list-based environment variable configuration fields for GPU memory and compute weights, allowing injection of the same weight value to multiple env vars. Update the injection logic to prefer the list over the legacy single env name, and add comprehensive tests for the new functionality.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## English

### Runtime behavior
- Virtual GPU memory and compute weights can now be injected into multiple environment variables.
- List settings take precedence over legacy single-variable settings.
- Empty list entries are ignored. Empty lists use the legacy variable name.
- Injection occurs only for single-device allocations.

### Affected components
- `katalyst-agent` GPU plugin options and `GPUQRMPluginConfig` support the new list settings.
- Virtual GPU runtime injection logic applies the same weight to each configured environment variable.
- Unit tests cover list precedence, fallback behavior, empty entries, and allocation conditions.
- A GPU topology-hints benchmark design document was added.

### Operational impact
- Existing configurations remain compatible.
- No controller, scheduler, release wiring, or dependency changes are included.

## 简体中文

### 运行时行为
- Virtual GPU memory 和 compute weight 现在可以注入多个环境变量。
- 列表配置优先于旧的单变量配置。
- 系统会忽略空列表项。列表为空时使用旧的变量名。
- 只有分配单个设备时才会执行注入。

### 受影响组件
- `katalyst-agent` GPU plugin options 和 `GPUQRMPluginConfig` 支持新的列表配置。
- Virtual GPU 运行时注入逻辑会将相同的 weight 写入每个配置的环境变量。
- Unit tests 覆盖列表优先级、回退行为、空列表项和设备分配条件。
- 新增 GPU topology-hints benchmark design document。

### 运维影响
- 现有配置保持兼容。
- 未涉及 controller、scheduler、release wiring 或 dependency 变更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->