### PR TITLE
fix(gpu/qrm): fix accompany resource allocation returning empty devices

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/accompanyresource/bind.go
+++ b/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/accompanyresource/bind.go
@@ -235,8 +235,8 @@ func (s *AccompanyResourceStrategy) allocateWithAffinity(
 
 	// Not enough affinity devices are currently available to satisfy the proportional accompany allocation.
 	// Rather than failing pod admission, we log a warning, emit a metric for visibility, and return
-	// success with an empty allocation. This lets the pod proceed to be allocated (e.g. without RDMA devices in this
-	// scenario) instead of being rejected.
+	// success with a partial allocation. This lets the pod proceed to be allocated (e.g. without the full expected number of RDMA devices)
+	// instead of being rejected.
 	general.Warningf("not enough devices to allocate: need %d, have %d, pod: %s/%s, container: %s, resourceName: %s, accompanyResource: %s",
 		devicesToAllocate, len(selected),
 		ctx.ResourceReq.PodNamespace, ctx.ResourceReq.PodName, ctx.ResourceReq.ContainerName,
@@ -245,7 +245,7 @@ func (s *AccompanyResourceStrategy) allocateWithAffinity(
 
 	return &allocate.AllocationResult{
 		Success:          true,
-		AllocatedDevices: []string{},
+		AllocatedDevices: selected.UnsortedList(),
 	}, nil
 }
 

--- a/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/accompanyresource/bind_test.go
+++ b/pkg/agent/qrm-plugins/gpu/strategy/allocate/strategies/accompanyresource/bind_test.go
@@ -49,6 +49,8 @@ func TestBind(t *testing.T) {
 		ctx                                     *allocate.AllocationContext
 		sortedDevices                           []string
 		expectedResult                          *allocate.AllocationResult
+		expectedAllocatedDeviceCandidates       []string
+		expectedAllocatedDeviceCount            int
 		expectedErr                             bool
 		preAllocatedResourceToTargetDeviceRatio float64
 	}{
@@ -368,7 +370,7 @@ func TestBind(t *testing.T) {
 			expectedErr: true,
 		},
 		{
-			name: "not enough devices to allocate returns success with empty allocation",
+			name: "not enough devices to allocate returns success with partial allocation",
 			ctx: &allocate.AllocationContext{
 				AccompanyResourceName: "rdma",
 				ResourceName:          "gpu",
@@ -397,7 +399,7 @@ func TestBind(t *testing.T) {
 			// Need 2 devices (2 accompany rdmas, ratio 1) but only "0" is available -> not enough.
 			sortedDevices: []string{"0"},
 			expectedResult: &allocate.AllocationResult{
-				AllocatedDevices: []string{},
+				AllocatedDevices: sets.NewString("0").UnsortedList(),
 				Success:          true,
 			},
 		},
@@ -502,7 +504,7 @@ func TestBind(t *testing.T) {
 			},
 		},
 		{
-			name: "ratio 2/3 with affinity: need 3 but limit 1 per device -> success with empty allocation",
+			name: "ratio 2/3 with affinity: need 3 but limit 1 per device -> success with partial allocation",
 			ctx: &allocate.AllocationContext{
 				AccompanyResourceName: "rdma",
 				ResourceName:          "gpu",
@@ -530,12 +532,13 @@ func TestBind(t *testing.T) {
 			},
 			sortedDevices: []string{"g0", "g1", "g2"},
 			expectedResult: &allocate.AllocationResult{
-				AllocatedDevices: []string{},
-				Success:          true,
+				Success: true,
 			},
+			expectedAllocatedDeviceCandidates: []string{"g0", "g1", "g2"},
+			expectedAllocatedDeviceCount:      2,
 		},
 		{
-			name: "ratio 2/5 with affinity: need 5 but total per-device capacity 4 -> success with empty allocation",
+			name: "ratio 2/5 with affinity: need 5 but total per-device capacity 4 -> success with partial allocation",
 			ctx: &allocate.AllocationContext{
 				AccompanyResourceName: "rdma",
 				ResourceName:          "gpu",
@@ -565,9 +568,10 @@ func TestBind(t *testing.T) {
 			},
 			sortedDevices: []string{"g0", "g1", "g2", "g3", "g4"},
 			expectedResult: &allocate.AllocationResult{
-				AllocatedDevices: []string{},
-				Success:          true,
+				Success: true,
 			},
+			expectedAllocatedDeviceCandidates: []string{"g0", "g1", "g2", "g3", "g4"},
+			expectedAllocatedDeviceCount:      4,
 		},
 		{
 			name: "fractional ratio returns error",
@@ -757,7 +761,12 @@ func TestBind(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedResult.Success, result.Success)
-				assert.ElementsMatch(t, tc.expectedResult.AllocatedDevices, result.AllocatedDevices)
+				if tc.expectedAllocatedDeviceCandidates != nil {
+					assert.Len(t, result.AllocatedDevices, tc.expectedAllocatedDeviceCount)
+					assert.Subset(t, tc.expectedAllocatedDeviceCandidates, result.AllocatedDevices)
+				} else {
+					assert.ElementsMatch(t, tc.expectedResult.AllocatedDevices, result.AllocatedDevices)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Previously the allocation strategy would return empty allocated devices even when some matching gpu devices were found for the accompany resource. Update the allocateWithAffinity method to return the actual selected devices, and update tests to validate partial allocation behavior correctly.

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### English
- `allocateWithAffinity` now returns the matching GPU devices selected before allocation becomes insufficient.
- GPU QRM now supports and reports partial allocation correctly.
- Tests validate allocation counts and candidate-device membership for partial allocations.
- No configuration, dependency, controller, scheduler, or release-wiring changes.
- Operational risk is low. The change affects GPU agent allocation behavior only.

### 简体中文
- `allocateWithAffinity` 现在会返回资源不足前已选中的匹配 GPU 设备。
- GPU QRM 现在可以正确支持并报告部分分配。
- 测试会验证部分分配的设备数量及其是否属于候选设备。
- 没有配置、依赖、controller、scheduler 或 release wiring 变更。
- 运行风险较低。此变更仅影响 GPU agent 的资源分配行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->