### PR TITLE
fix(gpu): gpu topology hints consider scheduler assignment for preferred hints

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -58,9 +58,6 @@ const (
 	metricAddKubeletCheckpointAllocationsFailed = "qrm_gpu_reporter_add_kubelet_checkpoint_allocations_failed"
 	metricEnsureKubeletDevicePluginPathFailed   = "qrm_gpu_reporter_ensure_kubelet_device_plugin_path_failed"
 	metricAddGPUZoneNodesFallbackNUMA           = "qrm_gpu_reporter_add_gpu_zone_nodes_fallback_numa"
-	// fallbackNUMANodeID is used when a device has no NUMA nodes reported;
-	// the device is attached under this NUMA node so its zone is still emitted.
-	fallbackNUMANodeID = 0
 )
 
 var zeroQuantity = *resource.NewQuantity(0, resource.DecimalSI)
@@ -699,15 +696,15 @@ func (p *gpuReporterPlugin) addGPUZoneNodes(deviceTopology *machine.DeviceTopolo
 		deviceNode := util.GenerateDeviceZoneNode(id, string(nodev1alpha1.TopologyTypeGPU))
 
 		numaNodes := device.NumaNodes
-		// If a device has no NUMA nodes, it is attached under NUMA fallbackNUMANodeID
+		// If a device has no NUMA nodes, it is attached under NUMA machine.FallbackNUMANodeID
 		// so its zone is still emitted; a warning log and a counter metric are recorded.
 		if len(numaNodes) == 0 {
-			general.Warningf("device %s has no NUMA nodes; defaulting to NUMA %d", id, fallbackNUMANodeID)
+			general.Warningf("device %s has no NUMA nodes; defaulting to NUMA %d", id, machine.FallbackNUMANodeID)
 			if p.emitter != nil {
 				_ = p.emitter.StoreInt64(metricAddGPUZoneNodesFallbackNUMA, 1, metrics.MetricTypeNameCount,
 					metrics.MetricTag{Key: "device_id", Val: id})
 			}
-			numaNodes = []int{fallbackNUMANodeID}
+			numaNodes = []int{machine.FallbackNUMANodeID}
 		}
 
 		for _, numaNode := range numaNodes {

--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu.go
@@ -209,6 +209,30 @@ func (p *GPUDevicePlugin) generateHintsFromAllocation(allocationInfo *state.Allo
 	}
 }
 
+// setPreferredHints sets hints to be preferred, prioritizing hints with NUMA nodes that match the selected NUMANodes.
+// Otherwise, it sets hints with NUMA nodes that match the minAffinitySize to be preferred.
+func setPreferredHints(
+	hints []*pluginapi.TopologyHint,
+	selectedNUMANodes machine.CPUSet,
+	minAffinitySize int,
+) {
+	if !selectedNUMANodes.IsEmpty() {
+		for _, hint := range hints {
+			hintNUMANodes, err := machine.NewCPUSetUint64(hint.Nodes...)
+			if err == nil && hintNUMANodes.Equals(selectedNUMANodes) {
+				hint.Preferred = true
+				return
+			}
+		}
+	}
+
+	for _, hint := range hints {
+		if len(hint.Nodes) == minAffinitySize {
+			hint.Preferred = true
+		}
+	}
+}
+
 func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 	deviceReq *pluginapi.DeviceRequest,
 	gpuTopology *machine.DeviceTopology,
@@ -227,12 +251,20 @@ func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 
 	// Gather all NUMA nodes that have healthy GPUs
 	numaNodesSet := sets.NewInt()
-	for _, dev := range gpuTopology.Devices {
+	numaNodesByDevice := make(map[string][]int, len(gpuTopology.Devices))
+	for deviceID, dev := range gpuTopology.Devices {
+		numaNodes := dev.NumaNodes
+		// When there are no numa nodes in a device, fallback to the FallbackNUMANodeID
+		if len(numaNodes) == 0 {
+			numaNodes = []int{machine.FallbackNUMANodeID}
+		}
+		numaNodesByDevice[deviceID] = numaNodes
+
 		if dev.Health != pluginapi.Healthy {
 			continue
 		}
 
-		numaNodesSet.Insert(dev.NumaNodes...)
+		numaNodesSet.Insert(numaNodes...)
 	}
 	numaNodes := numaNodesSet.List()
 
@@ -240,19 +272,22 @@ func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 	minAffinitySize := len(numaNodes)
 	var hints []*pluginapi.TopologyHint
 
-	selectedDevices := gpuutil.ParseGPUSelection(resReq.Annotations, p.Conf.GPUQRMPluginConfig.GPUSelectionResultAnnotationKey)
-	matched := false
+	selectedDevices := gpuutil.ParseGPUSelection(
+		resReq.Annotations,
+		p.Conf.GPUQRMPluginConfig.GPUSelectionResultAnnotationKey,
+	)
+	selectedNUMANodes := gpuTopology.GetDeviceNUMANodes(selectedDevices.UnsortedList()...)
 
 	// Iterate through all combinations of NUMA Nodes and build hints from them.
 	machine.IterateBitMasks(numaNodes, len(numaNodes), func(mask machine.BitMask) {
 		// Fast Path: Check to see if all of the reusable devices are part of the bitmask.
 		numMatching := 0
 		for d := range reusable {
-			dev, ok := gpuTopology.Devices[d]
-			if !ok || len(dev.NumaNodes) == 0 {
+			deviceNUMANodes, ok := numaNodesByDevice[d]
+			if !ok {
 				continue
 			}
-			if !mask.AnySet(dev.NumaNodes) {
+			if !mask.AnySet(deviceNUMANodes) {
 				return
 			}
 			numMatching++
@@ -261,11 +296,11 @@ func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 		// Fast Path: Check to see if enough available devices remain on the
 		// current NUMA node combination to satisfy the device request.
 		for d := range available {
-			dev, ok := gpuTopology.Devices[d]
-			if !ok || len(dev.NumaNodes) == 0 {
+			deviceNUMANodes, ok := numaNodesByDevice[d]
+			if !ok {
 				continue
 			}
-			if mask.AnySet(dev.NumaNodes) {
+			if mask.AnySet(deviceNUMANodes) {
 				numMatching++
 			}
 		}
@@ -316,28 +351,15 @@ func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 			minAffinitySize = mask.Count()
 		}
 
-		// Add it to the list of hints. Preferred stays false unless this mask's
-		// allocated devices match the scheduler's selection exactly.
-		hint := &pluginapi.TopologyHint{
+		// First set all hints' preferred to be false
+		hints = append(hints, &pluginapi.TopologyHint{
 			Nodes:     nodes,
 			Preferred: false,
-		}
-		if selectedDevices != nil && !matched && sets.NewString(result.AllocatedDevices...).Equal(selectedDevices) {
-			hint.Preferred = true
-			matched = true
-		}
-		hints = append(hints, hint)
+		})
 	})
 
-	// If no hint matched the scheduler's selection, fall back to preferring hints
-	// with the minimum affinity mask size.
-	if !matched {
-		for i := range hints {
-			if len(hints[i].Nodes) == minAffinitySize {
-				hints[i].Preferred = true
-			}
-		}
-	}
+	// Iterate through all of the hints and set preferred to be true
+	setPreferredHints(hints, selectedNUMANodes, minAffinitySize)
 
 	return hints
 }

--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu.go
@@ -240,6 +240,9 @@ func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 	minAffinitySize := len(numaNodes)
 	var hints []*pluginapi.TopologyHint
 
+	selectedDevices := gpuutil.ParseGPUSelection(resReq.Annotations, p.Conf.GPUQRMPluginConfig.GPUSelectionResultAnnotationKey)
+	matched := false
+
 	// Iterate through all combinations of NUMA Nodes and build hints from them.
 	machine.IterateBitMasks(numaNodes, len(numaNodes), func(mask machine.BitMask) {
 		// Fast Path: Check to see if all of the reusable devices are part of the bitmask.
@@ -313,20 +316,26 @@ func (p *GPUDevicePlugin) generateDeviceTopologyHints(
 			minAffinitySize = mask.Count()
 		}
 
-		// Add it to the list of hints. We set all hint preferences to 'false' on the first pass through.
-		hints = append(hints, &pluginapi.TopologyHint{
+		// Add it to the list of hints. Preferred stays false unless this mask's
+		// allocated devices match the scheduler's selection exactly.
+		hint := &pluginapi.TopologyHint{
 			Nodes:     nodes,
 			Preferred: false,
-		})
+		}
+		if selectedDevices != nil && !matched && sets.NewString(result.AllocatedDevices...).Equal(selectedDevices) {
+			hint.Preferred = true
+			matched = true
+		}
+		hints = append(hints, hint)
 	})
 
-	// Loop back through all hints and update the 'Preferred' field based on
-	// counting the number of bits sets in the affinity mask and comparing it
-	// to the minAffinity. Only those with an equal number of bits set will be
-	// considered preferred.
-	for i := range hints {
-		if len(hints[i].Nodes) == minAffinitySize {
-			hints[i].Preferred = true
+	// If no hint matched the scheduler's selection, fall back to preferring hints
+	// with the minimum affinity mask size.
+	if !matched {
+		for i := range hints {
+			if len(hints[i].Nodes) == minAffinitySize {
+				hints[i].Preferred = true
+			}
 		}
 	}
 

--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/canonical"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/deviceaffinity"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/virtual_gpu"
+	gpuutil "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/util"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm/statedirectory"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
@@ -483,6 +485,7 @@ func TestGPUDevicePlugin_GetAssociatedDeviceTopologyHints(t *testing.T) {
 		deviceReq                         *pluginapi.AssociatedDeviceRequest
 		deviceTopology                    *machine.DeviceTopology
 		requiredDeviceAffinity            bool
+		gpuSelectionAnnotationKey         string
 		expectedErr                       bool
 		expectedResp                      *pluginapi.AssociatedDeviceHintsResponse
 	}{
@@ -1249,6 +1252,150 @@ func TestGPUDevicePlugin_GetAssociatedDeviceTopologyHints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                      "scheduler selection annotation matches one hint, only that hint preferred",
+			podUID:                    "test-uid",
+			containerName:             "test-container",
+			gpuSelectionAnnotationKey: "gpu-selection",
+			deviceTopology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"test-gpu-0": {NumaNodes: []int{0}, Health: pluginapi.Healthy},
+					"test-gpu-1": {NumaNodes: []int{1}, Health: pluginapi.Healthy},
+				},
+			},
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						"gpu-selection":                 "test-gpu-0",
+					},
+					Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0", "test-gpu-1"},
+						DeviceRequest:    1,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					"gpu-selection":                 "test-gpu-0",
+				},
+				Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints: &pluginapi.ListOfTopologyHints{
+					Hints: []*pluginapi.TopologyHint{
+						{Nodes: []uint64{0}, Preferred: true},
+						{Nodes: []uint64{1}, Preferred: false},
+						{Nodes: []uint64{0, 1}, Preferred: false},
+					},
+				},
+			},
+		},
+		{
+			name:                      "scheduler selection annotation matches nothing, falls back to minAffinitySize preferred",
+			podUID:                    "test-uid",
+			containerName:             "test-container",
+			gpuSelectionAnnotationKey: "gpu-selection",
+			deviceTopology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"test-gpu-0": {NumaNodes: []int{0}, Health: pluginapi.Healthy},
+					"test-gpu-1": {NumaNodes: []int{1}, Health: pluginapi.Healthy},
+				},
+			},
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						"gpu-selection":                 "nonexistent-gpu",
+					},
+					Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0", "test-gpu-1"},
+						DeviceRequest:    1,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					"gpu-selection":                 "nonexistent-gpu",
+				},
+				Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints: &pluginapi.ListOfTopologyHints{
+					Hints: []*pluginapi.TopologyHint{
+						{Nodes: []uint64{0}, Preferred: true},
+						{Nodes: []uint64{1}, Preferred: true},
+						{Nodes: []uint64{0, 1}, Preferred: false},
+					},
+				},
+			},
+		},
+		{
+			name:                      "scheduler selection annotation is empty, falls back to minAffinitySize preferred",
+			podUID:                    "test-uid",
+			containerName:             "test-container",
+			gpuSelectionAnnotationKey: "gpu-selection",
+			deviceTopology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"test-gpu-0": {NumaNodes: []int{0}, Health: pluginapi.Healthy},
+					"test-gpu-1": {NumaNodes: []int{1}, Health: pluginapi.Healthy},
+				},
+			},
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						"gpu-selection":                 "",
+					},
+					Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0", "test-gpu-1"},
+						DeviceRequest:    1,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					"gpu-selection":                 "",
+				},
+				Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints: &pluginapi.ListOfTopologyHints{
+					Hints: []*pluginapi.TopologyHint{
+						{Nodes: []uint64{0}, Preferred: true},
+						{Nodes: []uint64{1}, Preferred: true},
+						{Nodes: []uint64{0, 1}, Preferred: false},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1295,6 +1442,11 @@ func TestGPUDevicePlugin_GetAssociatedDeviceTopologyHints(t *testing.T) {
 					}
 					basePlugin.Conf.GPUQRMPluginConfig.CustomAllocationStrategy["test-gpu"] = testDeviceAffinityAllocation
 				}
+			}
+
+			if tt.gpuSelectionAnnotationKey != "" {
+				basePlugin.Conf.GPUQRMPluginConfig.GPUSelectionResultAnnotationKey = tt.gpuSelectionAnnotationKey
+				basePlugin.PodAnnotationKeptKeys = append(basePlugin.PodAnnotationKeptKeys, tt.gpuSelectionAnnotationKey)
 			}
 
 			resp, err := devicePlugin.GetAssociatedDeviceTopologyHints(context.Background(), tt.deviceReq)
@@ -1448,6 +1600,67 @@ func TestFilterOccupiedDevicesFromRequest(t *testing.T) {
 			filterOccupiedDevicesFromRequest(req, tt.allocationResourcesMap)
 			assert.Equal(t, tt.expectedAvailableDevices, req.AvailableDevices)
 			assert.Equal(t, tt.expectedReusableDevices, req.ReusableDevices)
+		})
+	}
+}
+
+func TestParseGPUSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		key         string
+		expected    sets.String
+	}{
+		{
+			name:        "empty key returns nil",
+			annotations: map[string]string{"gpu-selection": "gpu-0,gpu-1"},
+			key:         "",
+			expected:    nil,
+		},
+		{
+			name:        "missing annotation returns nil",
+			annotations: map[string]string{"other": "gpu-0"},
+			key:         "gpu-selection",
+			expected:    nil,
+		},
+		{
+			name:        "empty annotation value returns nil",
+			annotations: map[string]string{"gpu-selection": ""},
+			key:         "gpu-selection",
+			expected:    nil,
+		},
+		{
+			name:        "annotation with only whitespace and commas returns nil",
+			annotations: map[string]string{"gpu-selection": "  ,  ,"},
+			key:         "gpu-selection",
+			expected:    nil,
+		},
+		{
+			name:        "single device",
+			annotations: map[string]string{"gpu-selection": "gpu-0"},
+			key:         "gpu-selection",
+			expected:    sets.NewString("gpu-0"),
+		},
+		{
+			name:        "multiple devices with whitespace trimmed",
+			annotations: map[string]string{"gpu-selection": " gpu-0 , gpu-1 ,  , gpu-2 "},
+			key:         "gpu-selection",
+			expected:    sets.NewString("gpu-0", "gpu-1", "gpu-2"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := gpuutil.ParseGPUSelection(tt.annotations, tt.key)
+			if tt.expected == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.True(t, got.Equal(tt.expected), "got=%v want=%v", got, tt.expected)
+			}
 		})
 	}
 }

--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
@@ -1253,6 +1253,92 @@ func TestGPUDevicePlugin_GetAssociatedDeviceTopologyHints(t *testing.T) {
 			},
 		},
 		{
+			name:          "device without NUMA nodes generates fallback NUMA hint",
+			podUID:        "test-uid",
+			containerName: "test-container",
+			deviceTopology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"test-gpu-0": {Health: pluginapi.Healthy},
+				},
+			},
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+					Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0"},
+						DeviceRequest:    1,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints: &pluginapi.ListOfTopologyHints{
+					Hints: []*pluginapi.TopologyHint{
+						{Nodes: []uint64{machine.FallbackNUMANodeID}, Preferred: true},
+					},
+				},
+			},
+		},
+		{
+			name:                      "scheduler-selected device without NUMA nodes prefers fallback NUMA hint",
+			podUID:                    "test-uid",
+			containerName:             "test-container",
+			gpuSelectionAnnotationKey: "gpu-selection",
+			deviceTopology: &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{
+					"test-gpu-0": {Health: pluginapi.Healthy},
+					"test-gpu-1": {NumaNodes: []int{1}, Health: pluginapi.Healthy},
+				},
+			},
+			deviceReq: &pluginapi.AssociatedDeviceRequest{
+				ResourceRequest: &pluginapi.ResourceRequest{
+					PodUid:        "test-uid",
+					ContainerName: "test-container",
+					Annotations: map[string]string{
+						consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+						"gpu-selection":                 "test-gpu-0",
+					},
+					Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				},
+				DeviceName: "test-gpu",
+				DeviceRequest: []*pluginapi.DeviceRequest{
+					{
+						DeviceName:       "test-gpu",
+						AvailableDevices: []string{"test-gpu-0", "test-gpu-1"},
+						DeviceRequest:    1,
+					},
+				},
+			},
+			expectedResp: &pluginapi.AssociatedDeviceHintsResponse{
+				PodUid:        "test-uid",
+				ContainerName: "test-container",
+				DeviceName:    "test-gpu",
+				Annotations: map[string]string{
+					consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores,
+					"gpu-selection":                 "test-gpu-0",
+				},
+				Labels: map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+				DeviceHints: &pluginapi.ListOfTopologyHints{
+					Hints: []*pluginapi.TopologyHint{
+						{Nodes: []uint64{machine.FallbackNUMANodeID}, Preferred: true},
+						{Nodes: []uint64{1}, Preferred: false},
+						{Nodes: []uint64{machine.FallbackNUMANodeID, 1}, Preferred: false},
+					},
+				},
+			},
+		},
+		{
 			name:                      "scheduler selection annotation matches one hint, only that hint preferred",
 			podUID:                    "test-uid",
 			containerName:             "test-container",

--- a/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/scheduler/filter.go
+++ b/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/scheduler/filter.go
@@ -17,11 +17,10 @@ limitations under the License.
 package scheduler
 
 import (
-	"strings"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/strategy/allocate"
+	gpuutil "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/util"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
 
@@ -37,17 +36,9 @@ func (s *SchedulerStrategy) Filter(
 
 	// Read the scheduled GPU selection result (e.g., a comma-separated list of device IDs)
 	// from the pod's annotations injected by the control plane scheduler.
-	key := ctx.GPUQRMPluginConfig.GPUSelectionResultAnnotationKey
-	selectionResult, ok := ctx.ResourceReq.Annotations[key]
-	if !ok || selectionResult == "" {
+	selectedSet := gpuutil.ParseGPUSelection(ctx.ResourceReq.Annotations, ctx.GPUQRMPluginConfig.GPUSelectionResultAnnotationKey)
+	if selectedSet == nil {
 		return allAvailableDevices, nil
-	}
-
-	selectedSet := sets.NewString()
-	for _, deviceID := range strings.Split(selectionResult, ",") {
-		if deviceID = strings.TrimSpace(deviceID); deviceID != "" {
-			selectedSet.Insert(deviceID)
-		}
 	}
 	availableSet := sets.NewString(allAvailableDevices...)
 

--- a/pkg/agent/qrm-plugins/gpu/util/util.go
+++ b/pkg/agent/qrm-plugins/gpu/util/util.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	pkgerrors "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +33,29 @@ import (
 )
 
 var ErrNoAvailableVirtualGPUHints = pkgerrors.New("no available virtual gpu hints")
+
+// ParseGPUSelection returns the set of GPU device IDs the control-plane scheduler
+// has pre-selected for this pod, or nil if no usable selection annotation is present.
+// The annotation value is a comma-separated list of device IDs.
+func ParseGPUSelection(annotations map[string]string, key string) sets.String {
+	if key == "" {
+		return nil
+	}
+	raw, ok := annotations[key]
+	if !ok || raw == "" {
+		return nil
+	}
+	selected := sets.NewString()
+	for _, id := range strings.Split(raw, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			selected.Insert(id)
+		}
+	}
+	if selected.Len() == 0 {
+		return nil
+	}
+	return selected
+}
 
 func GetNUMANodesCountToFitGPUReq(
 	gpuReq float64, cpuTopology *machine.CPUTopology, gpuTopology *machine.DeviceTopology,

--- a/pkg/util/machine/device.go
+++ b/pkg/util/machine/device.go
@@ -32,6 +32,8 @@ import (
 const (
 	resyncInterval = 30 * time.Second
 	DimensionNuma  = "numa"
+	// FallbackNUMANodeID is used when a device has no reported NUMA topology.
+	FallbackNUMANodeID = 0
 )
 
 // DeviceTopologyRegistry is a registry of all topology providers that knows how to provide topology information of machine devices
@@ -439,6 +441,30 @@ func (t *DeviceTopology) IsDeviceHealthy(id string) (bool, bool) {
 		return false, false
 	}
 	return deviceInfo.Health == pluginapi.Healthy, true
+}
+
+// GetDeviceNUMANodes returns the NUMA nodes associated with the given devices,
+// falling back to FallbackNUMANodeID when a device has no NUMA topology.
+func (t *DeviceTopology) GetDeviceNUMANodes(deviceIDs ...string) CPUSet {
+	numaNodes := NewCPUSet()
+	if t == nil || len(deviceIDs) == 0 {
+		return numaNodes
+	}
+
+	for _, deviceID := range deviceIDs {
+		device, ok := t.Devices[deviceID]
+		if !ok {
+			general.Errorf("device %q not found in topology", deviceID)
+			return NewCPUSet()
+		}
+		if len(device.NumaNodes) == 0 {
+			general.Warningf("device %q has no NUMA nodes; defaulting to NUMA %d", deviceID, FallbackNUMANodeID)
+			numaNodes.Add(FallbackNUMANodeID)
+			continue
+		}
+		numaNodes.Add(device.NumaNodes...)
+	}
+	return numaNodes
 }
 
 // GroupDeviceAffinity forms a topology graph such that all devices within a DeviceIDs group have an affinity with each other.

--- a/pkg/util/machine/device.go
+++ b/pkg/util/machine/device.go
@@ -142,7 +142,9 @@ func (r *DeviceTopologyRegistry) updateTopology(deviceName string) {
 		return
 	}
 
-	if err = r.SetDeviceTopology(deviceName, lastDeviceTopology); err != nil {
+	clonedTopology := lastDeviceTopology.Clone()
+
+	if err = r.SetDeviceTopology(deviceName, clonedTopology); err != nil {
 		general.Errorf("failed to set new device topology for device %q: %v", deviceName, err)
 	}
 
@@ -176,6 +178,7 @@ func (r *DeviceTopologyRegistry) RegisterTopologyChangeNotifier(notifier func())
 }
 
 // SetDeviceTopology sets the device topology for the specified device name.
+// To prevent race conditions, the device topology passed in should be cloned.
 func (r *DeviceTopologyRegistry) SetDeviceTopology(deviceName string, deviceTopology *DeviceTopology) error {
 	r.mux.Lock()
 
@@ -203,7 +206,7 @@ func (r *DeviceTopologyRegistry) SetDeviceTopology(deviceName string, deviceTopo
 		changed := !reflect.DeepEqual(r.lastDeviceTopologies[deviceName], deviceTopology)
 
 		// Cache the device topology only when SetDeviceTopology succeeds
-		r.lastDeviceTopologies[deviceName] = deviceTopology
+		r.lastDeviceTopologies[deviceName] = deviceTopology.Clone()
 
 		if changed {
 			general.Infof("device topology changed for device %s, triggering %d notifiers", deviceName, len(r.topologyChangeNotifiers))
@@ -433,6 +436,41 @@ type DeviceTopology struct {
 	PriorityDimensions []string
 	// UpdateTime is the timestamp when the topology was last updated.
 	UpdateTime int64
+}
+
+// Clone returns a deep copy of the device topology.
+func (t *DeviceTopology) Clone() *DeviceTopology {
+	if t == nil {
+		return nil
+	}
+
+	cloned := &DeviceTopology{
+		UpdateTime: t.UpdateTime,
+	}
+	if t.PriorityDimensions != nil {
+		cloned.PriorityDimensions = make([]string, len(t.PriorityDimensions))
+		copy(cloned.PriorityDimensions, t.PriorityDimensions)
+	}
+	if t.Devices == nil {
+		return cloned
+	}
+
+	cloned.Devices = make(map[string]DeviceInfo, len(t.Devices))
+	for id, info := range t.Devices {
+		clonedInfo := info
+		if info.NumaNodes != nil {
+			clonedInfo.NumaNodes = make([]int, len(info.NumaNodes))
+			copy(clonedInfo.NumaNodes, info.NumaNodes)
+		}
+		if info.Dimensions != nil {
+			clonedInfo.Dimensions = make(DeviceDimensions, len(info.Dimensions))
+			for key, value := range info.Dimensions {
+				clonedInfo.Dimensions[key] = value
+			}
+		}
+		cloned.Devices[id] = clonedInfo
+	}
+	return cloned
 }
 
 func (t *DeviceTopology) IsDeviceHealthy(id string) (bool, bool) {

--- a/pkg/util/machine/device_test.go
+++ b/pkg/util/machine/device_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machine
 
 import (
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -26,6 +27,75 @@ import (
 
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 )
+
+func TestDeviceTopologyClone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil topology", func(t *testing.T) {
+		t.Parallel()
+		var topology *DeviceTopology
+		assert.Nil(t, topology.Clone())
+	})
+
+	t.Run("deep copy", func(t *testing.T) {
+		t.Parallel()
+		topology := &DeviceTopology{
+			Devices: map[string]DeviceInfo{
+				"gpu-0": {
+					Health:     "Healthy",
+					NumaNodes:  []int{0, 1},
+					Dimensions: DeviceDimensions{"socket": "0"},
+				},
+			},
+			PriorityDimensions: []string{"socket"},
+			UpdateTime:         100,
+		}
+
+		cloned := topology.Clone()
+		cloned.Devices["gpu-1"] = DeviceInfo{}
+		clonedInfo := cloned.Devices["gpu-0"]
+		clonedInfo.NumaNodes[0] = 2
+		clonedInfo.Dimensions["socket"] = "1"
+		cloned.Devices["gpu-0"] = clonedInfo
+		cloned.PriorityDimensions[0] = "numa"
+
+		assert.NotContains(t, topology.Devices, "gpu-1")
+		assert.Equal(t, []int{0, 1}, topology.Devices["gpu-0"].NumaNodes)
+		assert.Equal(t, "0", topology.Devices["gpu-0"].Dimensions["socket"])
+		assert.Equal(t, []string{"socket"}, topology.PriorityDimensions)
+		assert.Equal(t, int64(100), cloned.UpdateTime)
+	})
+
+	t.Run("preserves nil nested fields", func(t *testing.T) {
+		t.Parallel()
+		topology := &DeviceTopology{
+			Devices: map[string]DeviceInfo{"gpu-0": {}},
+		}
+
+		cloned := topology.Clone()
+
+		assert.Nil(t, cloned.Devices["gpu-0"].NumaNodes)
+		assert.Nil(t, cloned.Devices["gpu-0"].Dimensions)
+		assert.Nil(t, cloned.PriorityDimensions)
+	})
+
+	t.Run("preserves non-nil empty slices", func(t *testing.T) {
+		t.Parallel()
+		topology := &DeviceTopology{
+			Devices: map[string]DeviceInfo{
+				"gpu-0": {NumaNodes: []int{}},
+			},
+			PriorityDimensions: []string{},
+		}
+
+		cloned := topology.Clone()
+
+		assert.NotNil(t, cloned.Devices["gpu-0"].NumaNodes)
+		assert.Empty(t, cloned.Devices["gpu-0"].NumaNodes)
+		assert.NotNil(t, cloned.PriorityDimensions)
+		assert.Empty(t, cloned.PriorityDimensions)
+	})
+}
 
 func TestDeviceTopologyRegistry_TopologyChangeNotifiers(t *testing.T) {
 	t.Parallel()
@@ -69,6 +139,180 @@ func TestDeviceTopologyRegistry_TopologyChangeNotifiers(t *testing.T) {
 	err = registry.SetDeviceTopology("gpu", gpuTopology2)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, callCount)
+}
+
+func TestDeviceTopologyRegistry_SetDeviceTopologyUsesCallerClone(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceTopologyRegistry(metrics.DummyMetrics{})
+	registry.RegisterDeviceTopologyProvider("gpu", NewDeviceTopologyProvider())
+
+	input := &DeviceTopology{
+		Devices: map[string]DeviceInfo{
+			"gpu-0": {NumaNodes: []int{0}, Dimensions: DeviceDimensions{"socket": "0"}},
+		},
+	}
+	topology := input.Clone()
+	assert.NoError(t, registry.SetDeviceTopology("gpu", topology))
+
+	input.Devices["gpu-1"] = DeviceInfo{}
+	info := input.Devices["gpu-0"]
+	info.NumaNodes[0] = 1
+	info.Dimensions["socket"] = "1"
+	input.Devices["gpu-0"] = info
+
+	published, err := registry.GetDeviceTopology("gpu")
+	assert.NoError(t, err)
+	assert.Same(t, topology, published)
+	assert.NotContains(t, published.Devices, "gpu-1")
+	assert.Equal(t, []int{0}, published.Devices["gpu-0"].NumaNodes)
+	assert.Equal(t, "0", published.Devices["gpu-0"].Dimensions["socket"])
+}
+
+type retainingDeviceTopologyProvider struct {
+	topology *DeviceTopology
+	setCalls int
+	setErr   error
+}
+
+func (p *retainingDeviceTopologyProvider) SetDeviceTopology(topology *DeviceTopology) error {
+	p.setCalls++
+	p.topology = topology
+	return p.setErr
+}
+
+func (p *retainingDeviceTopologyProvider) GetDeviceTopology() (*DeviceTopology, error) {
+	return p.topology, nil
+}
+
+func TestDeviceTopologyRegistry_SetDeviceTopologyIsolatesCachedTopologyFromProvider(t *testing.T) {
+	t.Parallel()
+
+	registry := NewDeviceTopologyRegistry(metrics.DummyMetrics{})
+	provider := &retainingDeviceTopologyProvider{}
+	registry.RegisterDeviceTopologyProvider("gpu", provider)
+
+	topology := &DeviceTopology{
+		Devices: map[string]DeviceInfo{
+			"gpu-0": {
+				NumaNodes:  []int{0},
+				Dimensions: DeviceDimensions{"socket": "0"},
+			},
+		},
+		PriorityDimensions: []string{"socket"},
+		UpdateTime:         100,
+	}
+	expected := topology.Clone()
+	assert.NoError(t, registry.SetDeviceTopology("gpu", topology))
+
+	provider.topology.Devices["gpu-1"] = DeviceInfo{}
+	info := provider.topology.Devices["gpu-0"]
+	info.NumaNodes[0] = 1
+	info.Dimensions["socket"] = "1"
+	provider.topology.Devices["gpu-0"] = info
+	provider.topology.PriorityDimensions[0] = "numa"
+	provider.topology.UpdateTime = 200
+
+	cached, err := registry.getLastTopology("gpu")
+	assert.NoError(t, err)
+	assert.NotSame(t, provider.topology, cached)
+	assert.Equal(t, expected, cached)
+}
+
+type mutatingDeviceAffinityProvider struct {
+	dimensionValue string
+}
+
+func (p *mutatingDeviceAffinityProvider) SetDeviceAffinity(topology *DeviceTopology) {
+	info := topology.Devices["gpu-0"]
+	info.Dimensions = DeviceDimensions{"socket": p.dimensionValue}
+	topology.Devices["gpu-0"] = info
+}
+
+func (*mutatingDeviceAffinityProvider) WatchTopologyChanged(stopCh <-chan struct{}) <-chan struct{} {
+	return nil
+}
+
+func TestDeviceTopologyRegistry_UpdateTopology(t *testing.T) {
+	t.Run("clones cached topology before updating affinity", func(t *testing.T) {
+		registry := NewDeviceTopologyRegistry(metrics.DummyMetrics{})
+		registry.RegisterDeviceTopologyProvider("gpu", NewDeviceTopologyProvider())
+		affinityProvider := &mutatingDeviceAffinityProvider{dimensionValue: "0"}
+		registry.RegisterTopologyAffinityProvider("gpu", affinityProvider)
+
+		assert.NoError(t, registry.SetDeviceTopology("gpu", &DeviceTopology{
+			Devices: map[string]DeviceInfo{"gpu-0": {}},
+		}))
+		previous, err := registry.getLastTopology("gpu")
+		assert.NoError(t, err)
+
+		affinityProvider.dimensionValue = "1"
+		registry.updateTopology("gpu")
+
+		current, err := registry.getLastTopology("gpu")
+		assert.NoError(t, err)
+		assert.NotSame(t, previous, current)
+		assert.Equal(t, "0", previous.Devices["gpu-0"].Dimensions["socket"])
+		assert.Equal(t, "1", current.Devices["gpu-0"].Dimensions["socket"])
+	})
+
+	t.Run("does nothing without cached topology", func(t *testing.T) {
+		registry := NewDeviceTopologyRegistry(metrics.DummyMetrics{})
+		provider := &retainingDeviceTopologyProvider{}
+		registry.RegisterDeviceTopologyProvider("gpu", provider)
+
+		registry.updateTopology("gpu")
+
+		assert.Zero(t, provider.setCalls)
+		assert.Nil(t, provider.topology)
+	})
+
+	t.Run("preserves cached topology when provider update fails", func(t *testing.T) {
+		registry := NewDeviceTopologyRegistry(metrics.DummyMetrics{})
+		provider := &retainingDeviceTopologyProvider{}
+		registry.RegisterDeviceTopologyProvider("gpu", provider)
+		affinityProvider := &mutatingDeviceAffinityProvider{dimensionValue: "0"}
+		registry.RegisterTopologyAffinityProvider("gpu", affinityProvider)
+
+		assert.NoError(t, registry.SetDeviceTopology("gpu", &DeviceTopology{
+			Devices: map[string]DeviceInfo{"gpu-0": {}},
+		}))
+		cached, err := registry.getLastTopology("gpu")
+		assert.NoError(t, err)
+
+		provider.setErr = errors.New("set topology failed")
+		affinityProvider.dimensionValue = "1"
+		registry.updateTopology("gpu")
+
+		current, err := registry.getLastTopology("gpu")
+		assert.NoError(t, err)
+		assert.Same(t, cached, current)
+		assert.NotSame(t, cached, provider.topology)
+		assert.Equal(t, "0", current.Devices["gpu-0"].Dimensions["socket"])
+		assert.Equal(t, "1", provider.topology.Devices["gpu-0"].Dimensions["socket"])
+	})
+}
+
+func TestDeviceTopologyRegistry_UpdateTopologyDoesNotMutatePublishedSnapshot(t *testing.T) {
+	registry := NewDeviceTopologyRegistry(metrics.DummyMetrics{})
+	registry.RegisterDeviceTopologyProvider("gpu", NewDeviceTopologyProvider())
+	affinityProvider := &mutatingDeviceAffinityProvider{dimensionValue: "0"}
+	registry.RegisterTopologyAffinityProvider("gpu", affinityProvider)
+
+	assert.NoError(t, registry.SetDeviceTopology("gpu", &DeviceTopology{
+		Devices: map[string]DeviceInfo{"gpu-0": {}},
+	}))
+	previous, err := registry.GetDeviceTopology("gpu")
+	assert.NoError(t, err)
+
+	affinityProvider.dimensionValue = "1"
+	registry.updateTopology("gpu")
+
+	current, err := registry.GetDeviceTopology("gpu")
+	assert.NoError(t, err)
+	assert.NotSame(t, previous, current)
+	assert.Equal(t, "0", previous.Devices["gpu-0"].Dimensions["socket"])
+	assert.Equal(t, "1", current.Devices["gpu-0"].Dimensions["socket"])
 }
 
 func TestDeviceTopologyRegistry_GetAffinityDevices(t *testing.T) {
@@ -539,34 +783,47 @@ func TestDeviceTopology_GetDeviceNUMANodes(t *testing.T) {
 			"device-3": {NumaNodes: []int{2}},
 		},
 	}
+	var nilTopology *DeviceTopology
 	tests := []struct {
 		name      string
+		topology  *DeviceTopology
 		deviceIDs []string
 		expected  CPUSet
 	}{
 		{
 			name:      "combine device NUMA nodes",
+			topology:  topology,
 			deviceIDs: []string{"device-0", "device-1"},
 			expected:  NewCPUSet(0, 1),
 		},
 		{
 			name:     "no devices",
+			topology: topology,
 			expected: NewCPUSet(),
 		},
 		{
 			name:      "unknown device",
+			topology:  topology,
 			deviceIDs: []string{"unknown"},
 			expected:  NewCPUSet(),
 		},
 		{
 			name:      "device without NUMA nodes",
+			topology:  topology,
 			deviceIDs: []string{"device-2"},
 			expected:  NewCPUSet(FallbackNUMANodeID),
 		},
 		{
 			name:      "continue after device without NUMA nodes",
+			topology:  topology,
 			deviceIDs: []string{"device-2", "device-3"},
 			expected:  NewCPUSet(FallbackNUMANodeID, 2),
+		},
+		{
+			name:      "nil topology",
+			topology:  nilTopology,
+			deviceIDs: []string{"device-0"},
+			expected:  NewCPUSet(),
 		},
 	}
 
@@ -574,7 +831,7 @@ func TestDeviceTopology_GetDeviceNUMANodes(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.True(t, topology.GetDeviceNUMANodes(tt.deviceIDs...).Equals(tt.expected))
+			assert.True(t, tt.topology.GetDeviceNUMANodes(tt.deviceIDs...).Equals(tt.expected))
 		})
 	}
 }

--- a/pkg/util/machine/device_test.go
+++ b/pkg/util/machine/device_test.go
@@ -528,6 +528,57 @@ func TestHasAnyDeviceAffinity(t *testing.T) {
 	}
 }
 
+func TestDeviceTopology_GetDeviceNUMANodes(t *testing.T) {
+	t.Parallel()
+
+	topology := &DeviceTopology{
+		Devices: map[string]DeviceInfo{
+			"device-0": {NumaNodes: []int{0}},
+			"device-1": {NumaNodes: []int{0, 1}},
+			"device-2": {},
+			"device-3": {NumaNodes: []int{2}},
+		},
+	}
+	tests := []struct {
+		name      string
+		deviceIDs []string
+		expected  CPUSet
+	}{
+		{
+			name:      "combine device NUMA nodes",
+			deviceIDs: []string{"device-0", "device-1"},
+			expected:  NewCPUSet(0, 1),
+		},
+		{
+			name:     "no devices",
+			expected: NewCPUSet(),
+		},
+		{
+			name:      "unknown device",
+			deviceIDs: []string{"unknown"},
+			expected:  NewCPUSet(),
+		},
+		{
+			name:      "device without NUMA nodes",
+			deviceIDs: []string{"device-2"},
+			expected:  NewCPUSet(FallbackNUMANodeID),
+		},
+		{
+			name:      "continue after device without NUMA nodes",
+			deviceIDs: []string{"device-2", "device-3"},
+			expected:  NewCPUSet(FallbackNUMANodeID, 2),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, topology.GetDeviceNUMANodes(tt.deviceIDs...).Equals(tt.expected))
+		})
+	}
+}
+
 func TestDeviceTopology_GroupDeviceAffinity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### English

- GPU topology hints now prefer NUMA nodes linked to scheduler-selected GPUs.
- Empty or unmatched selections retain the existing minimum-affinity preference.
- Devices without topology data use `FallbackNUMANodeID`.
- `gpuutil.ParseGPUSelection` centralizes annotation parsing and ignores empty entries.
- `DeviceTopology.GetDeviceNUMANodes` aggregates NUMA nodes and safely handles nil or missing devices.
- `DeviceTopology.Clone` isolates topology inputs, cached data, and published snapshots from mutation.
- The GPU agent, scheduler allocation strategy, and reporter use shared selection parsing and fallback behavior.
- Controller wiring, scheduler selection behavior, and release wiring are unchanged.
- No configuration or dependency updates are included.
- Rollout risk is limited to incorrect scheduler annotations or topology data. Invalid or unmatched selections preserve default hint behavior.
- Tests cover scheduler-based hint selection, parsing, fallback behavior, NUMA aggregation, clone isolation, and nil or missing-device handling.

### 简体中文

- GPU topology hints 现在优先选择与 scheduler 选定 GPU 关联的 NUMA 节点。
- 如果 selection 为空或不匹配，系统会保留现有的最小 NUMA affinity preference。
- 如果设备缺少 topology 数据，系统会使用 `FallbackNUMANodeID`。
- `gpuutil.ParseGPUSelection` 统一解析 annotation，并忽略空条目。
- `DeviceTopology.GetDeviceNUMANodes` 聚合 NUMA 节点，并安全处理 nil 或缺失设备。
- `DeviceTopology.Clone` 隔离 topology 输入、缓存数据和已发布 snapshot，防止数据被修改。
- GPU agent、scheduler allocation strategy 和 reporter 使用共享的 selection 解析及 fallback 行为。
- 不涉及 controller wiring、scheduler selection 行为或 release wiring。
- 本次变更不包含配置或依赖更新。
- rollout 风险主要来自错误的 scheduler annotation 或 topology 数据。无效或未匹配的 selection 会保留默认 hint 行为。
- 测试覆盖 scheduler hint selection、解析、fallback 行为、NUMA 聚合、clone 隔离以及 nil 或缺失设备处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->