### PR TITLE
refactor(cpu qrm): allow for dynamic updating of reserved CPUs

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/consts/consts.go
+++ b/pkg/agent/qrm-plugins/cpu/consts/consts.go
@@ -35,6 +35,7 @@ const (
 	CommunicateWithAdvisor     = CPUPluginDynamicPolicyName + "_communicate_with_advisor"
 	SyncCPUBurst               = CPUPluginDynamicPolicyName + "_sync_cpu_burst"
 	SyncSystemExclusivePool    = CPUPluginDynamicPolicyName + "_sync_system_exclusive_pool"
+	SyncReservedCPUs           = CPUPluginDynamicPolicyName + "_sync_reserved_cpus"
 	SyncCPUWeight              = CPUPluginDynamicPolicyName + "_sync_cpu_weight"
 )
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load.go
@@ -427,7 +427,8 @@ func (p *CPUPressureLoadEviction) checkSharedPressureByPoolSize(pod2Pool PodPool
 // accumulateSharedPoolsLimit calculates the cpu core limit used by shared core pool,
 // and it equals: machine-core - cores-for-dedicated-pods - reserved-cores-reclaim-pods - reserved-cores-system-pods.
 func (p *CPUPressureLoadEviction) accumulateSharedPoolsLimit() int {
-	availableCPUSet := p.state.GetMachineState().GetFilteredAvailableCPUSet(p.systemReservedCPUs, nil, nil)
+	reservedCPUs := p.state.GetReservedCPUs()
+	availableCPUSet := p.state.GetMachineState().GetFilteredAvailableCPUSet(reservedCPUs, nil, nil)
 
 	coreNumReservedForReclaim := p.dynamicConf.GetDynamicConfiguration().MinReclaimedResourceForAllocate[v1.ResourceCPU]
 	if coreNumReservedForReclaim.Value() > int64(p.metaServer.NumCPUs) {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/cpueviction/strategy/pressure_load_test.go
@@ -135,6 +135,40 @@ func TestNewCPUPressureLoadEviction(t *testing.T) {
 	as.Nil(createPluginErr)
 	as.Nil(err)
 	as.NotNil(plugin)
+	stateImpl.SetReservedCPUs(plugin.(*CPUPressureLoadEviction).systemReservedCPUs)
+}
+
+func TestCPUPressureLoadEvictionGetCurrentSystemReservedCPUs(t *testing.T) {
+	t.Parallel()
+
+	cpuTopology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+	conf := makeConf(defaultMetricRingSize, int64(defaultCPUPressureEvictionPodGracePeriodSeconds),
+		defaultLoadUpperBoundRatio, defaultLoadLowerBoundRatio,
+		defaultLoadThresholdMetPercentage, defaultReservedForReclaim,
+		defaultReservedForAllocate, 2)
+	metaServer := makeMetaServer(metric.NewFakeMetricsFetcher(metrics.DummyMetrics{}), cpuTopology)
+	stateImpl, err := makeState(cpuTopology)
+	require.NoError(t, err)
+
+	plugin, err := NewCPUPressureLoadEviction(metrics.DummyMetrics{}, metaServer, conf, stateImpl)
+	require.NoError(t, err)
+	eviction := plugin.(*CPUPressureLoadEviction)
+
+	stateImpl.SetReservedCPUs(eviction.systemReservedCPUs)
+	assert.True(t, eviction.state.GetReservedCPUs().Equals(eviction.systemReservedCPUs))
+	staticSharedPoolsLimit := eviction.accumulateSharedPoolsLimit()
+
+	dynamicReservedCPUs := machine.NewCPUSet(0, 2, 4, 6)
+	stateImpl.SetReservedCPUs(dynamicReservedCPUs)
+	assert.True(t, eviction.state.GetReservedCPUs().Equals(dynamicReservedCPUs))
+	assert.Equal(t,
+		staticSharedPoolsLimit+eviction.systemReservedCPUs.Size()-dynamicReservedCPUs.Size(),
+		eviction.accumulateSharedPoolsLimit(),
+	)
+
+	stateImpl.SetReservedCPUs(machine.NewCPUSet())
+	assert.True(t, eviction.state.GetReservedCPUs().IsEmpty())
 }
 
 func TestThresholdMet(t *testing.T) {
@@ -155,6 +189,7 @@ func TestThresholdMet(t *testing.T) {
 	plugin, createPluginErr := NewCPUPressureLoadEviction(metrics.DummyMetrics{}, metaServer, conf, stateImpl)
 	as.Nil(createPluginErr)
 	as.NotNil(plugin)
+	stateImpl.SetReservedCPUs(plugin.(*CPUPressureLoadEviction).systemReservedCPUs)
 
 	pod1UID := string(uuid.NewUUID())
 	testName := "test"
@@ -445,6 +480,7 @@ func TestGetTopEvictionPods(t *testing.T) {
 	as.Nil(createPluginErr)
 	as.Nil(err)
 	as.NotNil(plugin)
+	stateImpl.SetReservedCPUs(plugin.(*CPUPressureLoadEviction).systemReservedCPUs)
 
 	pod1UID := string(uuid.NewUUID())
 	pod2UID := string(uuid.NewUUID())
@@ -1655,6 +1691,7 @@ func TestCPUPressureLoadEviction_collectMetrics(t *testing.T) {
 			as.Nil(err)
 			as.NotNil(plugin)
 			p := plugin.(*CPUPressureLoadEviction)
+			stateImpl.SetReservedCPUs(p.systemReservedCPUs)
 			p.collectMetrics(context.TODO())
 			metricRing := p.metricsHistory[consts.MetricLoad1MinContainer][commonstate.PoolNameShare][""]
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/canonical/optimizer.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/canonical/optimizer.go
@@ -119,7 +119,7 @@ func (o *canonicalHintOptimizer) populateHintsByPreferPolicy(numaNodes []int, pr
 			general.Warningf("NUMA node %d not found in machineState, skipping", nodeID)
 			continue
 		}
-		availableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(o.reservedCPUs)
+		availableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(o.state.GetReservedCPUs())
 		if !cpuutil.CPUIsSufficient(request, availableCPUQuantity) {
 			general.Warningf("numa_binding shared_cores container skip NUMA: %d available: %.3f request: %.3f",
 				nodeID, availableCPUQuantity, request)
@@ -170,8 +170,9 @@ func (o *canonicalHintOptimizer) filterNUMANodesByHintPreferLowThreshold(request
 			general.Warningf("NUMA node %d not found in machineState, skipping", nodeID)
 			continue
 		}
-		availableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(o.reservedCPUs)
-		allocatableCPUQuantity := machineState[nodeID].GetFilteredDefaultCPUSet(nil, nil).Difference(o.reservedCPUs).Size()
+		reservedCPUs := o.state.GetReservedCPUs()
+		availableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(reservedCPUs)
+		allocatableCPUQuantity := machineState[nodeID].GetFilteredDefaultCPUSet(nil, nil).Difference(reservedCPUs).Size()
 
 		if allocatableCPUQuantity == 0 {
 			general.Warningf("numa: %d allocatable cpu quantity is zero", nodeID)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/canonical/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/canonical/optimizer_test.go
@@ -62,6 +62,7 @@ func TestNewCanonicalHintOptimizer(t *testing.T) {
 		State:        stateImpl,
 		ReservedCPUs: machine.NewCPUSet(0),
 	}
+	stateImpl.SetReservedCPUs(options.ReservedCPUs)
 
 	optimizer, err := NewCanonicalHintOptimizer(options)
 	require.NoError(t, err)
@@ -746,6 +747,9 @@ func TestCanonicalHintOptimizer_OptimizeHints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			if tt.fields.state != nil {
+				tt.fields.state.SetReservedCPUs(tt.fields.reservedCPUs)
+			}
 			o := &canonicalHintOptimizer{
 				state:                         tt.fields.state,
 				reservedCPUs:                  tt.fields.reservedCPUs,

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/metricbased/optimizer.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/metricbased/optimizer.go
@@ -178,7 +178,7 @@ func (o *metricBasedHintOptimizer) isNUMAOverThreshold(numa int, threshold, requ
 
 	used += request
 
-	allocatable := float64(machineState[numa].GetFilteredDefaultCPUSet(nil, nil).Difference(o.reservedCPUs).Size())
+	allocatable := float64(machineState[numa].GetFilteredDefaultCPUSet(nil, nil).Difference(o.state.GetReservedCPUs()).Size())
 
 	if allocatable == 0 {
 		return false, fmt.Errorf("invalid allocatable")

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/metricbased/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/metricbased/optimizer_test.go
@@ -416,7 +416,8 @@ func TestMetricBasedHintOptimizer_OptimizeHints(t *testing.T) {
 func TestMetricBasedHintOptimizer_isNUMAOverThreshold(t *testing.T) {
 	t.Parallel()
 
-	// cpuTopology, _ := machine.GenerateDummyCPUTopology(8, 1, 2) // 2 NUMA nodes, 4 CPUs each
+	cpuTopology, err := machine.GenerateDummyCPUTopology(8, 1, 2)
+	require.NoError(t, err)
 	machineState := state.NUMANodeMap{
 		0: &state.NUMANodeState{DefaultCPUSet: machine.NewCPUSet(0, 1, 2, 3)},
 		1: &state.NUMANodeState{DefaultCPUSet: machine.NewCPUSet(4, 5, 6, 7)},
@@ -552,8 +553,21 @@ func TestMetricBasedHintOptimizer_isNUMAOverThreshold(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			stateImpl, err := state.NewCheckpointState(
+				&statedirectory.StateDirectoryConfiguration{StateFileDirectory: t.TempDir()},
+				"test",
+				"test",
+				cpuTopology,
+				false,
+				state.GenerateMachineStateFromPodEntries,
+				metrics.DummyMetrics{},
+			)
+			require.NoError(t, err)
+			stateImpl.SetReservedCPUs(tt.fields.reservedCPUs)
+
 			o := &metricBasedHintOptimizer{
 				mutex:             sync.RWMutex{},
+				state:             stateImpl,
 				numaMetrics:       tt.fields.numaMetrics,
 				reservedCPUs:      tt.fields.reservedCPUs,
 				metricSampleTime:  10 * time.Minute,

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer.go
@@ -365,7 +365,7 @@ func (o *resourcePackageHintOptimizer) calculateNodeCPUMetrics(
 
 		// Calculate the actual available physical CPU quantity for "Unpinned" pods.
 		// unpinnedAllocatable is calculated by subtracting reservedCPUs and PinnedCPUs from the union of DefaultCPUSet and AllocatedCPUSet.
-		unpinnedAllocatable := float64(ns.DefaultCPUSet.Union(ns.AllocatedCPUSet).Difference(o.reservedCPUs).Difference(pinnedCPUSet).Size())
+		unpinnedAllocatable := float64(ns.DefaultCPUSet.Union(ns.AllocatedCPUSet).Difference(o.state.GetReservedCPUs()).Difference(pinnedCPUSet).Size())
 
 		unpinnedAvailable = general.MaxFloat64(unpinnedAllocatable-unpinnedPreciseAllocated, 0)
 	}

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/resourcepackage/optimizer_test.go
@@ -52,12 +52,14 @@ func (m *MockState) GetMachineState() state.NUMANodeMap {
 }
 
 // Implement other required methods with empty implementations
+func (m *MockState) GetReservedCPUs() machine.CPUSet  { return machine.NewCPUSet() }
 func (m *MockState) GetNUMAHeadroom() map[int]float64 { return nil }
 func (m *MockState) GetPodEntries() state.PodEntries  { return nil }
 func (m *MockState) GetAllocationInfo(podUID string, containerName string) *state.AllocationInfo {
 	return nil
 }
 func (m *MockState) GetAllowSharedCoresOverlapReclaimedCores() bool               { return false }
+func (m *MockState) SetReservedCPUs(reservedCPUs machine.CPUSet)                  {}
 func (m *MockState) SetMachineState(numaNodeMap state.NUMANodeMap, persist bool)  {}
 func (m *MockState) SetNUMAHeadroom(numaHeadroom map[int]float64, persist bool)   {}
 func (m *MockState) SetPodEntries(podEntries state.PodEntries, writeThrough bool) {}
@@ -235,6 +237,7 @@ func TestResourcePackageHintOptimizer_calculateNodeCPUMetrics(t *testing.T) {
 	convey.Convey("Test calculateNodeCPUMetrics", t, func() {
 		optimizer := &resourcePackageHintOptimizer{
 			reservedCPUs: machine.NewCPUSet(),
+			state:        &MockState{},
 		}
 
 		convey.Convey("ns is nil", func() {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer.go
@@ -126,7 +126,7 @@ func (o *cpuTotalRequestThresholdHintOptimizer) OptimizeHints(
 }
 
 func (o *cpuTotalRequestThresholdHintOptimizer) getTotalAllocatable(numaSet machine.CPUSet) float64 {
-	return float64(o.metaServer.CPUDetails.CPUsInNUMANodes(numaSet.ToSliceInt()...).Difference(o.reservedCPUs).Size())
+	return float64(o.metaServer.CPUDetails.CPUsInNUMANodes(numaSet.ToSliceInt()...).Difference(o.state.GetReservedCPUs()).Size())
 }
 
 func (o *cpuTotalRequestThresholdHintOptimizer) getTotalRequest(req *pluginapi.ResourceRequest,

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/hintoptimizer/policy/totalrequestthreshold/optimizer_test.go
@@ -41,6 +41,11 @@ type fakeState struct {
 	podEntries   state.PodEntries
 	allocations  map[string]map[string]*state.AllocationInfo
 	allowOverlap bool
+	reservedCPUs machine.CPUSet
+}
+
+func (f *fakeState) GetReservedCPUs() machine.CPUSet {
+	return f.reservedCPUs.Clone()
 }
 
 func (f *fakeState) GetMachineState() state.NUMANodeMap {
@@ -64,6 +69,10 @@ func (f *fakeState) GetAllocationInfo(podUID string, containerName string) *stat
 
 func (f *fakeState) GetAllowSharedCoresOverlapReclaimedCores() bool {
 	return f.allowOverlap
+}
+
+func (f *fakeState) SetReservedCPUs(reservedCPUs machine.CPUSet) {
+	f.reservedCPUs = reservedCPUs.Clone()
 }
 
 func (f *fakeState) SetMachineState(numaNodeMap state.NUMANodeMap, _ bool) {
@@ -182,10 +191,17 @@ func TestGetTotalAllocatableUsesTopologyCPUDetails(t *testing.T) {
 				PodFetcher: &pod.PodFetcherStub{},
 			},
 		},
+		state:        &fakeState{},
 		reservedCPUs: machine.NewCPUSet(0),
 	}
+	optimizer.state.SetReservedCPUs(optimizer.reservedCPUs)
 
 	require.Equal(t, float64(cpuTopology.CPUDetails.CPUsInNUMANodes(0).Difference(optimizer.reservedCPUs).Size()),
+		optimizer.getTotalAllocatable(machine.NewCPUSet(0)))
+
+	dynamicReservedCPUs := machine.NewCPUSet(1)
+	optimizer.state.SetReservedCPUs(dynamicReservedCPUs)
+	require.Equal(t, float64(cpuTopology.CPUDetails.CPUsInNUMANodes(0).Difference(dynamicReservedCPUs).Size()),
 		optimizer.getTotalAllocatable(machine.NewCPUSet(0)))
 }
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy.go
@@ -80,6 +80,7 @@ const (
 	syncCPUIdlePeriod             = 30 * time.Second
 	syncCPUBurstPeriod            = 10 * time.Second
 	syncSystemExclusivePoolPeriod = 10 * time.Second
+	syncReservedCPUsPeriod        = 30 * time.Second
 	syncCPUWeightPeriod           = 10 * time.Second
 
 	healthCheckTolerationTimes = 3
@@ -131,7 +132,6 @@ type DynamicPolicy struct {
 	// todo if we want to use dynamic configuration, we'd better not use self-defined conf
 	enableCPUAdvisor                          bool
 	getAdviceInterval                         time.Duration
-	reservedCPUs                              machine.CPUSet
 	cpuAdvisorSocketAbsPath                   string
 	cpuPluginSocketAbsPath                    string
 	extraStateFileAbsPath                     string
@@ -171,7 +171,6 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		return false, agent.ComponentStub{}, fmt.Errorf("GetCoresReservedForSystem for reservedCPUsNum: %d, reservedCPUList: %s failed with error: %v",
 			conf.ReservedCPUCores, conf.ReservedCPUList, reserveErr)
 	}
-
 	wrappedEmitter := agentCtx.EmitterPool.GetDefaultMetricsEmitter().WithTags(agentName, metrics.MetricTag{
 		Key: util.QRMPluginPolicyTagName,
 		Val: cpuconsts.CPUResourcePluginPolicyNameDynamic,
@@ -182,6 +181,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 	if stateErr != nil {
 		return false, agent.ComponentStub{}, fmt.Errorf("NewCheckpointState failed with error: %v", stateErr)
 	}
+	stateImpl.SetReservedCPUs(reservedCPUs)
 
 	state.SetReadonlyState(stateImpl)
 	state.SetReadWriteState(stateImpl)
@@ -198,10 +198,6 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		}
 	}
 
-	// since the reservedCPUs won't influence stateImpl directly.
-	// so we don't modify stateImpl with reservedCPUs here.
-	// for those pods have already been allocated reservedCPUs,
-	// we won't touch them and wait them to be deleted the next update.
 	policyImplement := &DynamicPolicy{
 		name:   fmt.Sprintf("%s_%s", agentName, cpuconsts.CPUResourcePluginPolicyNameDynamic),
 		stopCh: make(chan struct{}),
@@ -229,7 +225,6 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		enableSNBHighNumaPreference:   conf.EnableSNBHighNumaPreference,
 		enableCPUAdvisor:              conf.CPUQRMPluginConfig.EnableCPUAdvisor,
 		getAdviceInterval:             conf.CPUQRMPluginConfig.GetAdviceInterval,
-		reservedCPUs:                  reservedCPUs,
 		extraStateFileAbsPath:         conf.ExtraStateFileAbsPath,
 		enableCPUBurst:                conf.CPUQRMPluginConfig.EnableCPUBurst,
 		enableSyncingCPUIdle:          conf.CPUQRMPluginConfig.EnableSyncingCPUIdle,
@@ -405,6 +400,17 @@ func (p *DynamicPolicy) Start() (err error) {
 		qrm.QRMCPUPluginPeriodicalHandlerGroupName, p.syncSystemExclusivePool, syncSystemExclusivePoolPeriod, healthCheckTolerationTimes)
 	if err != nil {
 		general.Errorf("start %v failed,err:%v", cpuconsts.SyncSystemExclusivePool, err)
+	}
+
+	// Runtime reserved CPU sync is only meaningful when kubelet /configz is the
+	// source of truth. Static Katalyst reservation mode intentionally keeps the
+	// startup value unchanged.
+	if p.conf.UseKubeletReservedConfig {
+		err = periodicalhandler.RegisterPeriodicalHandlerWithHealthz(cpuconsts.SyncReservedCPUs, general.HealthzCheckStateNotReady,
+			qrm.QRMCPUPluginPeriodicalHandlerGroupName, p.syncReservedCPUs, syncReservedCPUsPeriod, healthCheckTolerationTimes)
+		if err != nil {
+			general.Errorf("start %v failed,err:%v", cpuconsts.SyncReservedCPUs, err)
+		}
 	}
 
 	// start cpu-idle syncing if needed
@@ -588,9 +594,10 @@ func (p *DynamicPolicy) GetResourcesAllocation(_ context.Context,
 
 	podEntries := p.state.GetPodEntries()
 	machineState := p.state.GetMachineState()
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	// rumpUpPooledCPUs is the total available cpu cores minus those that are reserved
-	rumpUpPooledCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
+	rumpUpPooledCPUs := machineState.GetFilteredAvailableCPUSet(reservedCPUs,
 		func(ai *state.AllocationInfo) bool {
 			return ai.CheckDedicated() || ai.CheckSharedNUMABinding()
 		},
@@ -790,13 +797,14 @@ func (p *DynamicPolicy) GetTopologyAwareAllocatableResources(_ context.Context,
 	general.Infof("is called")
 
 	numaNodes := p.machineInfo.CPUDetails.NUMANodes().ToSliceInt()
+	reservedCPUs := p.state.GetReservedCPUs()
 	topologyAwareAllocatableQuantityList := make([]*pluginapi.TopologyAwareQuantity, 0, len(numaNodes))
 	topologyAwareCapacityQuantityList := make([]*pluginapi.TopologyAwareQuantity, 0, len(numaNodes))
 
 	for _, numaNode := range numaNodes {
 		numaNodeCPUs := p.machineInfo.CPUDetails.CPUsInNUMANodes(numaNode).Clone()
 		topologyAwareAllocatableQuantityList = append(topologyAwareAllocatableQuantityList, &pluginapi.TopologyAwareQuantity{
-			ResourceValue: float64(numaNodeCPUs.Difference(p.reservedCPUs).Size()),
+			ResourceValue: float64(numaNodeCPUs.Difference(reservedCPUs).Size()),
 			Node:          uint64(numaNode),
 		})
 		topologyAwareCapacityQuantityList = append(topologyAwareCapacityQuantityList, &pluginapi.TopologyAwareQuantity{
@@ -810,7 +818,7 @@ func (p *DynamicPolicy) GetTopologyAwareAllocatableResources(_ context.Context,
 			string(v1.ResourceCPU): {
 				IsNodeResource:                       false,
 				IsScalarResource:                     true,
-				AggregatedAllocatableQuantity:        float64(p.machineInfo.NumCPUs - p.reservedCPUs.Size()),
+				AggregatedAllocatableQuantity:        float64(p.machineInfo.NumCPUs - reservedCPUs.Size()),
 				TopologyAwareAllocatableQuantityList: topologyAwareAllocatableQuantityList,
 				AggregatedCapacityQuantity:           float64(p.machineInfo.NumCPUs),
 				TopologyAwareCapacityQuantityList:    topologyAwareCapacityQuantityList,
@@ -1257,7 +1265,7 @@ func (p *DynamicPolicy) generateHintOptimizerFactoryOptions() policy.HintOptimiz
 		MetaServer:             p.metaServer,
 		ResourcePackageManager: p.resourcePackageManager,
 		State:                  p.state,
-		ReservedCPUs:           p.reservedCPUs,
+		ReservedCPUs:           p.state.GetReservedCPUs(),
 	}
 }
 
@@ -1319,23 +1327,24 @@ func (p *DynamicPolicy) cleanPools() error {
 
 // initReservePool initializes reserve pool for system cores workload
 func (p *DynamicPolicy) initReservePool() error {
+	reservedCPUs := p.state.GetReservedCPUs()
 	reserveAllocationInfo := p.state.GetAllocationInfo(commonstate.PoolNameReserve, commonstate.FakedContainerName)
 	if reserveAllocationInfo != nil && !reserveAllocationInfo.AllocationResult.IsEmpty() {
 		general.Infof("pool: %s allocation result transform from %s to %s",
-			commonstate.PoolNameReserve, reserveAllocationInfo.AllocationResult.String(), p.reservedCPUs)
+			commonstate.PoolNameReserve, reserveAllocationInfo.AllocationResult.String(), reservedCPUs)
 	}
 
-	general.Infof("initReservePool %s: %s", commonstate.PoolNameReserve, p.reservedCPUs)
-	topologyAwareAssignments, err := machine.GetNumaAwareAssignments(p.machineInfo.CPUTopology, p.reservedCPUs)
+	general.Infof("initReservePool %s: %s", commonstate.PoolNameReserve, reservedCPUs)
+	topologyAwareAssignments, err := machine.GetNumaAwareAssignments(p.machineInfo.CPUTopology, reservedCPUs)
 	if err != nil {
 		return fmt.Errorf("unable to calculate topologyAwareAssignments for pool: %s, result cpuset: %s, error: %v",
-			commonstate.PoolNameReserve, p.reservedCPUs.String(), err)
+			commonstate.PoolNameReserve, reservedCPUs.String(), err)
 	}
 
 	curReserveAllocationInfo := &state.AllocationInfo{
 		AllocationMeta:                   commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameReserve),
-		AllocationResult:                 p.reservedCPUs.Clone(),
-		OriginalAllocationResult:         p.reservedCPUs.Clone(),
+		AllocationResult:                 reservedCPUs.Clone(),
+		OriginalAllocationResult:         reservedCPUs.Clone(),
 		TopologyAwareAssignments:         topologyAwareAssignments,
 		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(topologyAwareAssignments),
 	}
@@ -1347,8 +1356,9 @@ func (p *DynamicPolicy) initReservePool() error {
 // initReclaimPool initializes pools for reclaimed-cores.
 // if this info already exists in state-file, just use it, otherwise calculate right away
 func (p *DynamicPolicy) initReclaimPool() error {
+	reservedCPUs := p.state.GetReservedCPUs()
 	// for reclaimed pool, we must make them exist when the node isn't in hybrid mode even if cause overlap
-	allAvailableCPUs := p.machineInfo.CPUDetails.CPUs().Difference(p.reservedCPUs)
+	allAvailableCPUs := p.machineInfo.CPUDetails.CPUs().Difference(reservedCPUs)
 	defaultReservedReclaimedCPUSet, _, tErr := calculator.TakeHTByNUMABalance(p.machineInfo, allAvailableCPUs, p.reservedReclaimedCPUsSize)
 	if tErr != nil {
 		return fmt.Errorf("fallback TakeHTByNUMABalance faild in generatePoolsAndIsolation for defaultReservedReclaimedCPUSet with error: %v", tErr)
@@ -1368,7 +1378,7 @@ func (p *DynamicPolicy) initReclaimPool() error {
 		noneResidentCPUs := podEntries.GetFilteredPoolsCPUSet(state.ResidentPools)
 
 		machineState := p.state.GetMachineState()
-		availableCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
+		availableCPUs := machineState.GetFilteredAvailableCPUSet(reservedCPUs,
 			func(ai *state.AllocationInfo) bool {
 				return ai.CheckDedicated() || ai.CheckSharedNUMABinding()
 			},
@@ -1443,7 +1453,8 @@ func (p *DynamicPolicy) checkNonBindingShareCoresCpuResource(req *pluginapi.Reso
 	shareCoresAllocatedInt := state.GetNonBindingSharedRequestedQuantityFromPodEntries(p.state.GetPodEntries(), map[string]float64{req.PodUid: reqFloat64}, p.getContainerRequestedCores)
 
 	machineState := p.state.GetMachineState()
-	pooledCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
+	reservedCPUs := p.state.GetReservedCPUs()
+	pooledCPUs := machineState.GetFilteredAvailableCPUSet(reservedCPUs,
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckDedicated),
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckSharedOrDedicatedNUMABinding))
 
@@ -1557,5 +1568,88 @@ func (p *DynamicPolicy) updateAllocationInfo(podUID, containerName string, oldAl
 	}
 
 	p.state.SetAllocationInfo(podUID, containerName, allocationInfo, persist)
+	return nil
+}
+
+// applyReservedCPUs publishes a validated reserved CPU set
+// without changing existing allocation entries.
+func (p *DynamicPolicy) applyReservedCPUs(nextReservedCPUs machine.CPUSet) error {
+	p.state.SetReservedCPUs(nextReservedCPUs)
+	if err := p.initReservePool(); err != nil {
+		general.Errorf("initReservePool failed with error: %v", err)
+		return err
+	}
+	return nil
+}
+
+// syncReservedCPUs is the periodical handler entrypoint for kubelet reserved CPU sync.
+//
+// The periodical handler framework does not consume returned errors, so the
+// actual reconciliation lives in syncReservedCPUsOnce for testability and this
+// wrapper only logs failures.
+func (p *DynamicPolicy) syncReservedCPUs(_ *config.Configuration,
+	_ interface{},
+	_ *dynamicconfig.DynamicAgentConfiguration,
+	_ metrics.MetricEmitter,
+	_ *metaserver.MetaServer,
+) {
+	if err := p.syncReservedCPUsOnce(); err != nil {
+		general.Errorf("sync reserved CPUs failed with error: %v", err)
+	}
+}
+
+// syncReservedCPUsOnce reconciles DynamicPolicy with kubelet reserved CPU configuration.
+// If the reserved cpus did not change, it returns early.
+func (p *DynamicPolicy) syncReservedCPUsOnce() error {
+	currentReservedCPUList := p.conf.ReservedCPUList
+	currentReservedCPUCores := p.conf.ReservedCPUCores
+	currentReservedCPUs := p.state.GetReservedCPUs()
+	// Calculate the new reserved cpus.
+	nextReservedCPUs, err := cpuutil.GetCoresReservedForSystem(
+		p.conf,
+		p.metaServer,
+		p.machineInfo,
+		p.machineInfo.CPUDetails.CPUs().Clone(),
+	)
+	if err != nil {
+		_ = general.UpdateHealthzStateByError(cpuconsts.SyncReservedCPUs, err)
+		return err
+	}
+
+	if nextReservedCPUs.Equals(currentReservedCPUs) {
+		// No kubelet change was observed. Mark the handler healthy and return early.
+		_ = general.UpdateHealthzState(cpuconsts.SyncReservedCPUs, general.HealthzCheckStateReady, "")
+		return nil
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	// this function rollbacks reserved cpus with previous values if there are any errors
+	rollbackReservedCPUConfig := func() error {
+		p.conf.ReservedCPUList = currentReservedCPUList
+		p.conf.ReservedCPUCores = currentReservedCPUCores
+		p.state.SetReservedCPUs(currentReservedCPUs)
+		if err := p.initReservePool(); err != nil {
+			general.Errorf("initReservePool failed with error: %v", err)
+			return err
+		}
+		return nil
+	}
+
+	// Apply the new reserved cpus without changing existing allocations.
+	if applyErr := p.applyReservedCPUs(nextReservedCPUs); applyErr != nil {
+		if rollbackErr := rollbackReservedCPUConfig(); rollbackErr != nil {
+			general.Errorf("rollbackReservedCPUConfig failed with error: %v", rollbackErr)
+			_ = general.UpdateHealthzStateByError(cpuconsts.SyncReservedCPUs, rollbackErr)
+			return rollbackErr
+		}
+		general.Errorf("applyReservedCPUs failed with error: %v", applyErr)
+		_ = general.UpdateHealthzStateByError(cpuconsts.SyncReservedCPUs, applyErr)
+		return applyErr
+	}
+
+	general.Infof("sync reserved CPUs from %q to %q", currentReservedCPUs.String(), nextReservedCPUs.String())
+	_ = general.UpdateHealthzState(cpuconsts.SyncReservedCPUs, general.HealthzCheckStateReady, "")
 	return nil
 }

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_advisor_handler.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_advisor_handler.go
@@ -1309,6 +1309,7 @@ func (p *DynamicPolicy) applyBlocks(blockCPUSet advisorapi.BlockCPUSet, resp *ad
 	newEntries := make(state.PodEntries)
 	dedicatedCPUSet := machine.NewCPUSet()
 	pooledUnionDedicatedCPUSet := machine.NewCPUSet()
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	// calculate NUMAs without actual numa_binding reclaimed pods
 	nonReclaimActualBindingNUMAs := p.state.GetMachineState().GetFilteredNUMASet(state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckReclaimedActualNUMABinding))
@@ -1441,7 +1442,7 @@ func (p *DynamicPolicy) applyBlocks(blockCPUSet advisorapi.BlockCPUSet, resp *ad
 	notAllocatablePoolsCPUs := state.GetUnitedPoolsCPUs(p.state.GetPodEntries(), state.IsForbiddenPool, commonstate.IsSystemPool)
 	// rampUpCPUs include reclaim pool in NUMAs without NUMA_binding cpus
 	rampUpCPUs := p.machineInfo.CPUDetails.CPUs().
-		Difference(p.reservedCPUs).
+		Difference(reservedCPUs).
 		Difference(dedicatedCPUSet).
 		Difference(sharedBindingNUMACPUs).
 		Difference(notAllocatablePoolsCPUs)
@@ -1622,11 +1623,12 @@ func (p *DynamicPolicy) applyNUMAHeadroom(resp *advisorapi.ListAndWatchResponse)
 }
 
 func (p *DynamicPolicy) reviseReclaimPool(newEntries state.PodEntries, nonReclaimActualBindingNUMAs, pooledUnionDedicatedCPUSet machine.CPUSet) error {
+	reservedCPUs := p.state.GetReservedCPUs()
 	// if there is no block for state.PoolNameReclaim pool,
 	// we must make it existing here even if cause overlap
 	if newEntries.CheckPoolEmpty(commonstate.PoolNameReclaim) {
 		notAllocatablePoolsCPUs := state.GetUnitedPoolsCPUs(p.state.GetPodEntries(), state.IsForbiddenPool, commonstate.IsSystemPool)
-		reclaimPoolCPUSet := p.machineInfo.CPUDetails.CPUs().Difference(p.reservedCPUs).Difference(pooledUnionDedicatedCPUSet).Difference(notAllocatablePoolsCPUs)
+		reclaimPoolCPUSet := p.machineInfo.CPUDetails.CPUs().Difference(reservedCPUs).Difference(pooledUnionDedicatedCPUSet).Difference(notAllocatablePoolsCPUs)
 		if reclaimPoolCPUSet.IsEmpty() {
 			reclaimPoolCPUSet = p.reservedReclaimedCPUSet.Clone()
 			general.Infof("fallback takeByNUMABalance for reclaimPoolCPUSet: %s", reclaimPoolCPUSet.String())

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers.go
@@ -73,7 +73,8 @@ func (p *DynamicPolicy) sharedCoresWithoutNUMABindingAllocationHandler(_ context
 	}
 
 	machineState := p.state.GetMachineState()
-	pooledCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
+	reservedCPUs := p.state.GetReservedCPUs()
+	pooledCPUs := machineState.GetFilteredAvailableCPUSet(reservedCPUs,
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckDedicated),
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckSharedOrDedicatedNUMABinding))
 	// cores that are not allocatable from user binding need to be deducted from the pool.
@@ -654,9 +655,10 @@ func (p *DynamicPolicy) allocateNumaBindingCPUs(numCPUs int, hint *pluginapi.Top
 	hintNodes := hint.Nodes
 	pkgName := rputil.GetResourcePackageName(reqAnnotations)
 	numaRPPinnedCPUSet := machineState.GetNUMAResourcePackagePinnedCPUSet()
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	for _, numaNode := range hintNodes {
-		availableCPUs := machineState[int(numaNode)].GetAvailableCPUSet(p.reservedCPUs)
+		availableCPUs := machineState[int(numaNode)].GetAvailableCPUSet(reservedCPUs)
 
 		// Filter available CPUs based on Resource Package (RP) pinning rules:
 		// 1. If the current RP has pinned CPUs, restrict allocation strictly to those CPUs.
@@ -1074,7 +1076,8 @@ func (p *DynamicPolicy) adjustPoolsAndIsolatedEntries(
 	machineState state.NUMANodeMap,
 	persistCheckpoint bool,
 ) error {
-	availableCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs, nil,
+	reservedCPUs := p.state.GetReservedCPUs()
+	availableCPUs := machineState.GetFilteredAvailableCPUSet(reservedCPUs, nil,
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckDedicatedNUMABindingNUMAExclusive))
 
 	// rpPinnedCPUSet contains the pinned CPU sets for resource packages
@@ -1244,6 +1247,7 @@ func (p *DynamicPolicy) applyPoolsAndIsolatedInfo(poolsCPUSet map[string]machine
 ) error {
 	newPodEntries := make(state.PodEntries)
 	unionDedicatedIsolatedCPUSet := machine.NewCPUSet()
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	// calculate NUMAs without actual numa_binding reclaimed pods
 	nonReclaimActualBindingNUMAs := p.state.GetMachineState().GetFilteredNUMASet(state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckReclaimedActualNUMABinding))
@@ -1341,7 +1345,7 @@ func (p *DynamicPolicy) applyPoolsAndIsolatedInfo(poolsCPUSet map[string]machine
 	sharedBindingNUMACPUs := p.machineInfo.CPUDetails.CPUsInNUMANodes(sharedBindingNUMAs.UnsortedList()...)
 	notAllocatablePoolsCPUs := state.GetUnitedPoolsCPUs(newPodEntries, state.IsForbiddenPool, commonstate.IsSystemPool)
 	// rampUpCPUs include reclaim pool in NUMAs without NUMA_binding cpus
-	rampUpCPUs := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs,
+	rampUpCPUs := machineState.GetFilteredAvailableCPUSet(reservedCPUs,
 		nil,
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckDedicatedNUMABindingNUMAExclusive)).
 		Difference(unionDedicatedIsolatedCPUSet).
@@ -1534,6 +1538,7 @@ func (p *DynamicPolicy) generateNUMABindingPoolsCPUSetInPlace(poolsCPUSet map[st
 	numaToPoolQuantityMap := make(map[int]map[string]int)
 	originalAvailableCPUSet := availableCPUs.Clone()
 	enableReclaim := p.dynamicConfig.GetDynamicConfiguration().EnableReclaim
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	for poolName, numaToQuantity := range poolsQuantityMap {
 		for numaID, quantity := range numaToQuantity {
@@ -1552,7 +1557,7 @@ func (p *DynamicPolicy) generateNUMABindingPoolsCPUSetInPlace(poolsCPUSet map[st
 
 	for numaID, numaPoolsToQuantityMap := range numaToPoolQuantityMap {
 		numaPoolsTotalQuantity := general.SumUpMapValues(numaPoolsToQuantityMap)
-		numaCPUs := p.machineInfo.CPUDetails.CPUsInNUMANodes(numaID).Difference(p.reservedCPUs)
+		numaCPUs := p.machineInfo.CPUDetails.CPUsInNUMANodes(numaID).Difference(reservedCPUs)
 		numaAvailableCPUs := numaCPUs.Intersection(availableCPUs)
 		availableSize := numaAvailableCPUs.Size()
 
@@ -1594,6 +1599,7 @@ func (p *DynamicPolicy) generatePoolsAndIsolation(
 	reclaimOverlapShareRatio map[string]float64) (poolsCPUSet map[string]machine.CPUSet,
 	isolatedCPUSet map[string]map[string]machine.CPUSet, err error,
 ) {
+	reservedCPUs := p.state.GetReservedCPUs()
 	poolsBindingNUMAs := sets.NewInt()
 	poolsToSkip := make([]string, 0, len(poolsQuantityMap))
 	nonBindingPoolsQuantityMap := make(map[string]int)
@@ -1722,7 +1728,7 @@ func (p *DynamicPolicy) generatePoolsAndIsolation(
 
 	// deal with reserve pool
 	if poolsCPUSet[commonstate.PoolNameReserve].IsEmpty() {
-		poolsCPUSet[commonstate.PoolNameReserve] = p.reservedCPUs.Clone()
+		poolsCPUSet[commonstate.PoolNameReserve] = reservedCPUs
 		general.Infof("set pool %s:%s", commonstate.PoolNameReserve, poolsCPUSet[commonstate.PoolNameReserve].String())
 	} else {
 		err = fmt.Errorf("static pool %s result: %s is generated dynamically", commonstate.PoolNameReserve, poolsCPUSet[commonstate.PoolNameReserve].String())
@@ -2204,6 +2210,7 @@ func (p *DynamicPolicy) getSystemPoolCPUSetAndNumaAwareAssignments(podEntries st
 	if allocationInfo == nil {
 		return machine.CPUSet{}, nil, fmt.Errorf("allocationInfo is nil")
 	}
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	poolCPUSet := machine.NewCPUSet()
 	specifiedPoolName := allocationInfo.GetSpecifiedPoolName()
@@ -2230,7 +2237,7 @@ func (p *DynamicPolicy) getSystemPoolCPUSetAndNumaAwareAssignments(podEntries st
 	if poolCPUSet.IsEmpty() {
 		// if the pod is numa binding, get the default cpuset from machine state
 		if allocationInfo.CheckNUMABinding() {
-			poolCPUSet = p.state.GetMachineState().GetAvailableCPUSet(p.reservedCPUs)
+			poolCPUSet = p.state.GetMachineState().GetAvailableCPUSet(reservedCPUs)
 		}
 
 		// if the default cpuset is empty or no numa binding, use all cpuset as default cpuset

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_allocation_handlers_test.go
@@ -546,8 +546,8 @@ func TestDynamicPolicy_allocateNumaBindingCPUs(t *testing.T) {
 
 			p, err := getTestDynamicPolicyWithInitialization(cpuTopology, tmpDir)
 			as.Nil(err)
-			p.reservedCPUs = machine.NewCPUSet()
-			t.Logf("Reserved: %s", p.reservedCPUs.String())
+			p.state.SetReservedCPUs(machine.NewCPUSet())
+			t.Logf("Reserved: %s", p.state.GetReservedCPUs().String())
 
 			got, err := p.allocateNumaBindingCPUs(tt.args.numCPUs, tt.args.hint, tt.args.machineState, tt.args.reqAnnotations)
 			if (err != nil) != tt.wantErr {
@@ -665,7 +665,7 @@ func TestDynamicPolicy_generateNUMABindingPoolsCPUSetInPlace(t *testing.T) {
 
 			// Clear state to ensure clean slate
 			p.state.SetPodEntries(state.PodEntries{}, false)
-			p.reservedCPUs = machine.NewCPUSet()
+			p.state.SetReservedCPUs(machine.NewCPUSet())
 
 			p.dynamicConfig.GetDynamicConfiguration().EnableReclaim = tt.enableReclaim
 
@@ -703,7 +703,7 @@ func TestDynamicPolicy_adjustPoolsAndIsolatedEntries_Pinned(t *testing.T) {
 	as.Nil(err)
 
 	// Clear reserved CPUs to ensure deterministic allocation for test
-	p.reservedCPUs = machine.NewCPUSet()
+	p.state.SetReservedCPUs(machine.NewCPUSet())
 
 	// Enable Reclaim
 	p.dynamicConfig.GetDynamicConfiguration().EnableReclaim = true
@@ -947,7 +947,7 @@ func TestDynamicPolicy_groupAndAllocatePools(t *testing.T) {
 
 			// Clear state
 			p.state.SetPodEntries(state.PodEntries{}, false)
-			p.reservedCPUs = machine.NewCPUSet()
+			p.state.SetReservedCPUs(machine.NewCPUSet())
 
 			gotPools, gotIsolated, err := p.groupAndAllocatePools(tt.args.poolsQuantityMap, tt.args.isolatedQuantityMap, tt.args.availableCPUs, tt.args.rpPinnedCPUSet, tt.args.reclaimOverlapShareRatio)
 			if (err != nil) != tt.wantErr {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler.go
@@ -670,7 +670,8 @@ func (p *DynamicPolicy) calculateSystemExclusivePoolChanges(
 }
 
 func (p *DynamicPolicy) applySystemExclusivePoolChanges(toCreate, toUpdate map[string]int, toDelete sets.String) error {
-	availableCPUs := p.state.GetMachineState().GetFilteredAvailableCPUSet(p.reservedCPUs,
+	reservedCPUs := p.state.GetReservedCPUs()
+	availableCPUs := p.state.GetMachineState().GetFilteredAvailableCPUSet(reservedCPUs,
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckDedicated),
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckDedicatedNUMABindingNUMAExclusive))
 	notAllocatablePoolsCPUs := state.GetUnitedPoolsCPUs(p.state.GetPodEntries(), state.IsForbiddenPool, commonstate.IsSystemPool)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_async_handler_test.go
@@ -520,7 +520,7 @@ func TestApplySystemExclusivePoolChanges(t *testing.T) {
 	t.Parallel()
 
 	policy := newTestDynamicPolicy(t, "apply-system-exclusive-pool-changes")
-	policy.reservedCPUs = machine.NewCPUSet()
+	policy.state.SetReservedCPUs(machine.NewCPUSet())
 	defaultSystemCPUs := policy.machineInfo.CPUDetails.CPUs()
 
 	policy.state.SetAllocationInfo("pod-with-pool", "main",

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers.go
@@ -265,6 +265,7 @@ func (p *DynamicPolicy) calculateHints(
 
 	totalAvailableCPUs := machine.NewCPUSet()
 	numaToAvailableCPUCount := make(map[int]int, len(numaNodes))
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	availableNUMAs := p.filterNUMANodesByNonBinding(request, podEntries, machineState, req, numaNumber)
 	for _, nodeID := range numaNodes {
@@ -283,7 +284,7 @@ func (p *DynamicPolicy) calculateHints(
 			general.Warningf("numa_binding container skip NUMA: %d, allocated: %d",
 				nodeID, machineState[nodeID].AllocatedCPUSet.Size())
 		} else {
-			availableCPUs := machineState[nodeID].GetAvailableCPUSet(p.reservedCPUs)
+			availableCPUs := machineState[nodeID].GetAvailableCPUSet(reservedCPUs)
 			numaToAvailableCPUCount[nodeID] = availableCPUs.Size()
 			totalAvailableCPUs.Add(availableCPUs.ToSliceNoSortInt()...)
 		}
@@ -641,6 +642,7 @@ func (p *DynamicPolicy) sharedCoresWithNUMABindingHintHandler(_ context.Context,
 
 	machineState := p.state.GetMachineState()
 	podEntries := p.state.GetPodEntries()
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	var hints map[string]*pluginapi.ListOfTopologyHints
 
@@ -668,7 +670,7 @@ func (p *DynamicPolicy) sharedCoresWithNUMABindingHintHandler(_ context.Context,
 				return nil, fmt.Errorf("snb port not support cross numa")
 			}
 			nodeID := numaSet.ToSliceInt()[0]
-			availableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(p.reservedCPUs)
+			availableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(reservedCPUs)
 			originRequest, _ := allocationInfo.GetPodAggregatedRequest()
 
 			general.Infof("pod: %s/%s, container: %s request cpu inplace update resize on numa %d (available: %.3f, request:%.3f->%.3f)",
@@ -731,7 +733,8 @@ func (p *DynamicPolicy) filterNUMANodesByNonBinding(
 		return machine.NewCPUSet()
 	}
 
-	nonBindingNUMAsCPUQuantity := machineState.GetFilteredAvailableCPUSet(p.reservedCPUs, nil,
+	reservedCPUs := p.state.GetReservedCPUs()
+	nonBindingNUMAsCPUQuantity := machineState.GetFilteredAvailableCPUSet(reservedCPUs, nil,
 		state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckSharedOrDedicatedNUMABinding)).Size()
 	nonBindingNUMAs := machineState.GetFilteredNUMASet(state.WrapAllocationMetaFilter((*commonstate.AllocationMeta).CheckSharedOrDedicatedNUMABinding))
 	nonBindingSharedRequestedQuantity := state.GetNonBindingSharedRequestedQuantityFromPodEntries(podEntries, nil, p.getContainerRequestedCores)
@@ -749,9 +752,10 @@ func (p *DynamicPolicy) filterNUMANodesByNonBindingSharedRequestedQuantity(
 	machineState state.NUMANodeMap, numaNodes []int, numaNumber int,
 ) machine.CPUSet {
 	filteredNUMANodes := make([]int, 0, len(numaNodes))
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	for _, nodeID := range numaNodes {
-		allocatableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(p.reservedCPUs)
+		allocatableCPUQuantity := machineState[nodeID].GetAvailableCPUQuantity(reservedCPUs)
 		if nonBindingNUMAs.Contains(nodeID) {
 			// take this non-binding NUMA for candidate shared_cores with numa_binding,
 			// won't cause non-binding shared_cores in short supply

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_hint_handlers_test.go
@@ -614,10 +614,14 @@ func TestCalculateHintsForNUMABindingSharedCores1(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			statePolicy, stateErr := getTestDynamicPolicyWithoutInitialization(cpuTopology, t.TempDir())
+			require.NoError(t, stateErr)
+			statePolicy.state.SetReservedCPUs(machine.NewCPUSet())
 			p := &DynamicPolicy{
 				machineInfo: &machine.KatalystMachineInfo{
 					CPUTopology: cpuTopology,
 				},
+				state:                               statePolicy.state,
 				numaBindingResultAnnotationKey:      "katalyst-test/nume-bind-result",
 				sharedCoresNUMABindingHintOptimizer: &hintoptimizer.DummyHintOptimizer{},
 				dynamicConfig:                       dynamic.NewDynamicAgentConfiguration(),

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner.go
@@ -159,7 +159,7 @@ func (p *DynamicPolicy) GetIRQForbiddenCores() (machine.CPUSet, error) {
 	forbiddenCores := machine.NewCPUSet()
 
 	// get irq forbidden cores from cpu plugin checkpoint
-	forbiddenCores = forbiddenCores.Union(p.reservedCPUs)
+	forbiddenCores = forbiddenCores.Union(p.state.GetReservedCPUs())
 	forbiddenCores = forbiddenCores.Union(state.GetUnitedPoolsCPUs(p.state.GetPodEntries(), commonstate.IsSystemPool))
 
 	// get irq forbidden cores from pinned resource package
@@ -171,7 +171,7 @@ func (p *DynamicPolicy) GetIRQForbiddenCores() (machine.CPUSet, error) {
 }
 
 func (p *DynamicPolicy) GetStepExpandableCPUsMax() int {
-	availableTotalCPUSetSize := p.state.GetMachineState().GetAvailableCPUSet(p.reservedCPUs).Size()
+	availableTotalCPUSetSize := p.state.GetMachineState().GetAvailableCPUSet(p.state.GetReservedCPUs()).Size()
 	res := int(math.Ceil(irqutil.DefaultIRQExclusiveMaxStepExpansionRate * float64(availableTotalCPUSetSize)))
 
 	return res
@@ -194,6 +194,7 @@ func (p *DynamicPolicy) GetExclusiveIRQCPUSet() (machine.CPUSet, error) {
 // SetExclusiveIRQCPUSet sets the exclusive cpu set for Interrupt.
 func (p *DynamicPolicy) SetExclusiveIRQCPUSet(irqCPUSet machine.CPUSet) error {
 	general.Infof("set the current irq exclusive cpu set: %v", irqCPUSet)
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	forbidden, err := p.GetIRQForbiddenCores()
 	if err != nil {
@@ -203,7 +204,7 @@ func (p *DynamicPolicy) SetExclusiveIRQCPUSet(irqCPUSet machine.CPUSet) error {
 
 	// 1. check cpuSet nums（max）
 	irqCPUSetSize := irqCPUSet.Size()
-	availableTotalCPUSetSize := p.state.GetMachineState().GetAvailableCPUSet(p.reservedCPUs).Size()
+	availableTotalCPUSetSize := p.state.GetMachineState().GetAvailableCPUSet(reservedCPUs).Size()
 	maxExpandableSize := int(math.Ceil(float64(availableTotalCPUSetSize) * irqutil.DefaultIRQExclusiveMaxExpansionRate))
 	if irqCPUSetSize >= maxExpandableSize {
 		general.Errorf("the specified number of cpusets %v exceeds the max amount %v", irqCPUSetSize, maxExpandableSize)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
@@ -280,7 +280,7 @@ func TestDynamicPolicy_GetIRQForbiddenCores(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mock reserved CPUs
-	policy.reservedCPUs = machine.NewCPUSet(0, 1)
+	policy.state.SetReservedCPUs(machine.NewCPUSet(0, 1))
 
 	// Prepare resource packages in NPD
 	npdFetcher := &npd.DummyNPDFetcher{
@@ -371,6 +371,25 @@ func TestDynamicPolicy_GetIRQForbiddenCores(t *testing.T) {
 	assert.True(t, expected.Equals(forbiddenCores), "expected %v, got %v", expected, forbiddenCores)
 }
 
+func TestDynamicPolicy_IRQReadersObserveUpdatedReservedCPUs(t *testing.T) {
+	t.Parallel()
+
+	policy := newTestDynamicPolicy(t, "irq-readers-updated-reserved-cpus")
+	initialReservedCPUs := machine.NewCPUSet(0, 1)
+	policy.state.SetReservedCPUs(initialReservedCPUs)
+
+	forbiddenCores, err := policy.GetIRQForbiddenCores()
+	require.NoError(t, err)
+	assert.True(t, forbiddenCores.Intersection(initialReservedCPUs).Equals(initialReservedCPUs))
+
+	updatedReservedCPUs := machine.NewCPUSet(2, 3)
+	policy.state.SetReservedCPUs(updatedReservedCPUs)
+
+	forbiddenCores, err = policy.GetIRQForbiddenCores()
+	require.NoError(t, err)
+	assert.True(t, forbiddenCores.Intersection(updatedReservedCPUs).Equals(updatedReservedCPUs))
+}
+
 func TestDynamicPolicy_GetExclusiveIRQCPUSet(t *testing.T) {
 	t.Parallel()
 
@@ -402,7 +421,7 @@ func TestDynamicPolicy_SetExclusiveIRQCPUSet(t *testing.T) {
 		as := require.New(t)
 		policyImpl := newTestDynamicPolicy(t, "set-exclusive-irq-cpuset-1")
 
-		available := policyImpl.state.GetMachineState().GetAvailableCPUSet(policyImpl.reservedCPUs)
+		available := policyImpl.state.GetMachineState().GetAvailableCPUSet(policyImpl.state.GetReservedCPUs())
 		maxExpandableSize := int(math.Ceil(float64(available.Size()) * irqutil.DefaultIRQExclusiveMaxExpansionRate))
 		as.Greater(maxExpandableSize, 0)
 
@@ -417,7 +436,7 @@ func TestDynamicPolicy_SetExclusiveIRQCPUSet(t *testing.T) {
 		as := require.New(t)
 		policyImpl := newTestDynamicPolicy(t, "set-exclusive-irq-cpuset-2")
 
-		available := policyImpl.state.GetMachineState().GetAvailableCPUSet(policyImpl.reservedCPUs)
+		available := policyImpl.state.GetMachineState().GetAvailableCPUSet(policyImpl.state.GetReservedCPUs())
 		maxExpandableSize := int(math.Ceil(float64(available.Size()) * irqutil.DefaultIRQExclusiveMaxExpansionRate))
 		maxStepExpandableSize := policyImpl.GetStepExpandableCPUsMax()
 		as.Greater(maxExpandableSize, maxStepExpandableSize+1)
@@ -434,10 +453,10 @@ func TestDynamicPolicy_SetExclusiveIRQCPUSet(t *testing.T) {
 		policyImpl := newTestDynamicPolicy(t, "set-exclusive-irq-cpuset-3")
 
 		reservedCPU := []int{2, 4}
-		policyImpl.reservedCPUs = machine.NewCPUSet(reservedCPU...)
+		policyImpl.state.SetReservedCPUs(machine.NewCPUSet(reservedCPU...))
 		forbidden, err := policyImpl.GetIRQForbiddenCores()
 		as.NoError(err)
-		as.True(forbidden.Equals(policyImpl.reservedCPUs))
+		as.True(forbidden.Equals(policyImpl.state.GetReservedCPUs()))
 
 		irqCPUSet := machine.NewCPUSet(forbidden.ToSliceInt()[0])
 		err = policyImpl.SetExclusiveIRQCPUSet(irqCPUSet)
@@ -468,7 +487,7 @@ func TestDynamicPolicy_SetExclusiveIRQCPUSet(t *testing.T) {
 		as := require.New(t)
 		policyImpl := newTestDynamicPolicy(t, "set-exclusive-irq-cpuset-4")
 
-		available := policyImpl.state.GetMachineState().GetAvailableCPUSet(policyImpl.reservedCPUs)
+		available := policyImpl.state.GetMachineState().GetAvailableCPUSet(policyImpl.state.GetReservedCPUs())
 		as.Greater(available.Size(), 0)
 
 		irqCPUSet := machine.NewCPUSet(available.ToSliceInt()[0])

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_resource_package.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_resource_package.go
@@ -138,6 +138,7 @@ func (p *DynamicPolicy) syncNumaResourcePackage(
 	stateChanged := false
 	newResourcePackageState := make(map[string]*state.ResourcePackageState)
 	pinnedPackages := sets.NewString()
+	reservedCPUs := p.state.GetReservedCPUs()
 
 	for _, containerEntries := range numaState.PodEntries {
 		if containerEntries.IsPoolEntry() {
@@ -173,7 +174,7 @@ func (p *DynamicPolicy) syncNumaResourcePackage(
 		}
 	}
 
-	availableCPUs := p.machineInfo.CPUDetails.CPUsInNUMANodes(numaID).Difference(p.reservedCPUs)
+	availableCPUs := p.machineInfo.CPUDetails.CPUsInNUMANodes(numaID).Difference(reservedCPUs)
 	// exclude interrupt cpuset from available cpuset
 	if interruptAllocationInfo != nil {
 		availableCPUs = availableCPUs.Difference(interruptAllocationInfo.AllocationResult)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_resource_package_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_resource_package_test.go
@@ -146,13 +146,13 @@ func TestSyncResourcePackageStates(t *testing.T) {
 			name: "Shrink Pinned CPUSet with Shared Cores Constraint",
 			initialState: func(dp *DynamicPolicy) {
 				// Ensure deterministic reserved CPUs and clear existing pool
-				dp.reservedCPUs = machine.NewCPUSet(0, 1)
+				dp.state.SetReservedCPUs(machine.NewCPUSet(0, 1))
 				podEntries := dp.state.GetPodEntries()
 				delete(podEntries, commonstate.PoolNameReserve)
 				dp.state.SetPodEntries(podEntries, false)
 
 				// Calculate valid CPUSet for pkg-b on NUMA 0 (need 4 CPUs)
-				cpus0 := dp.machineInfo.CPUDetails.CPUsInNUMANodes(0).Difference(dp.reservedCPUs)
+				cpus0 := dp.machineInfo.CPUDetails.CPUsInNUMANodes(0).Difference(dp.state.GetReservedCPUs())
 				pkgBCPUSet := machine.NewCPUSet(cpus0.ToSliceInt()[:4]...)
 
 				// Pod constraint: Shared pod requesting 1 CPUs
@@ -355,7 +355,7 @@ func TestSyncResourcePackageStates(t *testing.T) {
 				// We must use actual NUMA 0 CPUs from machineInfo because GenerateDummyCPUTopology might be interleaved.
 				cpusInNuma0 := dp.machineInfo.CPUDetails.CPUsInNUMANodes(0)
 				// Exclude reserved (if any) and current pinned
-				available := cpusInNuma0.Difference(dp.reservedCPUs).Difference(machine.NewCPUSet(0, 1))
+				available := cpusInNuma0.Difference(dp.state.GetReservedCPUs()).Difference(machine.NewCPUSet(0, 1))
 
 				// Set AllocatedCPUSet to occupy ALL available CPUs
 				ms[0].AllocatedCPUSet = available

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_test.go
@@ -64,6 +64,7 @@ import (
 	coreconsts "github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/kubeletconfig"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/kcc"
@@ -76,6 +77,7 @@ import (
 	cgroupcmutils "github.com/kubewharf/katalyst-core/pkg/util/cgroup/manager"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
 const (
@@ -83,6 +85,500 @@ const (
 )
 
 var policyTestMutex = advisorTestMutex
+
+type errorKubeletConfigFetcher struct {
+	err error
+}
+
+func (f *errorKubeletConfigFetcher) GetKubeletConfig(context.Context) (*native.KubeletConfiguration, error) {
+	return nil, f.err
+}
+
+func TestDynamicPolicySyncReservedCPUs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates reserved CPU state", func(t *testing.T) {
+		t.Parallel()
+
+		policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+		setFakeKubeletReservedSystemCPUs(t, policy.metaServer, "4,6")
+
+		policy.syncReservedCPUs(nil, nil, nil, nil, nil)
+
+		assert.True(t, policy.state.GetReservedCPUs().Equals(machine.NewCPUSet(4, 6)))
+		reserveInfo := policy.state.GetAllocationInfo(commonstate.PoolNameReserve, commonstate.FakedContainerName)
+		require.NotNil(t, reserveInfo)
+		assert.True(t, reserveInfo.AllocationResult.Equals(machine.NewCPUSet(4, 6)))
+	})
+
+	t.Run("preserves reserved CPU state when kubelet config fetch fails", func(t *testing.T) {
+		t.Parallel()
+
+		policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+		policy.metaServer.KubeletConfigFetcher = &errorKubeletConfigFetcher{err: fmt.Errorf("fetch kubelet config")}
+
+		policy.syncReservedCPUs(nil, nil, nil, nil, nil)
+
+		assert.True(t, policy.state.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+		reserveInfo := policy.state.GetAllocationInfo(commonstate.PoolNameReserve, commonstate.FakedContainerName)
+		require.NotNil(t, reserveInfo)
+		assert.True(t, reserveInfo.AllocationResult.Equals(machine.NewCPUSet(0, 2)))
+	})
+}
+
+func TestDynamicPolicySyncReservedCPUsNoop(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	setFakeKubeletReservedSystemCPUs(t, policy.metaServer, "0,2")
+
+	err := policy.syncReservedCPUsOnce()
+
+	assert.NoError(t, err)
+	assert.True(t, policy.state.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+	reserveInfo := policy.state.GetAllocationInfo(commonstate.PoolNameReserve, commonstate.FakedContainerName)
+	require.NotNil(t, reserveInfo)
+	assert.True(t, reserveInfo.AllocationResult.Equals(machine.NewCPUSet(0, 2)))
+}
+
+func TestDynamicPolicySyncReservedCPUsNoopForSameReservedCPUQuantity(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	setFakeKubeletReservedCPUQuantity(t, policy.metaServer, "2")
+	trackingState := &trackingCPUState{State: policy.state}
+	policy.state = trackingState
+	previousReservedCPUList := policy.conf.ReservedCPUList
+	previousReservedCPUCores := policy.conf.ReservedCPUCores
+
+	err := policy.syncReservedCPUsOnce()
+
+	require.NoError(t, err)
+	assert.True(t, policy.state.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+	assert.Equal(t, previousReservedCPUList, policy.conf.ReservedCPUList)
+	assert.Equal(t, previousReservedCPUCores, policy.conf.ReservedCPUCores)
+	assert.Zero(t, trackingState.storeStateCalls)
+}
+
+func TestDynamicPolicySyncReservedCPUsUpdatesReservedCPUsAndReservePool(t *testing.T) {
+	t.Parallel()
+
+	nextReservedCPUs := machine.NewCPUSet(4, 6)
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	setFakeKubeletReservedSystemCPUs(t, policy.metaServer, "4,6")
+
+	err := policy.syncReservedCPUsOnce()
+
+	assert.NoError(t, err)
+	assert.True(t, policy.state.GetReservedCPUs().Equals(machine.NewCPUSet(4, 6)))
+	reserveInfo := policy.state.GetAllocationInfo(commonstate.PoolNameReserve, commonstate.FakedContainerName)
+	require.NotNil(t, reserveInfo)
+	assert.True(t, reserveInfo.AllocationResult.Equals(nextReservedCPUs))
+	availableCPUs := policy.state.GetMachineState().GetAvailableCPUSet(policy.state.GetReservedCPUs())
+	assert.True(t, availableCPUs.Intersection(nextReservedCPUs).IsEmpty())
+}
+
+func TestDynamicPolicySyncReservedCPUsRestoresStateAfterReservePoolUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	currentReservedCPUs := machine.NewCPUSet(0, 2)
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, currentReservedCPUs)
+	currentReservedCPUList := policy.conf.ReservedCPUList
+	currentReservedCPUCores := policy.conf.ReservedCPUCores
+	nextReservedCPUs := machine.NewCPUSet(4, 6)
+	policy.state = &failingReservedCPUState{
+		State:            policy.state,
+		machineInfo:      policy.machineInfo,
+		originalTopology: policy.machineInfo.CPUTopology,
+		failOn:           nextReservedCPUs,
+	}
+	setFakeKubeletReservedSystemCPUs(t, policy.metaServer, nextReservedCPUs.String())
+
+	err := policy.syncReservedCPUsOnce()
+
+	require.Error(t, err)
+	assert.True(t, policy.state.GetReservedCPUs().Equals(currentReservedCPUs))
+	assert.Equal(t, currentReservedCPUList, policy.conf.ReservedCPUList)
+	assert.Equal(t, currentReservedCPUCores, policy.conf.ReservedCPUCores)
+}
+
+func TestDynamicPolicySyncReservedCPUsPreservesExistingSharedCoreCPUSetWhenShrinking(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet())
+	require.NoError(t, policy.initReclaimPool())
+	initialReclaimPool := policy.state.GetAllocationInfo(commonstate.PoolNameReclaim, commonstate.FakedContainerName)
+	require.NotNil(t, initialReclaimPool)
+	setFakeKubeletReservedCPUQuantity(t, policy.metaServer, "2")
+
+	allCPUs := policy.machineInfo.CPUDetails.CPUs()
+	assignments, err := machine.GetNumaAwareAssignments(policy.machineInfo.CPUTopology, allCPUs)
+	require.NoError(t, err)
+
+	policy.state.SetAllocationInfo(commonstate.PoolNameShare, commonstate.FakedContainerName, &state.AllocationInfo{
+		AllocationMeta:                   commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameShare),
+		AllocationResult:                 allCPUs.Clone(),
+		OriginalAllocationResult:         allCPUs.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+	}, false)
+	policy.state.SetAllocationInfo("pod-uid", "main", &state.AllocationInfo{
+		AllocationMeta: commonstate.GenerateGenericContainerAllocationMeta(&pluginapi.ResourceRequest{
+			PodUid:        "pod-uid",
+			PodNamespace:  "default",
+			PodName:       "shared-pod",
+			ContainerName: "main",
+			ContainerType: pluginapi.ContainerType_MAIN,
+		}, commonstate.PoolNameShare, consts.PodAnnotationQoSLevelSharedCores),
+		AllocationResult:                 allCPUs.Clone(),
+		OriginalAllocationResult:         allCPUs.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+		RequestQuantity:                  1,
+	}, false)
+
+	err = policy.syncReservedCPUsOnce()
+
+	require.NoError(t, err)
+	reservedCPUs := policy.state.GetReservedCPUs()
+	assert.Equal(t, 2, reservedCPUs.Size())
+
+	allocationInfo := policy.state.GetAllocationInfo("pod-uid", "main")
+	require.NotNil(t, allocationInfo)
+	assert.False(t, allocationInfo.AllocationResult.IsEmpty())
+	assert.True(t, allocationInfo.AllocationResult.Equals(allCPUs))
+
+	sharePool := policy.state.GetAllocationInfo(commonstate.PoolNameShare, commonstate.FakedContainerName)
+	require.NotNil(t, sharePool)
+	assert.True(t, sharePool.AllocationResult.Equals(allCPUs))
+
+	reclaimPool := policy.state.GetAllocationInfo(commonstate.PoolNameReclaim, commonstate.FakedContainerName)
+	require.NotNil(t, reclaimPool)
+	assert.True(t, reclaimPool.AllocationResult.Equals(initialReclaimPool.AllocationResult))
+}
+
+func TestDynamicPolicySyncReservedCPUsPreservesExistingSharedCoreCPUSetWhenExpanding(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	setFakeKubeletReservedCPUQuantity(t, policy.metaServer, "4")
+
+	sharedCPUs := policy.machineInfo.CPUDetails.CPUs().Difference(machine.NewCPUSet(0, 2))
+	assignments, err := machine.GetNumaAwareAssignments(policy.machineInfo.CPUTopology, sharedCPUs)
+	require.NoError(t, err)
+	policy.state.SetAllocationInfo(commonstate.PoolNameShare, commonstate.FakedContainerName, &state.AllocationInfo{
+		AllocationMeta:                   commonstate.GenerateGenericPoolAllocationMeta(commonstate.PoolNameShare),
+		AllocationResult:                 sharedCPUs.Clone(),
+		OriginalAllocationResult:         sharedCPUs.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+	}, false)
+	policy.state.SetAllocationInfo("pod-uid", "main", &state.AllocationInfo{
+		AllocationMeta: commonstate.AllocationMeta{
+			PodUid:        "pod-uid",
+			ContainerName: "main",
+			QoSLevel:      consts.PodAnnotationQoSLevelSharedCores,
+			OwnerPoolName: commonstate.PoolNameShare,
+		},
+		AllocationResult:                 sharedCPUs.Clone(),
+		OriginalAllocationResult:         sharedCPUs.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+		RequestQuantity:                  1,
+	}, false)
+
+	err = policy.syncReservedCPUsOnce()
+
+	require.NoError(t, err)
+	reservedCPUs := policy.state.GetReservedCPUs()
+	assert.Equal(t, 4, reservedCPUs.Size())
+
+	allocationInfo := policy.state.GetAllocationInfo("pod-uid", "main")
+	require.NotNil(t, allocationInfo)
+	assert.True(t, allocationInfo.AllocationResult.Equals(sharedCPUs))
+
+	sharePool := policy.state.GetAllocationInfo(commonstate.PoolNameShare, commonstate.FakedContainerName)
+	require.NotNil(t, sharePool)
+	assert.True(t, sharePool.AllocationResult.Equals(sharedCPUs))
+}
+
+func TestDynamicPolicySyncReservedCPUsPreservesFullyAllocatedDedicatedCPUs(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet())
+	setFakeKubeletReservedSystemCPUs(t, policy.metaServer, "0,1")
+
+	allCPUs := policy.machineInfo.CPUDetails.CPUs()
+	assignments, err := machine.GetNumaAwareAssignments(policy.machineInfo.CPUTopology, allCPUs)
+	require.NoError(t, err)
+	policy.state.SetAllocationInfo("dedicated-pod", "main", &state.AllocationInfo{
+		AllocationMeta: commonstate.GenerateGenericContainerAllocationMeta(&pluginapi.ResourceRequest{
+			PodUid:        "dedicated-pod",
+			PodNamespace:  "default",
+			PodName:       "dedicated-pod",
+			ContainerName: "main",
+			ContainerType: pluginapi.ContainerType_MAIN,
+		}, commonstate.EmptyOwnerPoolName, consts.PodAnnotationQoSLevelDedicatedCores),
+		AllocationResult:                 allCPUs.Clone(),
+		OriginalAllocationResult:         allCPUs.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+		RequestQuantity:                  float64(allCPUs.Size()),
+	}, false)
+
+	err = policy.syncReservedCPUsOnce()
+
+	require.NoError(t, err)
+	assert.True(t, policy.state.GetReservedCPUs().Equals(machine.NewCPUSet(0, 1)))
+	dedicatedAllocation := policy.state.GetAllocationInfo("dedicated-pod", "main")
+	require.NotNil(t, dedicatedAllocation)
+	assert.True(t, dedicatedAllocation.AllocationResult.Equals(allCPUs))
+}
+
+func TestDynamicPolicySyncReservedCPUsSelectionIsDeterministicForSameCandidates(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	setFakeKubeletReservedCPUQuantity(t, policy.metaServer, "3")
+	candidateCPUs := policy.machineInfo.CPUDetails.CPUs().Clone().Difference(machine.NewCPUSet(4))
+
+	got1, err := cpuutil.GetCoresReservedForSystem(policy.conf, policy.metaServer, policy.machineInfo, candidateCPUs)
+	require.NoError(t, err)
+	got2, err := cpuutil.GetCoresReservedForSystem(policy.conf, policy.metaServer, policy.machineInfo, candidateCPUs)
+	require.NoError(t, err)
+
+	assert.True(t, got1.Equals(got2))
+	assert.True(t, got1.Equals(machine.NewCPUSet(0, 2, 5)))
+}
+
+func TestDynamicPolicyApplyReservedCPUsLockedUpdatesReservePoolBeforeAdjustingEntries(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	trackingState := &trackingCPUState{State: policy.state}
+	policy.state = trackingState
+
+	nextReservedCPUs := machine.NewCPUSet(4, 6)
+	policy.Lock()
+	err := policy.applyReservedCPUs(nextReservedCPUs)
+	policy.Unlock()
+
+	require.NoError(t, err)
+	assert.True(t, policy.state.GetReservedCPUs().Equals(nextReservedCPUs))
+	reservePool := policy.state.GetAllocationInfo(commonstate.PoolNameReserve, commonstate.FakedContainerName)
+	require.NotNil(t, reservePool)
+	assert.True(t, reservePool.AllocationResult.Equals(nextReservedCPUs))
+	assert.True(t, reservePool.OriginalAllocationResult.Equals(nextReservedCPUs))
+	assert.Zero(t, trackingState.storeStateCalls)
+	assert.Equal(t, 1, trackingState.persistedSetAllocationInfoCalls)
+	assert.Zero(t, trackingState.persistedSetMachineStateCalls)
+}
+
+func TestDynamicPolicyApplyReservedCPUsLockedExcludesSystemPoolFromReclaimPool(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	systemCPUs := machine.NewCPUSet(10, 12)
+	setTestPoolAllocation(t, policy.machineInfo.CPUTopology, policy.state, commonstate.GetSystemPoolName("test"), systemCPUs)
+	setTestPoolAllocation(t, policy.machineInfo.CPUTopology, policy.state, commonstate.PoolNameReclaim, machine.NewCPUSet(4, 6))
+
+	nextReservedCPUs := machine.NewCPUSet(0, 2, 4, 6)
+	policy.Lock()
+	err := policy.applyReservedCPUs(nextReservedCPUs)
+	policy.Unlock()
+
+	require.NoError(t, err)
+	reclaimPool := policy.state.GetAllocationInfo(commonstate.PoolNameReclaim, commonstate.FakedContainerName)
+	require.NotNil(t, reclaimPool)
+	assert.True(t, reclaimPool.AllocationResult.Intersection(systemCPUs).IsEmpty())
+}
+
+func TestDynamicPolicyApplyReservedCPUsLockedPreservesReclaimedPodEntries(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	oldReclaimCPUs := machine.NewCPUSet(4, 6)
+	setTestPoolAllocation(t, policy.machineInfo.CPUTopology, policy.state, commonstate.PoolNameReclaim, oldReclaimCPUs)
+	setTestReclaimedAllocation(t, policy.machineInfo.CPUTopology, policy.state, "reclaimed-pod", "main", oldReclaimCPUs)
+
+	nextReservedCPUs := machine.NewCPUSet(0, 2, 4, 6)
+	policy.Lock()
+	err := policy.applyReservedCPUs(nextReservedCPUs)
+	policy.Unlock()
+
+	require.NoError(t, err)
+	reclaimPool := policy.state.GetAllocationInfo(commonstate.PoolNameReclaim, commonstate.FakedContainerName)
+	require.NotNil(t, reclaimPool)
+	reclaimedPod := policy.state.GetAllocationInfo("reclaimed-pod", "main")
+	require.NotNil(t, reclaimedPod)
+	assert.True(t, reclaimedPod.AllocationResult.Equals(oldReclaimCPUs))
+	assert.True(t, reclaimPool.AllocationResult.Equals(oldReclaimCPUs))
+}
+
+func TestDynamicPolicyApplyReservedCPUsLockedPreservesReclaimedNUMABindingPodEntries(t *testing.T) {
+	t.Parallel()
+
+	policy := makeTestDynamicPolicyWithReservedCPUs(t, machine.NewCPUSet(0, 2))
+	oldReclaimCPUs := machine.NewCPUSet(4, 6, 8, 10)
+	setTestPoolAllocation(t, policy.machineInfo.CPUTopology, policy.state, commonstate.PoolNameReclaim, oldReclaimCPUs)
+	setTestReclaimedNUMABindingAllocation(t, policy.machineInfo.CPUTopology, policy.state, "reclaimed-rnb-pod", "main", machine.NewCPUSet(4), 2)
+
+	nextReservedCPUs := machine.NewCPUSet(0, 2, 4, 6)
+	policy.Lock()
+	err := policy.applyReservedCPUs(nextReservedCPUs)
+	policy.Unlock()
+
+	require.NoError(t, err)
+	reclaimPool := policy.state.GetAllocationInfo(commonstate.PoolNameReclaim, commonstate.FakedContainerName)
+	require.NotNil(t, reclaimPool)
+	reclaimedPod := policy.state.GetAllocationInfo("reclaimed-rnb-pod", "main")
+	require.NotNil(t, reclaimedPod)
+	assert.True(t, reclaimedPod.AllocationResult.Equals(machine.NewCPUSet(4)))
+	assert.True(t, reclaimedPod.OriginalAllocationResult.Equals(machine.NewCPUSet(4)))
+}
+
+func makeTestDynamicPolicyWithReservedCPUs(t *testing.T, reservedCPUs machine.CPUSet) *DynamicPolicy {
+	t.Helper()
+
+	topology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+
+	policy, err := getTestDynamicPolicyWithoutInitialization(topology, t.TempDir())
+	require.NoError(t, err)
+
+	policy.state.SetReservedCPUs(reservedCPUs)
+	policy.conf.ReservedCPUList = reservedCPUs.String()
+	policy.conf.UseKubeletReservedConfig = true
+	policy.metaServer.KatalystMachineInfo = policy.machineInfo
+	policy.metaServer.CPUDetails = policy.machineInfo.CPUDetails
+
+	require.NoError(t, policy.initReservePool())
+	require.NoError(t, policy.initReclaimPool())
+	return policy
+}
+
+func setFakeKubeletReservedSystemCPUs(t *testing.T, metaServer *metaserver.MetaServer, reservedCPUList string) {
+	t.Helper()
+	metaServer.KubeletConfigFetcher = kubeletconfig.NewFakeKubeletConfigFetcher(native.KubeletConfiguration{
+		ReservedSystemCPUs: reservedCPUList,
+	})
+}
+
+func setFakeKubeletReservedCPUQuantity(t *testing.T, metaServer *metaserver.MetaServer, reservedCPUQuantity string) {
+	t.Helper()
+	metaServer.KubeletConfigFetcher = kubeletconfig.NewFakeKubeletConfigFetcher(native.KubeletConfiguration{
+		SystemReserved: map[string]string{
+			string(v1.ResourceCPU): reservedCPUQuantity,
+		},
+	})
+}
+
+func setTestPoolAllocation(t *testing.T, topology *machine.CPUTopology, stateImpl state.State, poolName string, cpus machine.CPUSet) {
+	t.Helper()
+	assignments, err := machine.GetNumaAwareAssignments(topology, cpus)
+	require.NoError(t, err)
+
+	stateImpl.SetAllocationInfo(poolName, commonstate.FakedContainerName, &state.AllocationInfo{
+		AllocationMeta:                   commonstate.GenerateGenericPoolAllocationMeta(poolName),
+		AllocationResult:                 cpus.Clone(),
+		OriginalAllocationResult:         cpus.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+	}, false)
+}
+
+func setTestReclaimedAllocation(t *testing.T, topology *machine.CPUTopology, stateImpl state.State, podUID, containerName string, cpus machine.CPUSet) {
+	t.Helper()
+	assignments, err := machine.GetNumaAwareAssignments(topology, cpus)
+	require.NoError(t, err)
+
+	stateImpl.SetAllocationInfo(podUID, containerName, &state.AllocationInfo{
+		AllocationMeta: commonstate.AllocationMeta{
+			PodUid:        podUID,
+			ContainerName: containerName,
+			QoSLevel:      consts.PodAnnotationQoSLevelReclaimedCores,
+			OwnerPoolName: commonstate.PoolNameReclaim,
+			Annotations:   map[string]string{},
+		},
+		AllocationResult:                 cpus.Clone(),
+		OriginalAllocationResult:         cpus.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+		RequestQuantity:                  1,
+	}, false)
+}
+
+func setTestReclaimedNUMABindingAllocation(t *testing.T, topology *machine.CPUTopology, stateImpl state.State, podUID, containerName string, cpus machine.CPUSet, numaID int) {
+	t.Helper()
+	assignments, err := machine.GetNumaAwareAssignments(topology, cpus)
+	require.NoError(t, err)
+
+	stateImpl.SetAllocationInfo(podUID, containerName, &state.AllocationInfo{
+		AllocationMeta: commonstate.AllocationMeta{
+			PodUid:        podUID,
+			ContainerName: containerName,
+			QoSLevel:      consts.PodAnnotationQoSLevelReclaimedCores,
+			OwnerPoolName: commonstate.PoolNameReclaim,
+			Annotations: map[string]string{
+				consts.PodAnnotationMemoryEnhancementNumaBinding: consts.PodAnnotationMemoryEnhancementNumaBindingEnable,
+				cpuconsts.CPUStateAnnotationKeyNUMAHint:          machine.NewCPUSet(numaID).String(),
+			},
+		},
+		AllocationResult:                 cpus.Clone(),
+		OriginalAllocationResult:         cpus.Clone(),
+		TopologyAwareAssignments:         assignments,
+		OriginalTopologyAwareAssignments: machine.DeepcopyCPUAssignment(assignments),
+		RequestQuantity:                  1,
+	}, false)
+}
+
+type trackingCPUState struct {
+	state.State
+
+	storeStateCalls                 int
+	persistedSetAllocationInfoCalls int
+	persistedSetMachineStateCalls   int
+}
+
+func (s *trackingCPUState) StoreState() error {
+	s.storeStateCalls++
+	return s.State.StoreState()
+}
+
+func (s *trackingCPUState) SetAllocationInfo(
+	podUID string,
+	containerName string,
+	allocationInfo *state.AllocationInfo,
+	persist bool,
+) {
+	if persist {
+		s.persistedSetAllocationInfoCalls++
+	}
+	s.State.SetAllocationInfo(podUID, containerName, allocationInfo, persist)
+}
+
+func (s *trackingCPUState) SetMachineState(numaNodeMap state.NUMANodeMap, persist bool) {
+	if persist {
+		s.persistedSetMachineStateCalls++
+	}
+	s.State.SetMachineState(numaNodeMap, persist)
+}
+
+type failingReservedCPUState struct {
+	state.State
+	machineInfo      *machine.KatalystMachineInfo
+	originalTopology *machine.CPUTopology
+	failOn           machine.CPUSet
+}
+
+func (s *failingReservedCPUState) SetReservedCPUs(reservedCPUs machine.CPUSet) {
+	s.State.SetReservedCPUs(reservedCPUs)
+	if reservedCPUs.Equals(s.failOn) {
+		s.machineInfo.CPUTopology = nil
+		return
+	}
+	s.machineInfo.CPUTopology = s.originalTopology
+}
 
 type cpuTestCase struct {
 	cpuNum      int
@@ -162,7 +658,6 @@ func getTestDynamicPolicyWithoutInitialization(
 		advisorValidator:          validator.NewCPUAdvisorValidator(stateImpl, machineInfo),
 		featureGateManager:        featuregatenegotiation.NewFeatureGateManager(config.NewConfiguration()),
 		reservedReclaimedCPUsSize: general.Max(reservedReclaimedCPUsSize, topology.NumNUMANodes),
-		reservedCPUs:              reservedCPUs,
 		enableReclaimNUMABinding:  true,
 		emitter:                   metrics.DummyMetrics{},
 		podDebugAnnoKeys:          []string{podDebugAnnoKey},
@@ -172,6 +667,7 @@ func getTestDynamicPolicyWithoutInitialization(
 
 		topologyAllocationAnnotationKey: coreconsts.QRMPodAnnotationTopologyAllocationKey,
 	}
+	policyImplement.state.SetReservedCPUs(reservedCPUs)
 
 	// Important: We must register the topologyAllocationHook and set the annotation keys
 	// to ensure that the test environment correctly generates NUMA topology annotations
@@ -5777,7 +6273,7 @@ func TestGetResourcesAllocation(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			0: 3,
 			1: 3,

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/resize_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/resize_test.go
@@ -780,7 +780,7 @@ func TestNonBindingShareCoresInplaceUpdateResize(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 3,
 			uint64(1): 3,
@@ -858,7 +858,7 @@ func TestNonBindingShareCoresInplaceUpdateResize(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 10,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 3,
 			uint64(1): 3,
@@ -950,7 +950,7 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 11,
 			uint64(1): 11,
@@ -1009,7 +1009,7 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 11,
 			uint64(1): 11,
@@ -1077,7 +1077,7 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 11,
 			uint64(1): 11,
@@ -1099,7 +1099,7 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 11,
 			uint64(1): 11,
@@ -1176,7 +1176,7 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 11,
 			uint64(1): 11,
@@ -1198,7 +1198,7 @@ func TestNonBindingShareCoresInplaceUpdateResizeWithSidecar(t *testing.T) {
 		IsNodeResource:    false,
 		IsScalarResource:  true,
 		AllocatedQuantity: 42,
-		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.reservedCPUs).Difference(reclaim.AllocationResult).String(),
+		AllocationResult:  cpuTopology.CPUDetails.CPUs().Difference(dynamicPolicy.state.GetReservedCPUs()).Difference(reclaim.AllocationResult).String(),
 		TopologyAssignments: map[uint64]uint64{
 			uint64(0): 11,
 			uint64(1): 11,

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state.go
@@ -742,6 +742,7 @@ func (nm NUMANodeMap) String() string {
 
 // reader is used to get information from local states
 type reader interface {
+	GetReservedCPUs() machine.CPUSet
 	GetMachineState() NUMANodeMap
 	GetNUMAHeadroom() map[int]float64
 	GetPodEntries() PodEntries
@@ -752,6 +753,7 @@ type reader interface {
 // writer is used to store information into local states,
 // and it also provides functionality to maintain the local files
 type writer interface {
+	SetReservedCPUs(reservedCPUs machine.CPUSet)
 	SetMachineState(numaNodeMap NUMANodeMap, persist bool)
 	SetNUMAHeadroom(numaHeadroom map[int]float64, persist bool)
 	SetPodEntries(podEntries PodEntries, writeThrough bool)

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_checkpoint.go
@@ -160,6 +160,20 @@ func (sc *stateCheckpoint) InitNewCheckpoint(empty bool) checkpointmanager.Check
 	return checkpoint
 }
 
+func (sc *stateCheckpoint) GetReservedCPUs() machine.CPUSet {
+	sc.RLock()
+	defer sc.RUnlock()
+
+	return sc.cache.GetReservedCPUs()
+}
+
+func (sc *stateCheckpoint) SetReservedCPUs(reservedCPUs machine.CPUSet) {
+	sc.Lock()
+	defer sc.Unlock()
+
+	sc.cache.SetReservedCPUs(reservedCPUs)
+}
+
 func (sc *stateCheckpoint) GetMachineState() NUMANodeMap {
 	sc.RLock()
 	defer sc.RUnlock()

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_mem.go
@@ -31,7 +31,8 @@ import (
 type cpuPluginState struct {
 	sync.RWMutex
 
-	cpuTopology *machine.CPUTopology
+	cpuTopology  *machine.CPUTopology
+	reservedCPUs machine.CPUSet
 
 	podEntries                            PodEntries
 	machineState                          NUMANodeMap
@@ -59,11 +60,26 @@ func GetDefaultMachineState(topology *machine.CPUTopology) NUMANodeMap {
 func NewCPUPluginState(topology *machine.CPUTopology) *cpuPluginState {
 	klog.InfoS("[cpu_plugin] initializing new cpu plugin in-memory state store")
 	return &cpuPluginState{
+		reservedCPUs:   machine.NewCPUSet(),
 		podEntries:     make(PodEntries),
 		machineState:   GetDefaultMachineState(topology),
 		socketTopology: topology.GetSocketTopology(),
 		cpuTopology:    topology,
 	}
+}
+
+func (s *cpuPluginState) GetReservedCPUs() machine.CPUSet {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.reservedCPUs.Clone()
+}
+
+func (s *cpuPluginState) SetReservedCPUs(reservedCPUs machine.CPUSet) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.reservedCPUs = reservedCPUs.Clone()
 }
 
 func (s *cpuPluginState) GetMachineState() NUMANodeMap {

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/state/state_test.go
@@ -1512,6 +1512,68 @@ func TestNewCheckpointState(t *testing.T) {
 	}
 }
 
+func TestCPUPluginStateReservedCPUsCloneIsolation(t *testing.T) {
+	t.Parallel()
+
+	topology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+
+	stateImpl := NewCPUPluginState(topology)
+	input := machine.NewCPUSet(0, 2)
+	stateImpl.SetReservedCPUs(input)
+
+	input.Add(4)
+	assert.True(t, stateImpl.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+
+	got := stateImpl.GetReservedCPUs()
+	got.Add(6)
+	assert.True(t, stateImpl.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+}
+
+func TestCPUPluginStateReservedCPUsSurvivesClearState(t *testing.T) {
+	t.Parallel()
+
+	topology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+
+	stateImpl := NewCPUPluginState(topology)
+	stateImpl.SetReservedCPUs(machine.NewCPUSet(0, 2))
+	stateImpl.ClearState()
+	assert.True(t, stateImpl.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+
+	stateImpl.SetReservedCPUs(machine.NewCPUSet())
+	stateImpl.ClearState()
+	assert.True(t, stateImpl.GetReservedCPUs().IsEmpty())
+}
+
+func TestCheckpointStateReservedCPUs(t *testing.T) {
+	t.Parallel()
+
+	topology, err := machine.GenerateDummyCPUTopology(16, 2, 4)
+	require.NoError(t, err)
+	stateImpl, err := NewCheckpointState(
+		&statedirectory.StateDirectoryConfiguration{StateFileDirectory: t.TempDir()},
+		"test-checkpoint",
+		"test-policy",
+		topology,
+		false,
+		GenerateMachineStateFromPodEntries,
+		metrics.DummyMetrics{},
+	)
+	require.NoError(t, err)
+
+	stateImpl.SetReservedCPUs(machine.NewCPUSet(0, 2))
+	got := stateImpl.GetReservedCPUs()
+	got.Add(4)
+	assert.True(t, stateImpl.GetReservedCPUs().Equals(machine.NewCPUSet(0, 2)))
+	require.NoError(t, stateImpl.StoreState())
+
+	checkpoint := stateImpl.(*stateCheckpoint).InitNewCheckpoint(false)
+	blob, err := checkpoint.MarshalCheckpoint()
+	require.NoError(t, err)
+	assert.NotContains(t, string(blob), "reservedCPUs")
+}
+
 func TestClearState(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/qrm-plugins/memory/consts/consts.go
+++ b/pkg/agent/qrm-plugins/memory/consts/consts.go
@@ -25,6 +25,7 @@ const (
 
 	MemoryPluginDynamicPolicyName = "qrm_memory_plugin_" + MemoryResourcePluginPolicyNameDynamic
 	ClearResidualState            = MemoryPluginDynamicPolicyName + "_clear_residual_state"
+	SyncReservedMemory            = MemoryPluginDynamicPolicyName + "_sync_reserved_memory"
 	SyncMemoryStateFromSpec       = MemoryPluginDynamicPolicyName + "_sync_memory_state_form_spec"
 	CheckMemSet                   = MemoryPluginDynamicPolicyName + "_check_mem_set"
 	ApplyExternalCGParams         = MemoryPluginDynamicPolicyName + "_apply_external_cg_params"

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -127,6 +128,7 @@ type DynamicPolicy struct {
 
 	topology *machine.CPUTopology
 	state    state.State
+	conf     *config.Configuration
 
 	migrateMemoryLock sync.Mutex
 	migratingMemory   map[string]map[string]bool
@@ -219,6 +221,7 @@ func NewDynamicPolicy(agentCtx *agent.GenericContext, conf *config.Configuration
 		emitter:                     wrappedEmitter,
 		metaServer:                  agentCtx.MetaServer,
 		state:                       stateImpl,
+		conf:                        conf,
 		stopCh:                      make(chan struct{}),
 		migratingMemory:             make(map[string]map[string]bool),
 		residualHitMap:              make(map[string]int64),
@@ -355,6 +358,15 @@ func (p *DynamicPolicy) Start() (err error) {
 		p.clearResidualState, stateCheckPeriod, healthCheckTolerationTimes)
 	if err != nil {
 		general.Errorf("start %v failed, err: %v", memconsts.ClearResidualState, err)
+	}
+
+	if p.conf != nil && p.conf.UseKubeletReservedConfig {
+		err = periodicalhandler.RegisterPeriodicalHandlerWithHealthz(memconsts.SyncReservedMemory,
+			general.HealthzCheckStateNotReady, qrm.QRMMemoryPluginPeriodicalHandlerGroupName,
+			p.syncReservedMemory, stateCheckPeriod, healthCheckTolerationTimes)
+		if err != nil {
+			general.Errorf("start %v failed, err: %v", memconsts.SyncReservedMemory, err)
+		}
 	}
 
 	// TODO: we should remove this healthy check when we support inplace update resize in all clusters.
@@ -557,6 +569,65 @@ func (p *DynamicPolicy) Start() (err error) {
 	go wait.BackoffUntil(communicateWithMemoryAdvisorServer, wait.NewExponentialBackoffManager(800*time.Millisecond,
 		30*time.Second, 2*time.Minute, 2.0, 0, &clock.RealClock{}), true, p.stopCh)
 
+	return nil
+}
+
+func (p *DynamicPolicy) syncReservedMemory(_ *config.Configuration,
+	_ interface{},
+	_ *dynamicconfig.DynamicAgentConfiguration,
+	_ metrics.MetricEmitter,
+	_ *metaserver.MetaServer,
+) {
+	if err := p.syncReservedMemoryOnce(); err != nil {
+		general.Errorf("sync reserved memory failed with error: %v", err)
+	}
+}
+
+// syncReservedMemoryOnce dynamically syncs reserved memory from kubelet.
+func (p *DynamicPolicy) syncReservedMemoryOnce() error {
+	nextReservedMemory, err := getResourcesReservedMemory(
+		p.conf,
+		p.metaServer,
+		p.state.GetMachineInfo(),
+		p.extraResourceNames,
+	)
+	if err != nil {
+		_ = general.UpdateHealthzStateByError(memconsts.SyncReservedMemory, err)
+		return err
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	currentReservedMemory := p.state.GetReservedMemory()
+	if reflect.DeepEqual(currentReservedMemory, nextReservedMemory) {
+		// Early exit if no change to reserved memory.
+		_ = general.UpdateHealthzState(memconsts.SyncReservedMemory, general.HealthzCheckStateReady, "")
+		return nil
+	}
+
+	machineState, err := state.GenerateMachineStateFromPodEntries(
+		p.state.GetMachineInfo(),
+		p.state.GetMemoryTopology(),
+		p.state.GetPodResourceEntries(),
+		p.state.GetMachineState(),
+		nextReservedMemory,
+		p.extraResourceNames,
+	)
+	if err != nil {
+		_ = general.UpdateHealthzStateByError(memconsts.SyncReservedMemory, err)
+		return err
+	}
+
+	p.state.SetReservedMemory(nextReservedMemory)
+	p.state.SetMachineState(machineState, false)
+	if err := p.state.StoreState(); err != nil {
+		_ = general.UpdateHealthzStateByError(memconsts.SyncReservedMemory, err)
+		return err
+	}
+
+	general.Infof("sync reserved memory from %v to %v", currentReservedMemory, nextReservedMemory)
+	_ = general.UpdateHealthzState(memconsts.SyncReservedMemory, general.HealthzCheckStateReady, "")
 	return nil
 }
 

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/policy_test.go
@@ -75,11 +75,13 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
 	metaserveragent "github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/kubeletconfig"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/external"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/asyncworker"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
 	"github.com/kubewharf/katalyst-core/pkg/util/qos"
 )
 
@@ -93,6 +95,207 @@ type topoTestCase struct {
 	numaNum     int
 	fakeNUMANum int
 	memGB       int
+}
+
+type errorKubeletConfigFetcher struct {
+	err error
+}
+
+func (f *errorKubeletConfigFetcher) GetKubeletConfig(context.Context) (*native.KubeletConfiguration, error) {
+	return nil, f.err
+}
+
+func quantityBytes(value string) uint64 {
+	quantity := resource.MustParse(value)
+	return uint64(quantity.Value())
+}
+
+func makeReservedMemorySyncPolicy(t *testing.T, extraResourceNames []string,
+	initialReservedMemory map[v1.ResourceName]map[int]uint64, kubeletConfig native.KubeletConfiguration,
+) *DynamicPolicy {
+	t.Helper()
+
+	topology, err := machine.GenerateDummyCPUTopology(16, 2, 2)
+	require.NoError(t, err)
+	machineInfo, err := machine.GenerateDummyMachineInfo(2, 16)
+	require.NoError(t, err)
+
+	conf := config.NewConfiguration()
+	conf.UseKubeletReservedConfig = true
+	conf.ExtraMemoryResources = extraResourceNames
+
+	stateImpl, err := state.NewCheckpointState(
+		&statedirectory.StateDirectoryConfiguration{StateFileDirectory: t.TempDir()},
+		memoryPluginStateFileName,
+		memconsts.MemoryResourcePluginPolicyNameDynamic,
+		topology,
+		machineInfo,
+		nil,
+		initialReservedMemory,
+		false,
+		metrics.DummyMetrics{},
+		extraResourceNames,
+	)
+	require.NoError(t, err)
+
+	metaServer := &metaserver.MetaServer{
+		MetaAgent: &metaserveragent.MetaAgent{
+			KubeletConfigFetcher: kubeletconfig.NewFakeKubeletConfigFetcher(kubeletConfig),
+		},
+	}
+	return &DynamicPolicy{
+		conf:               conf,
+		emitter:            metrics.DummyMetrics{},
+		metaServer:         metaServer,
+		topology:           topology,
+		state:              stateImpl,
+		extraResourceNames: extraResourceNames,
+	}
+}
+
+func TestDynamicPolicySyncReservedMemory(t *testing.T) {
+	t.Parallel()
+
+	memoryResource := v1.ResourceMemory
+	hugePagesResource := v1.ResourceName(v1.ResourceHugePagesPrefix + "2Mi")
+	zeroReservedMemory := func(resources ...v1.ResourceName) map[v1.ResourceName]map[int]uint64 {
+		reservedMemory := make(map[v1.ResourceName]map[int]uint64, len(resources))
+		for _, resourceName := range resources {
+			reservedMemory[resourceName] = map[int]uint64{0: 0, 1: 0}
+		}
+		return reservedMemory
+	}
+
+	t.Run("no-op keeps state unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		policy := makeReservedMemorySyncPolicy(t, nil, zeroReservedMemory(memoryResource), native.KubeletConfiguration{})
+		oldMachineState := policy.state.GetMachineState()
+		oldPodEntries := policy.state.GetPodResourceEntries()
+
+		require.NoError(t, policy.syncReservedMemoryOnce())
+
+		assert.Equal(t, zeroReservedMemory(memoryResource), policy.state.GetReservedMemory())
+		assert.Equal(t, oldMachineState, policy.state.GetMachineState())
+		assert.Equal(t, oldPodEntries, policy.state.GetPodResourceEntries())
+	})
+
+	t.Run("updates memory and hugepages and reports allocatable", func(t *testing.T) {
+		t.Parallel()
+
+		kubeletConfig := native.KubeletConfiguration{
+			SystemReserved: map[string]string{string(memoryResource): "4Gi"},
+			ReservedMemory: []native.MemoryReservation{
+				{
+					NumaNode: 0,
+					Limits: v1.ResourceList{
+						hugePagesResource: resource.MustParse("512Mi"),
+					},
+				},
+				{
+					NumaNode: 1,
+					Limits: v1.ResourceList{
+						hugePagesResource: resource.MustParse("512Mi"),
+					},
+				},
+			},
+		}
+		policy := makeReservedMemorySyncPolicy(t, []string{string(hugePagesResource)},
+			zeroReservedMemory(memoryResource, hugePagesResource), kubeletConfig)
+
+		require.NoError(t, policy.syncReservedMemoryOnce())
+
+		reservedMemory := policy.state.GetReservedMemory()
+		assert.Equal(t, quantityBytes("2Gi"), reservedMemory[memoryResource][0])
+		assert.Equal(t, quantityBytes("2Gi"), reservedMemory[memoryResource][1])
+		assert.Equal(t, quantityBytes("512Mi"), reservedMemory[hugePagesResource][0])
+		assert.Equal(t, quantityBytes("512Mi"), reservedMemory[hugePagesResource][1])
+
+		machineState := policy.state.GetMachineState()
+		assert.Equal(t, quantityBytes("6Gi"), machineState[memoryResource][0].Allocatable)
+		assert.Equal(t, quantityBytes("1536Mi"), machineState[hugePagesResource][0].Allocatable)
+
+		response, err := policy.GetTopologyAwareAllocatableResources(
+			context.Background(), &pluginapi.GetTopologyAwareAllocatableResourcesRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, float64(quantityBytes("12Gi")),
+			response.AllocatableResources[string(memoryResource)].AggregatedAllocatableQuantity)
+		assert.Equal(t, float64(quantityBytes("3Gi")),
+			response.AllocatableResources[string(hugePagesResource)].AggregatedAllocatableQuantity)
+	})
+
+	t.Run("preserves allocations when reservation exceeds free memory", func(t *testing.T) {
+		t.Parallel()
+
+		policy := makeReservedMemorySyncPolicy(t, nil, zeroReservedMemory(memoryResource), native.KubeletConfiguration{
+			SystemReserved: map[string]string{string(memoryResource): "4Gi"},
+		})
+		perNUMAMemory := quantityBytes("8Gi")
+		allNUMAs := machine.NewCPUSet(0, 1)
+		podEntries := state.PodResourceEntries{
+			memoryResource: {
+				"pod": {
+					"main": {
+						AllocationMeta: state.GenerateMemoryContainerAllocationMeta(&pluginapi.ResourceRequest{
+							PodUid:        "pod",
+							ContainerName: "main",
+							ContainerType: pluginapi.ContainerType_MAIN,
+						}, consts.PodAnnotationQoSLevelDedicatedCores),
+						AggregatedQuantity:   perNUMAMemory * 2,
+						NumaAllocationResult: allNUMAs,
+						TopologyAwareAllocations: map[int]uint64{
+							0: perNUMAMemory,
+							1: perNUMAMemory,
+						},
+					},
+				},
+			},
+		}
+		machineState, err := state.GenerateMachineStateFromPodEntries(
+			policy.state.GetMachineInfo(), policy.state.GetMemoryTopology(), podEntries,
+			policy.state.GetMachineState(), policy.state.GetReservedMemory(), nil)
+		require.NoError(t, err)
+		policy.state.SetPodResourceEntries(podEntries, false)
+		policy.state.SetMachineState(machineState, false)
+
+		require.NoError(t, policy.syncReservedMemoryOnce())
+
+		assert.Equal(t, podEntries, policy.state.GetPodResourceEntries())
+		for _, numaID := range []int{0, 1} {
+			numaState := policy.state.GetMachineState()[memoryResource][numaID]
+			assert.Equal(t, quantityBytes("2Gi"), numaState.SystemReserved)
+			assert.Equal(t, perNUMAMemory, numaState.Allocated)
+			assert.Equal(t, perNUMAMemory, numaState.Allocatable)
+			assert.Zero(t, numaState.Free)
+		}
+	})
+
+	t.Run("invalid reservation leaves state unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		policy := makeReservedMemorySyncPolicy(t, nil, zeroReservedMemory(memoryResource), native.KubeletConfiguration{
+			SystemReserved: map[string]string{string(memoryResource): "20Gi"},
+		})
+		oldMachineState := policy.state.GetMachineState()
+
+		require.Error(t, policy.syncReservedMemoryOnce())
+
+		assert.Equal(t, zeroReservedMemory(memoryResource), policy.state.GetReservedMemory())
+		assert.Equal(t, oldMachineState, policy.state.GetMachineState())
+	})
+
+	t.Run("kubelet fetch failure leaves state unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		policy := makeReservedMemorySyncPolicy(t, nil, zeroReservedMemory(memoryResource), native.KubeletConfiguration{})
+		oldMachineState := policy.state.GetMachineState()
+		policy.metaServer.KubeletConfigFetcher = &errorKubeletConfigFetcher{err: fmt.Errorf("fetch kubelet config")}
+
+		require.Error(t, policy.syncReservedMemoryOnce())
+
+		assert.Equal(t, zeroReservedMemory(memoryResource), policy.state.GetReservedMemory())
+		assert.Equal(t, oldMachineState, policy.state.GetMachineState())
+	})
 }
 
 var fakeConf = &config.Configuration{

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state.go
@@ -565,6 +565,7 @@ type reader interface {
 // writer is used to store information into local states,
 // and it also provides functionality to maintain the local files
 type writer interface {
+	SetReservedMemory(reservedMemory map[v1.ResourceName]map[int]uint64)
 	SetMachineState(numaNodeResourcesMap NUMANodeResourcesMap, persist bool)
 	SetNUMAHeadroom(m map[int]int64, persist bool)
 	SetPodResourceEntries(podResourceEntries PodResourceEntries, persist bool)

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_checkpoint.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_checkpoint.go
@@ -227,6 +227,14 @@ func (sc *stateCheckpoint) GetPodResourceEntries() PodResourceEntries {
 	return sc.cache.GetPodResourceEntries()
 }
 
+func (sc *stateCheckpoint) SetReservedMemory(reservedMemory map[v1.ResourceName]map[int]uint64) {
+	sc.Lock()
+	defer sc.Unlock()
+
+	sc.reservedMemory = cloneReservedMemory(reservedMemory)
+	sc.cache.SetReservedMemory(reservedMemory)
+}
+
 func (sc *stateCheckpoint) SetMachineState(numaNodeResourcesMap NUMANodeResourcesMap, persist bool) {
 	sc.Lock()
 	defer sc.Unlock()

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_mem.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_mem.go
@@ -47,6 +47,17 @@ type memoryPluginState struct {
 	extraResourceNames []string
 }
 
+func cloneReservedMemory(reservedMemory map[v1.ResourceName]map[int]uint64) map[v1.ResourceName]map[int]uint64 {
+	clonedReservedMemory := make(map[v1.ResourceName]map[int]uint64, len(reservedMemory))
+	for resourceName, numaReserved := range reservedMemory {
+		clonedReservedMemory[resourceName] = make(map[int]uint64, len(numaReserved))
+		for numaID, reservedQuantity := range numaReserved {
+			clonedReservedMemory[resourceName][numaID] = reservedQuantity
+		}
+	}
+	return clonedReservedMemory
+}
+
 func NewMemoryPluginState(topology *machine.CPUTopology, machineInfo *info.MachineInfo,
 	memoryTopology *machine.MemoryTopology, reservedMemory map[v1.ResourceName]map[int]uint64, extraResourceNames []string,
 ) (*memoryPluginState, error) {
@@ -78,16 +89,14 @@ func (s *memoryPluginState) GetReservedMemory() map[v1.ResourceName]map[int]uint
 	s.RLock()
 	defer s.RUnlock()
 
-	clonedReservedMemory := make(map[v1.ResourceName]map[int]uint64)
-	for resourceName, numaReserved := range s.reservedMemory {
-		clonedReservedMemory[resourceName] = make(map[int]uint64)
+	return cloneReservedMemory(s.reservedMemory)
+}
 
-		for numaId, reservedQuantity := range numaReserved {
-			clonedReservedMemory[resourceName][numaId] = reservedQuantity
-		}
-	}
+func (s *memoryPluginState) SetReservedMemory(reservedMemory map[v1.ResourceName]map[int]uint64) {
+	s.Lock()
+	defer s.Unlock()
 
-	return clonedReservedMemory
+	s.reservedMemory = cloneReservedMemory(reservedMemory)
 }
 
 func (s *memoryPluginState) GetMachineState() NUMANodeResourcesMap {

--- a/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_test.go
+++ b/pkg/agent/qrm-plugins/memory/dynamicpolicy/state/state_test.go
@@ -58,6 +58,60 @@ func TestGetWriteOnlyState(t *testing.T) {
 	}
 }
 
+func TestSetReservedMemory(t *testing.T) {
+	t.Parallel()
+
+	initialReservedMemory := map[v1.ResourceName]map[int]uint64{
+		v1.ResourceMemory: {
+			0: 1,
+		},
+	}
+	newReservedMemory := func() map[v1.ResourceName]map[int]uint64 {
+		return map[v1.ResourceName]map[int]uint64{
+			v1.ResourceMemory: {
+				0: 2,
+			},
+			v1.ResourceHugePagesPrefix + "2Mi": {
+				0: 3,
+			},
+		}
+	}
+
+	t.Run("memory state clones reads and writes", func(t *testing.T) {
+		t.Parallel()
+
+		stateImpl := &memoryPluginState{
+			reservedMemory: initialReservedMemory,
+		}
+		nextReservedMemory := newReservedMemory()
+		stateImpl.SetReservedMemory(nextReservedMemory)
+
+		nextReservedMemory[v1.ResourceMemory][0] = 4
+		assert.Equal(t, uint64(2), stateImpl.GetReservedMemory()[v1.ResourceMemory][0])
+
+		got := stateImpl.GetReservedMemory()
+		got[v1.ResourceMemory][0] = 5
+		assert.Equal(t, uint64(2), stateImpl.GetReservedMemory()[v1.ResourceMemory][0])
+	})
+
+	t.Run("checkpoint state updates restore input and cache", func(t *testing.T) {
+		t.Parallel()
+
+		cache := &memoryPluginState{
+			reservedMemory: initialReservedMemory,
+		}
+		stateImpl := &stateCheckpoint{
+			cache:          cache,
+			reservedMemory: initialReservedMemory,
+		}
+		nextReservedMemory := newReservedMemory()
+		stateImpl.SetReservedMemory(nextReservedMemory)
+
+		assert.Equal(t, nextReservedMemory, stateImpl.GetReservedMemory())
+		assert.Equal(t, nextReservedMemory, stateImpl.reservedMemory)
+	})
+}
+
 func TestNewMemoryPluginCheckpoint(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This change refactors the CPU QRM plugin to use a centralized reserved CPU store instead of directly accessing the reservedCPUs field across all components:
1. Add SyncReservedCPUs constant and reserved CPU store implementation
2. Introduce thread-safe ReservedCPUProvider interface
3. Replace all direct reservedCPUs field access with getReservedCPUs() method
4. Update all eviction, hint optimizer, and policy handler usages
5. Add comprehensive tests for reserved CPU store functionality
6. Implement syncReservedCPUsOnce to update reserved CPUs from kubelet config

The refactor improves code maintainability, ensures thread safety for concurrent reserved CPU access, and centralizes reservation state management.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## English

- CPU and memory plugins can synchronize kubelet-reserved resources at runtime through periodic health-checked handlers.
- CPU reservations now use thread-safe state storage with defensive copies. Allocation, eviction, hint optimization, IRQ tuning, and resource-package calculations observe updates consistently.
- CPU synchronization updates reserve and reclaim pools, preserves valid allocations, persists state, and restores state if pool updates fail.
- Memory synchronization updates reserved memory and hugepages, preserves allocations when free memory is insufficient, validates reservations, and persists cloned state.
- Tests cover synchronization, rollback, concurrency safety, clone isolation, persistence, allocation preservation, and error handling.
- The change affects agent plugin runtime behavior. No controller, scheduler, release wiring, dependency, or configuration schema updates are reported.
- Rollout risk is moderate because reservation changes can alter CPU and memory allocatable capacity and pool membership. Monitor synchronization health and allocation behavior.

## 简体中文

- CPU 和 memory plugin 现在可以通过定期执行且带健康检查的 handler，在运行时同步 kubelet 预留资源。
- CPU 预留资源改用线程安全的 state 存储，并使用防御性副本。分配、驱逐、hint optimizer、IRQ 调优和 resource-package 计算会一致地读取最新值。
- CPU 同步会更新 reserve pool 和 reclaim pool，保留有效分配，在 pool 更新失败时恢复 state，并持久化成功状态。
- Memory 同步会更新预留 memory 和 hugepages。在可用 memory 不足时保留现有分配，并校验和持久化复制后的 state。
- 测试覆盖同步、回滚、并发安全、clone 隔离、持久化、分配保留和错误处理。
- 此变更影响 agent plugin 的运行时行为。未发现 controller、scheduler、release wiring、dependency 或 configuration schema 更新。
- 发布风险为中等，因为预留资源变化可能改变 CPU 和 memory allocatable capacity 以及 pool 成员。请监控同步健康状态和分配行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->