### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,8 +12,10 @@ reviews:
   high_level_summary_instructions: >-
     Summarize runtime behavior changes, affected components, operational or
     rollout risk, and any config or dependency updates. Call out when changes
-    affect agent, controller, scheduler, or release wiring.
-  high_level_summary_in_walkthrough: true
+    affect agent, controller, scheduler, or release wiring. Write concise English text 
+    first, then equivalent Simplified Chinese. Do not translate code, paths, APIs, markers, 
+    protobuf names, or error strings.
+  high_level_summary_in_walkthrough: false
   review_status: true
   collapse_walkthrough: true
   poem: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,13 +1,8 @@
 language: "en-US"
 early_access: false
 tone_instructions: >-
-  Focus on correctness, concurrency safety, reconciliation behavior,
-  nil/error handling, and meaningful tests. Avoid style-only feedback unless it
-  affects maintainability. Write all review comments, summaries, and chat
-  replies in both English and Simplified Chinese, with English first and
-  Chinese second. Keep both versions concise and semantically equivalent. Do
-  not translate code, paths, APIs, kubebuilder markers, protobuf field names,
-  or error strings.
+  Be concise and direct. Keep comments short and actionable. Avoid style-only
+  feedback unless it affects readability or maintainability.
 
 reviews:
   profile: "chill"
@@ -43,6 +38,10 @@ reviews:
     - "!**/*.gif"
     - "!**/*.svg"
   path_instructions:
+    - path: "**"
+      instructions: |
+        Write review comments, summaries, and chat replies in both English and Simplified Chinese, with English first and Chinese second.
+        Keep both versions concise and semantically equivalent. Do not translate code, paths, APIs, kubebuilder markers, protobuf field names, or error strings.
     - path: "go.mod"
       instructions: |
         Review dependency and module version changes for runtime behavior risk, katalyst-api compatibility, and transitive Kubernetes or controller-runtime impact.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,79 @@
+language: "en-US"
+early_access: false
+tone_instructions: >-
+  Focus on correctness, concurrency safety, reconciliation behavior,
+  nil/error handling, and meaningful tests. Avoid style-only feedback unless it
+  affects maintainability. Write all review comments, summaries, and chat
+  replies in both English and Simplified Chinese, with English first and
+  Chinese second. Keep both versions concise and semantically equivalent. Do
+  not translate code, paths, APIs, kubebuilder markers, protobuf field names,
+  or error strings.
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_instructions: >-
+    Summarize runtime behavior changes, affected components, operational or
+    rollout risk, and any config or dependency updates. Call out when changes
+    affect agent, controller, scheduler, or release wiring.
+  high_level_summary_in_walkthrough: true
+  review_status: true
+  collapse_walkthrough: true
+  poem: false
+  slop_detection:
+    enabled: true
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_pause_after_reviewed_commits: 0
+    base_branches:
+      - "main"
+    ignore_title_keywords:
+      - "WIP"
+      - "DRAFT"
+      - "DO NOT MERGE"
+  path_filters:
+    - "!**/*.pb.go"
+    - "!**/zz_generated_*.go"
+    - "!docs/imgs/**"
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.gif"
+    - "!**/*.svg"
+  path_instructions:
+    - path: "go.mod"
+      instructions: |
+        Review dependency and module version changes for runtime behavior risk, katalyst-api compatibility, and transitive Kubernetes or controller-runtime impact.
+        Flag version bumps that likely require code updates, config changes, or coordinated rollout notes.
+    - path: ".github/workflows/**"
+      instructions: |
+        Review CI and release automation changes for correct branch triggers, pinned actions where appropriate, timeout and permission hygiene, and consistency with this repo's validation and release flow.
+        Flag changes that weaken testing, vetting, or release safety.
+    - path: "{cmd/**,pkg/agent/**,pkg/controller/**,pkg/metaserver/**,pkg/scheduler/**}"
+      instructions: |
+        Focus on runtime correctness: reconciliation idempotency, cache staleness, lock ordering, goroutine lifecycle, resource accounting, and nil/error paths.
+        Flag behavior that can cause inconsistent node state, leaked background work, or partial updates after failures.
+    - path: "pkg/config/**"
+      instructions: |
+        Check config defaulting and validation carefully.
+        Flag new fields that are not wired through startup paths, feature gates, validation, or tests.
+    - path: "**/*_test.go"
+      instructions: |
+        Prefer deterministic tests that cover failure paths, edge cases, and concurrency-sensitive behavior when relevant.
+        Avoid asking for broad end-to-end tests when focused unit coverage is sufficient.
+    - path: "docs/**/*.md"
+      instructions: |
+        Check for technical accuracy, outdated operational guidance, and mismatches between documented behavior and current runtime wiring.
+
+knowledge_base:
+  linked_repositories:
+    - repository: "kubewharf/katalyst-api"
+      instructions: >-
+        Use this repository to assess upstream API, protocol, constant, and
+        dependency compatibility. Focus on required consumer changes, version
+        bumps, and coordinated cross-repo rollout risk.
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -64,12 +64,7 @@ reviews:
         Check for technical accuracy, outdated operational guidance, and mismatches between documented behavior and current runtime wiring.
 
 knowledge_base:
-  linked_repositories:
-    - repository: "kubewharf/katalyst-api"
-      instructions: >-
-        Use this repository to assess upstream API, protocol, constant, and
-        dependency compatibility. Focus on required consumer changes, version
-        bumps, and coordinated cross-repo rollout risk.
+  automatic_repository_linking: true
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,9 @@
 language: "en-US"
 early_access: false
 tone_instructions: >-
-  Be concise and direct. Keep comments short and actionable. Avoid style-only
-  feedback unless it affects readability or maintainability.
+  Prioritize correctness, concurrency safety, nil/error handling, and tests.
+  Write concise English text first, then equivalent Simplified Chinese. Do not
+  translate code, paths, APIs, markers, protobuf names, or error strings.
 
 reviews:
   profile: "chill"
@@ -38,10 +39,6 @@ reviews:
     - "!**/*.gif"
     - "!**/*.svg"
   path_instructions:
-    - path: "**"
-      instructions: |
-        Write review comments, summaries, and chat replies in both English and Simplified Chinese, with English first and Chinese second.
-        Keep both versions concise and semantically equivalent. Do not translate code, paths, APIs, kubebuilder markers, protobuf field names, or error strings.
     - path: "go.mod"
       instructions: |
         Review dependency and module version changes for runtime behavior risk, katalyst-api compatibility, and transitive Kubernetes or controller-runtime impact.


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores / Config updates**
  * Updated `.coderabbit.yaml` to enforce bilingual review output rules (English first, then equivalent Simplified Chinese) and consistently forbid translating code, paths, APIs, markers, protobuf names, and error strings (in both `tone_instructions` and `reviews.high_level_summary_instructions`).
  * Enabled `reviews.high_level_summary: true` and disabled `reviews.high_level_summary_in_walkthrough: false`.
  * Added/updated `reviews.path_instructions` for targeted review guidance:
    * `go.mod`: review dependency/module version changes for runtime behavior risk and compatibility impacts.
    * `.github/workflows/**`: review CI/release automation safety (branch triggers, pinned actions, permissions/timeouts, validation/release flow).
    * `cmd/**`, `pkg/agent/**`, `pkg/controller/**`, `pkg/metaserver/**`, `pkg/scheduler/**`: focus on runtime correctness (idempotency, cache staleness, lock ordering, goroutine lifecycle, resource accounting, nil/error paths) to reduce inconsistent node state or leaked background work.
    * `pkg/config/**`: carefully check config defaulting/validation and wiring through startup/feature gates/tests.
    * `**/*_test.go`: encourage deterministic, concurrency/edge-case coverage when relevant.
    * `docs/**/*.md`: check accuracy and mismatches between documentation and runtime wiring.
  * Kept `reviews.path_filters` exclusions (e.g., generated `.pb.go` and image assets).
  * Switched `knowledge_base` to `automatic_repository_linking: true`.
  * Kept `chat.auto_reply: true` enabled.

* **Runtime behavior / rollout risk**
  * No production runtime logic changes—this PR only updates automated CodeRabbit review configuration and the content/structure of review feedback, so rollout risk is limited to how reviews are generated.

## CodeRabbit 总结

* **杂项 / 配置更新**
  * 更新了 `.coderabbit.yaml`，要求评论输出始终为双语格式（先英文、再对应简体中文），并在 `tone_instructions` 与 `reviews.high_level_summary_instructions` 中一致明确禁止翻译代码、路径、API、marker、protobuf 名称与错误字符串。
  * 启用 `reviews.high_level_summary: true`，并禁用 `reviews.high_level_summary_in_walkthrough: false`。
  * 新增/更新了 `reviews.path_instructions`，用于按路径提供更有针对性的审查指引：
    * `go.mod`：围绕运行时行为风险与兼容性影响评审依赖/模块版本变更。
    * `.github/workflows/**`：评审 CI/发布自动化安全性（分支触发、action 固定、权限与超时、与仓库验证/发布流程的一致性）。
    * `cmd/**`, `pkg/agent/**`, `pkg/controller/**`, `pkg/metaserver/**`, `pkg/scheduler/**`：聚焦运行时正确性（幂等性、缓存陈旧、锁顺序、goroutine 生命周期、资源核算、nil/错误路径），避免节点状态不一致或后台任务泄漏等问题。
    * `pkg/config/**`：仔细检查配置默认值/校验，以及是否正确贯通启动路径、特性开关、验证与测试。
    * `**/*_test.go`：在相关情况下鼓励确定性测试，并覆盖失败路径与并发/边界场景。
    * `docs/**/*.md`：核对技术准确性，避免文档与运行时接线不一致。
  * 保持 `reviews.path_filters` 的排除规则（例如生成的 `.pb.go` 与图片资源）。
  * 将 `knowledge_base` 切换为 `automatic_repository_linking: true`。
  * 保持 `chat.auto_reply: true` 开启。

* **运行时行为 / 上线风险**
  * 不涉及生产运行时代码逻辑变更——该 PR 仅修改 CodeRabbit 自动化评审配置与评审反馈的生成方式，因此上线风险仅限于评审内容/形式的变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->