### PR TITLE
fix(qrm): propagate checkpoint write errors

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/checkpoint_error_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/checkpoint_error_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpolicy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+func TestCheckpointWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+
+	t.Run("Allocate", func(t *testing.T) {
+		t.Parallel()
+
+		checkpointDir := t.TempDir()
+		policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, checkpointDir)
+		require.NoError(t, err)
+
+		req := newCPUCheckpointTestRequest()
+		restore := blockCPUCheckpointWrites(t, filepath.Join(checkpointDir, cpuPluginStateFileName))
+
+		resp, err := policy.Allocate(context.Background(), req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+
+		restore()
+		_, err = policy.Allocate(context.Background(), req)
+		require.NoError(t, err)
+
+		restoredPolicy, err := getTestDynamicPolicyWithInitialization(cpuTopology, checkpointDir)
+		require.NoError(t, err)
+		require.NotNil(t, restoredPolicy.state.GetAllocationInfo(req.PodUid, req.ContainerName))
+	})
+
+	t.Run("RemovePod", func(t *testing.T) {
+		t.Parallel()
+
+		checkpointDir := t.TempDir()
+		policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, checkpointDir)
+		require.NoError(t, err)
+
+		req := newCPUCheckpointTestRequest()
+		_, err = policy.Allocate(context.Background(), req)
+		require.NoError(t, err)
+
+		restore := blockCPUCheckpointWrites(t, filepath.Join(checkpointDir, cpuPluginStateFileName))
+		removeReq := &pluginapi.RemovePodRequest{PodUid: req.PodUid}
+		resp, err := policy.RemovePod(context.Background(), removeReq)
+		require.Error(t, err)
+		require.Nil(t, resp)
+
+		restore()
+		_, err = policy.RemovePod(context.Background(), removeReq)
+		require.NoError(t, err)
+
+		restoredPolicy, err := getTestDynamicPolicyWithInitialization(cpuTopology, checkpointDir)
+		require.NoError(t, err)
+		require.Nil(t, restoredPolicy.state.GetAllocationInfo(req.PodUid, req.ContainerName))
+	})
+}
+
+func newCPUCheckpointTestRequest() *pluginapi.ResourceRequest {
+	return &pluginapi.ResourceRequest{
+		PodUid:        "checkpoint-pod",
+		PodNamespace:  "default",
+		PodName:       "checkpoint-pod",
+		ContainerName: "container",
+		ContainerType: pluginapi.ContainerType_MAIN,
+		ResourceName:  string(v1.ResourceCPU),
+		ResourceRequests: map[string]float64{
+			string(v1.ResourceCPU): 2,
+		},
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+}
+
+func blockCPUCheckpointWrites(t *testing.T, checkpointPath string) func() {
+	t.Helper()
+
+	checkpoint, err := os.ReadFile(checkpointPath)
+	require.NoError(t, err)
+	info, err := os.Stat(checkpointPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(checkpointPath))
+	require.NoError(t, os.Mkdir(checkpointPath, 0o755))
+
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		require.NoError(t, os.RemoveAll(checkpointPath))
+		require.NoError(t, os.WriteFile(checkpointPath, checkpoint, info.Mode().Perm()))
+		restored = true
+	}
+	t.Cleanup(restore)
+	return restore
+}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -1042,6 +1042,10 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 		}
 		if err := p.state.StoreState(); err != nil {
 			general.ErrorS(err, "store state failed", "podName", req.PodName, "containerName", req.ContainerName)
+			resp = nil
+			respErr = fmt.Errorf("store state failed: %w", err)
+			_ = p.emitter.StoreInt64(util.MetricNameAllocateFailed, 1, metrics.MetricTypeNameRaw,
+				metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)})
 		}
 
 		p.Unlock()
@@ -1128,6 +1132,9 @@ func (p *DynamicPolicy) RemovePod(ctx context.Context,
 
 	podEntries := p.state.GetPodEntries()
 	if len(podEntries[req.PodUid]) == 0 {
+		if err := p.state.StoreState(); err != nil {
+			return nil, fmt.Errorf("store state failed: %w", err)
+		}
 		return &pluginapi.RemovePodResponse{}, nil
 	}
 
@@ -1158,6 +1165,7 @@ func (p *DynamicPolicy) RemovePod(ctx context.Context,
 	}
 	if err := p.state.StoreState(); err != nil {
 		general.ErrorS(err, "store state failed", "podUID", req.PodUid)
+		return nil, fmt.Errorf("store state failed: %w", err)
 	}
 
 	return &pluginapi.RemovePodResponse{}, nil

--- a/pkg/agent/qrm-plugins/cpu/nativepolicy/checkpoint_error_test.go
+++ b/pkg/agent/qrm-plugins/cpu/nativepolicy/checkpoint_error_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nativepolicy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+func TestCheckpointWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+
+	t.Run("Allocate", func(t *testing.T) {
+		t.Parallel()
+
+		for _, qosClass := range []v1.PodQOSClass{v1.PodQOSGuaranteed, v1.PodQOSBurstable} {
+			qosClass := qosClass
+			t.Run(string(qosClass), func(t *testing.T) {
+				t.Parallel()
+
+				checkpointDir := t.TempDir()
+				policy, err := getTestNativePolicy(cpuTopology, checkpointDir)
+				require.NoError(t, err)
+
+				req := newNativeCheckpointTestRequest(qosClass)
+				restore := blockNativeCheckpointWrites(t, filepath.Join(checkpointDir, cpuPluginStateFileName))
+
+				resp, err := policy.Allocate(context.Background(), req)
+				require.Error(t, err)
+				require.Nil(t, resp)
+
+				restore()
+				_, err = policy.Allocate(context.Background(), req)
+				require.NoError(t, err)
+
+				restoredPolicy, err := getTestNativePolicy(cpuTopology, checkpointDir)
+				require.NoError(t, err)
+				require.NotNil(t, restoredPolicy.state.GetAllocationInfo(req.PodUid, req.ContainerName))
+			})
+		}
+	})
+
+	t.Run("RemovePod", func(t *testing.T) {
+		t.Parallel()
+
+		checkpointDir := t.TempDir()
+		policy, err := getTestNativePolicy(cpuTopology, checkpointDir)
+		require.NoError(t, err)
+
+		req := newNativeCheckpointTestRequest(v1.PodQOSGuaranteed)
+		_, err = policy.Allocate(context.Background(), req)
+		require.NoError(t, err)
+
+		restore := blockNativeCheckpointWrites(t, filepath.Join(checkpointDir, cpuPluginStateFileName))
+		removeReq := &pluginapi.RemovePodRequest{PodUid: req.PodUid}
+		resp, err := policy.RemovePod(context.Background(), removeReq)
+		require.Error(t, err)
+		require.Nil(t, resp)
+
+		restore()
+		_, err = policy.RemovePod(context.Background(), removeReq)
+		require.NoError(t, err)
+
+		restoredPolicy, err := getTestNativePolicy(cpuTopology, checkpointDir)
+		require.NoError(t, err)
+		require.Nil(t, restoredPolicy.state.GetAllocationInfo(req.PodUid, req.ContainerName))
+	})
+}
+
+func newNativeCheckpointTestRequest(qosClass v1.PodQOSClass) *pluginapi.ResourceRequest {
+	return &pluginapi.ResourceRequest{
+		PodUid:         "checkpoint-pod-" + string(qosClass),
+		PodNamespace:   "default",
+		PodName:        "checkpoint-pod",
+		ContainerName:  "container",
+		ContainerType:  pluginapi.ContainerType_MAIN,
+		ResourceName:   string(v1.ResourceCPU),
+		NativeQosClass: string(qosClass),
+		ResourceRequests: map[string]float64{
+			string(v1.ResourceCPU): 2,
+		},
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+}
+
+func blockNativeCheckpointWrites(t *testing.T, checkpointPath string) func() {
+	t.Helper()
+
+	checkpoint, err := os.ReadFile(checkpointPath)
+	require.NoError(t, err)
+	info, err := os.Stat(checkpointPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(checkpointPath))
+	require.NoError(t, os.Mkdir(checkpointPath, 0o755))
+
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		require.NoError(t, os.RemoveAll(checkpointPath))
+		require.NoError(t, os.WriteFile(checkpointPath, checkpoint, info.Mode().Perm()))
+		restored = true
+	}
+	t.Cleanup(restore)
+	return restore
+}

--- a/pkg/agent/qrm-plugins/cpu/nativepolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/nativepolicy/policy.go
@@ -602,7 +602,7 @@ func (p *NativePolicy) RemovePod(ctx context.Context,
 func (p *NativePolicy) removePod(podUID string) error {
 	podEntries := p.state.GetPodEntries()
 	if len(podEntries[podUID]) == 0 {
-		return nil
+		return p.state.StoreState()
 	}
 	delete(podEntries, podUID)
 

--- a/pkg/agent/qrm-plugins/cpu/nativepolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/nativepolicy/policy_allocation_handlers.go
@@ -128,7 +128,7 @@ func (p *NativePolicy) dedicatedCoresAllocationHandler(_ context.Context,
 
 	// update pod entries directly.
 	// if one of subsequent steps is failed, we will delete current allocationInfo from podEntries in defer function of allocation function.
-	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, true)
+	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, false)
 	podEntries := p.state.GetPodEntries()
 
 	updatedMachineState, err := nativepolicyutil.GenerateMachineStateFromPodEntries(p.machineInfo.CPUTopology, podEntries, nil)
@@ -137,7 +137,10 @@ func (p *NativePolicy) dedicatedCoresAllocationHandler(_ context.Context,
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("GenerateMachineStateFromPodEntries failed with error: %v", err)
 	}
-	p.state.SetMachineState(updatedMachineState, true)
+	p.state.SetMachineState(updatedMachineState, false)
+	if err := p.state.StoreState(); err != nil {
+		return nil, fmt.Errorf("store state failed: %w", err)
+	}
 
 	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req)
 	if err != nil {
@@ -195,7 +198,7 @@ func (p *NativePolicy) sharedPoolAllocationHandler(ctx context.Context,
 
 	// update pod entries directly.
 	// if one of subsequent steps is failed, we will delete current allocationInfo from podEntries in defer function of allocation function.
-	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, true)
+	p.state.SetAllocationInfo(allocationInfo.PodUid, allocationInfo.ContainerName, allocationInfo, false)
 	podEntries := p.state.GetPodEntries()
 
 	updatedMachineState, err := nativepolicyutil.GenerateMachineStateFromPodEntries(p.machineInfo.CPUTopology, podEntries, nil)
@@ -204,7 +207,10 @@ func (p *NativePolicy) sharedPoolAllocationHandler(ctx context.Context,
 			req.PodNamespace, req.PodName, req.ContainerName, err)
 		return nil, fmt.Errorf("GenerateMachineStateFromPodEntries failed with error: %v", err)
 	}
-	p.state.SetMachineState(updatedMachineState, true)
+	p.state.SetMachineState(updatedMachineState, false)
+	if err := p.state.StoreState(); err != nil {
+		return nil, fmt.Errorf("store state failed: %w", err)
+	}
 
 	resp, err := cpuutil.PackAllocationResponse(allocationInfo, string(v1.ResourceCPU), util.OCIPropertyNameCPUSetCPUs, false, true, req)
 	if err != nil {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/checkpoint_error_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/checkpoint_error_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamicpolicy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+)
+
+func TestCheckpointWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+	machineInfo, err := machine.GenerateDummyMachineInfo(4, 32)
+	require.NoError(t, err)
+
+	t.Run("Allocate", func(t *testing.T) {
+		t.Parallel()
+
+		checkpointDir := t.TempDir()
+		policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, checkpointDir)
+		require.NoError(t, err)
+
+		req := newMemoryCheckpointTestRequest()
+		restore := blockMemoryCheckpointWrites(t, filepath.Join(checkpointDir, memoryPluginStateFileName))
+
+		resp, err := policy.Allocate(context.Background(), req)
+		require.Error(t, err)
+		require.Nil(t, resp)
+
+		restore()
+		_, err = policy.Allocate(context.Background(), req)
+		require.NoError(t, err)
+
+		restoredPolicy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, checkpointDir)
+		require.NoError(t, err)
+		require.NotNil(t, restoredPolicy.state.GetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName))
+	})
+
+	t.Run("RemovePod", func(t *testing.T) {
+		t.Parallel()
+
+		checkpointDir := t.TempDir()
+		policy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, checkpointDir)
+		require.NoError(t, err)
+
+		req := newMemoryCheckpointTestRequest()
+		_, err = policy.Allocate(context.Background(), req)
+		require.NoError(t, err)
+
+		restore := blockMemoryCheckpointWrites(t, filepath.Join(checkpointDir, memoryPluginStateFileName))
+		removeReq := &pluginapi.RemovePodRequest{PodUid: req.PodUid}
+		resp, err := policy.RemovePod(context.Background(), removeReq)
+		require.Error(t, err)
+		require.Nil(t, resp)
+
+		restore()
+		_, err = policy.RemovePod(context.Background(), removeReq)
+		require.NoError(t, err)
+
+		restoredPolicy, err := getTestDynamicPolicyWithInitialization(cpuTopology, machineInfo, checkpointDir)
+		require.NoError(t, err)
+		require.Nil(t, restoredPolicy.state.GetAllocationInfo(v1.ResourceMemory, req.PodUid, req.ContainerName))
+	})
+}
+
+func newMemoryCheckpointTestRequest() *pluginapi.ResourceRequest {
+	return &pluginapi.ResourceRequest{
+		PodUid:        "checkpoint-pod",
+		PodNamespace:  "default",
+		PodName:       "checkpoint-pod",
+		ContainerName: "container",
+		ContainerType: pluginapi.ContainerType_MAIN,
+		ResourceName:  string(v1.ResourceMemory),
+		ResourceRequests: map[string]float64{
+			string(v1.ResourceMemory): 1024 * 1024 * 1024,
+		},
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
+}
+
+func blockMemoryCheckpointWrites(t *testing.T, checkpointPath string) func() {
+	t.Helper()
+
+	checkpoint, err := os.ReadFile(checkpointPath)
+	require.NoError(t, err)
+	info, err := os.Stat(checkpointPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(checkpointPath))
+	require.NoError(t, os.Mkdir(checkpointPath, 0o755))
+
+	restored := false
+	restore := func() {
+		if restored {
+			return
+		}
+		require.NoError(t, os.RemoveAll(checkpointPath))
+		require.NoError(t, os.WriteFile(checkpointPath, checkpoint, info.Mode().Perm()))
+		restored = true
+	}
+	t.Cleanup(restore)
+	return restore
+}

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -737,6 +737,7 @@ func (p *DynamicPolicy) RemovePod(ctx context.Context,
 	}
 	if err := p.state.StoreState(); err != nil {
 		general.ErrorS(err, "store state failed", "podUID", req.PodUid)
+		return nil, fmt.Errorf("store state failed: %w", err)
 	}
 
 	return &pluginapi.RemovePodResponse{}, nil
@@ -1079,6 +1080,10 @@ func (p *DynamicPolicy) Allocate(ctx context.Context,
 		}
 		if err := p.state.StoreState(); err != nil {
 			general.ErrorS(err, "store state failed", "podName", req.PodName, "containerName", req.ContainerName)
+			resp = nil
+			respErr = fmt.Errorf("store state failed: %w", err)
+			_ = p.emitter.StoreInt64(util.MetricNameAllocateFailed, 1, metrics.MetricTypeNameRaw,
+				metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(respErr)})
 		}
 
 		p.Unlock()


### PR DESCRIPTION
Fixes #1221.

Return errors when CPU or memory QRM checkpoint updates fail, and make RemovePod retries persist pending deletions.

Tests cover allocation and removal with forced checkpoint write failures.

- QRM CPU and memory policies now return errors when final checkpoint writes fail during `Allocate` or `RemovePod`.
- Failed `Allocate` operations clear the response and record allocation-failure metrics.
- `RemovePod` persists pending deletions, including when the pod has no stored entries.
- Native CPU allocation handlers now persist state explicitly and return storage errors.
- Tests cover failed writes, retries, and state restoration after policy restart.
- No configuration or dependency changes are included.
- The changes affect the agent QRM plugins. They do not change controller, scheduler, or release wiring.
- Operational risk is low. Operations may now fail where they previously returned success with incomplete checkpoint state.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### English

- QRM CPU and memory policies now return errors when checkpoint persistence fails during `Allocate` or `RemovePod`.
- Failed `Allocate` operations clear the response and record allocation-failure metrics.
- `RemovePod` persists pending deletions, including when no stored pod entry exists.
- CPU allocation handlers explicitly persist state before returning responses.
- Tests cover forced checkpoint failures, retries, and state restoration after policy reload.
- The change affects agent-side QRM policy handling only. It does not change controller, scheduler, release wiring, configuration, or dependencies.
- Rollout risk is low. Checkpoint storage failures now fail operations explicitly and prevent stale state from being restored after a policy restart.

### 简体中文

- QRM CPU 和 memory policy 现在会在 `Allocate` 或 `RemovePod` 的 checkpoint 持久化失败时返回错误。
- `Allocate` 失败时会清除 response，并记录 allocation-failure metric。
- `RemovePod` 会持久化待删除状态，包括没有已存储 pod entry 的情况。
- CPU allocation handler 会在返回 response 前显式持久化状态。
- 测试覆盖强制 checkpoint 失败、重试，以及 policy reload 后的状态恢复。
- 此变更仅影响 agent 侧 QRM policy handling。不涉及 controller、scheduler、release wiring、配置或依赖项。
- 发布风险较低。Checkpoint storage failure 现在会使操作明确失败，并防止 stale state 在 policy restart 后被恢复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->