### PR TITLE
feat(cgroup): support skipping path handlers

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
@@ -71,14 +71,14 @@ func registerRelativeCgroupPathHandler(podUID string) {
 	registerRelativeCgroupPathHandlerOnce.Do(func() {
 		cgroupcommon.RegisterRelativeCgroupPathHandler(cgroupcommon.RelativeCgroupPathHandler{
 			Name: "unit_test",
-			Handler: func(pUID, containerID string) (string, error) {
+			Handler: func(pUID, containerID string) (string, bool, error) {
 				if pUID != podUID {
-					return "", fmt.Errorf("pod uid mismatch")
+					return "", false, fmt.Errorf("pod uid mismatch")
 				}
 				if containerID != "cid0" && containerID != "cid1" {
-					return "", fmt.Errorf("container id mismatch")
+					return "", false, fmt.Errorf("container id mismatch")
 				}
-				return fmt.Sprintf("/unit-test/%s/%s", pUID, containerID), nil
+				return fmt.Sprintf("/unit-test/%s/%s", pUID, containerID), false, nil
 			},
 		})
 	})

--- a/pkg/metaserver/agent/pod/kata.go
+++ b/pkg/metaserver/agent/pod/kata.go
@@ -62,56 +62,66 @@ func RegisterKataContainerFetcher(runtimePodFetcher RuntimePodFetcher) {
 
 // getKataContainerAbsoluteCgroupPath attempts to get the absolute cgroup path of a kata container
 // and returns an error if it fails to do so.
-func (k *KataContainerFetcher) getKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, error) {
+func (k *KataContainerFetcher) getKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, bool, error) {
+	cgroupPathSuffix, skip, err := k.getKataCgroupPathSuffix(podUID, containerId)
+	if skip {
+		return "", true, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
+	}
+
 	// First check if the cgroup exists for pod level
-	_, err := common.GetPodAbsCgroupPath(subsys, podUID)
+	_, err = common.GetPodAbsCgroupPath(subsys, podUID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get absolute path for pod %s, err: %v", podUID, err)
+		return "", false, fmt.Errorf("failed to get absolute path for pod %s, err: %v", podUID, err)
 	}
-	cgroupPathSuffix, err := k.getKataCgroupPathSuffix(podUID, containerId)
-	if err != nil {
-		return "", fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
-	}
-	return common.GetKubernetesAnyExistAbsCgroupPath(subsys, cgroupPathSuffix)
+	cgroupPath, err := common.GetKubernetesAnyExistAbsCgroupPath(subsys, cgroupPathSuffix)
+	return cgroupPath, false, err
 }
 
 // getKataContainerRelativeCgroupPath attempts to get the relative cgroup path of a kata container
 // and returns an error if it fails to do so.
-func (k *KataContainerFetcher) getKataContainerRelativeCgroupPath(podUID, containerId string) (string, error) {
+func (k *KataContainerFetcher) getKataContainerRelativeCgroupPath(podUID, containerId string) (string, bool, error) {
+	cgroupPathSuffix, skip, err := k.getKataCgroupPathSuffix(podUID, containerId)
+	if skip {
+		return "", true, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
+	}
+
 	// First check if the cgroup exists for pod level
-	_, err := common.GetPodRelativeCgroupPath(podUID)
+	_, err = common.GetPodRelativeCgroupPath(podUID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get relative cgroup path for pod %s, err: %v", podUID, err)
+		return "", false, fmt.Errorf("failed to get relative cgroup path for pod %s, err: %v", podUID, err)
 	}
-	cgroupPathSuffix, err := k.getKataCgroupPathSuffix(podUID, containerId)
-	if err != nil {
-		return "", fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
-	}
-	return common.GetKubernetesAnyExistRelativeCgroupPath(cgroupPathSuffix)
+	cgroupPath, err := common.GetKubernetesAnyExistRelativeCgroupPath(cgroupPathSuffix)
+	return cgroupPath, false, err
 }
 
 // getKataCgroupPathSuffix retrieves the sandbox id of the kata container and
 // then constructs the cgroup path suffix.
-func (k *KataContainerFetcher) getKataCgroupPathSuffix(podUID, containerId string) (string, error) {
+func (k *KataContainerFetcher) getKataCgroupPathSuffix(podUID, containerId string) (string, bool, error) {
 	infoRaw, err := k.runtimePodFetcher.GetContainerInfo(containerId)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container info, err: %v", err)
+		return "", false, fmt.Errorf("failed to get container info, err: %v", err)
 	}
 
 	var info ContainerInfo
 	if err := json.Unmarshal([]byte(infoRaw["info"]), &info); err != nil {
-		return "", fmt.Errorf("failed to unmarshal info of container into its sandbox id and runtime type, err: %v", err)
+		return "", false, fmt.Errorf("failed to unmarshal info of container into its sandbox id and runtime type, err: %v", err)
 	}
 	runtimeType := info.RuntimeType
 	if !strings.Contains(runtimeType, kataRuntimeType) {
-		return "", fmt.Errorf("runtime type of container is not kata runtime: %s", runtimeType)
+		return "", true, nil
 	}
 
 	sandboxId := info.SandboxID
 	if sandboxId == "" {
-		return "", fmt.Errorf("failed to get sandbox id of container")
+		return "", false, fmt.Errorf("failed to get sandbox id of container")
 	}
 
 	kataPathSuffix := fmt.Sprintf("kata_%s", sandboxId)
-	return path.Join(fmt.Sprintf("%s%s", common.PodCgroupPathPrefix, podUID), kataPathSuffix), nil
+	return path.Join(fmt.Sprintf("%s%s", common.PodCgroupPathPrefix, podUID), kataPathSuffix), false, nil
 }

--- a/pkg/metaserver/agent/pod/kata_test.go
+++ b/pkg/metaserver/agent/pod/kata_test.go
@@ -41,6 +41,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 		name                 string
 		fields               fields
 		wantCgroupPathSuffix string
+		wantSkip             bool
 		wantErr              bool
 	}{
 		{
@@ -55,6 +56,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -69,6 +71,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -83,6 +86,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -97,7 +101,8 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
-			wantErr:              true,
+			wantSkip:             true,
+			wantErr:              false,
 		},
 		{
 			name: "Can get the kata cgroup path suffix",
@@ -111,6 +116,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "pod12345678/kata_12345678",
+			wantSkip:             false,
 			wantErr:              false,
 		},
 	}
@@ -123,16 +129,43 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 					containerIdToInfo: tt.fields.containerIdToInfo,
 				},
 			}
-			pathSuffix, err := kataContainerFetcher.getKataCgroupPathSuffix(tt.fields.podUid, tt.fields.containerId)
+			pathSuffix, skip, err := kataContainerFetcher.getKataCgroupPathSuffix(tt.fields.podUid, tt.fields.containerId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getKataCgroupPathSuffix() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if skip != tt.wantSkip {
+				t.Errorf("getKataCgroupPathSuffix() skip = %v, want %v", skip, tt.wantSkip)
 			}
 			if pathSuffix != tt.wantCgroupPathSuffix {
 				t.Errorf("getKataCgroupPathSuffix() pathSuffix = %v, want %v", pathSuffix, tt.wantCgroupPathSuffix)
 			}
 		})
 	}
+}
+
+func TestKataContainerFetcher_getKataContainerCgroupPathSkipsNonKataRuntime(t *testing.T) {
+	t.Parallel()
+
+	kataContainerFetcher := &KataContainerFetcher{
+		runtimePodFetcher: &runtimePodFetcherStub{
+			containerIdToInfo: map[string]map[string]string{
+				"container1234": {
+					"info": testNonKataJsonInfo,
+				},
+			},
+		},
+	}
+
+	absPath, skip, err := kataContainerFetcher.getKataContainerAbsoluteCgroupPath("cpu", "12345", "container1234")
+	assert.Empty(t, absPath)
+	assert.True(t, skip)
+	assert.NoError(t, err)
+
+	relPath, skip, err := kataContainerFetcher.getKataContainerRelativeCgroupPath("12345", "container1234")
+	assert.Empty(t, relPath)
+	assert.True(t, skip)
+	assert.NoError(t, err)
 }
 
 func TestKataContainerFetcher_getKataContainerAbsoluteCgroupPath(t *testing.T) {
@@ -150,8 +183,9 @@ func TestKataContainerFetcher_getKataContainerAbsoluteCgroupPath(t *testing.T) {
 		},
 	}
 
-	absPath, err := kataContainerFetcher.getKataContainerAbsoluteCgroupPath("cpu", "12345", "123456")
+	absPath, skip, err := kataContainerFetcher.getKataContainerAbsoluteCgroupPath("cpu", "12345", "123456")
 	assert.Equal(t, absPath, "")
+	assert.False(t, skip)
 	assert.NotNil(t, err)
 }
 
@@ -170,7 +204,8 @@ func TestKataContainerFetcher_getKataContainerRelativeCgroupPath(t *testing.T) {
 		},
 	}
 
-	absPath, err := kataContainerFetcher.getKataContainerRelativeCgroupPath("12345", "123456")
+	absPath, skip, err := kataContainerFetcher.getKataContainerRelativeCgroupPath("12345", "123456")
 	assert.Equal(t, absPath, "")
+	assert.False(t, skip)
 	assert.NotNil(t, err)
 }

--- a/pkg/util/cgroup/common/path.go
+++ b/pkg/util/cgroup/common/path.go
@@ -184,12 +184,14 @@ func GetPodRelativeCgroupPath(podUID string) (string, error) {
 	return GetKubernetesAnyExistRelativeCgroupPath(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID))
 }
 
-func getContainerDefaultAbsCgroupPath(subsys, podUID, containerId string) (string, error) {
-	return GetKubernetesAnyExistAbsCgroupPath(subsys, path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+func getContainerDefaultAbsCgroupPath(subsys, podUID, containerId string) (string, bool, error) {
+	cgroupPath, err := GetKubernetesAnyExistAbsCgroupPath(subsys, path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+	return cgroupPath, false, err
 }
 
-func getContainerDefaultRelativeAbsCgroupPath(podUID, containerId string) (string, error) {
-	return GetKubernetesAnyExistRelativeCgroupPath(path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+func getContainerDefaultRelativeAbsCgroupPath(podUID, containerId string) (string, bool, error) {
+	cgroupPath, err := GetKubernetesAnyExistRelativeCgroupPath(path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+	return cgroupPath, false, err
 }
 
 // GetContainerAbsCgroupPath returns absolute cgroup path for container level
@@ -201,7 +203,10 @@ func GetContainerAbsCgroupPath(subsys, podUID, containerId string) (string, erro
 			errors = append(errors, fmt.Errorf("absolute cgroup path Handler for %s is nil", handler.Name))
 			continue
 		}
-		cgroupPath, err := handler.Handler(subsys, podUID, containerId)
+		cgroupPath, skip, err := handler.Handler(subsys, podUID, containerId)
+		if skip {
+			continue
+		}
 		if err == nil {
 			return cgroupPath, nil
 		}
@@ -219,7 +224,10 @@ func GetContainerRelativeCgroupPath(podUID, containerId string) (string, error) 
 			errors = append(errors, fmt.Errorf("relative cgroup path Handler for %s is nil", handler.Name))
 			continue
 		}
-		cgroupPath, err := handler.Handler(podUID, containerId)
+		cgroupPath, skip, err := handler.Handler(podUID, containerId)
+		if skip {
+			continue
+		}
 		if err == nil {
 			return cgroupPath, nil
 		}

--- a/pkg/util/cgroup/common/path_test.go
+++ b/pkg/util/cgroup/common/path_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,6 +69,88 @@ func TestGetContainerAbsCgroupPath(t *testing.T) {
 	as := require.New(t)
 	_, err := GetContainerAbsCgroupPath("cpuset", "", "")
 	as.NotNil(err)
+}
+
+func TestGetContainerAbsCgroupPathSkipsHandlers(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	const (
+		podUID      = "skip-handler-pod"
+		containerID = "skip-handler-container"
+	)
+
+	absoluteCgroupPathHandlerLock.Lock()
+	oldHandlers := absoluteCgroupPathHandlerList
+	absoluteCgroupPathHandlerList = []AbsoluteCgroupPathHandler{
+		{
+			Name: "skip",
+			Handler: func(subsys, podUID, containerId string) (string, bool, error) {
+				return "", true, nil
+			},
+		},
+		{
+			Name: "success",
+			Handler: func(subsys, podUID, containerId string) (string, bool, error) {
+				if podUID != "skip-handler-pod" || containerId != "skip-handler-container" {
+					return "", false, fmt.Errorf("unexpected container")
+				}
+				return "/sys/fs/cgroup/cpu/pod/container", false, nil
+			},
+		},
+	}
+	absoluteCgroupPathHandlerLock.Unlock()
+	defer func() {
+		absoluteCgroupPathHandlerLock.Lock()
+		absoluteCgroupPathHandlerList = oldHandlers
+		absoluteCgroupPathHandlerLock.Unlock()
+	}()
+
+	cgroupPath, err := GetContainerAbsCgroupPath("cpu", podUID, containerID)
+	as.NoError(err)
+	as.Equal("/sys/fs/cgroup/cpu/pod/container", cgroupPath)
+}
+
+func TestGetContainerRelativeCgroupPathSkipsHandlers(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	const (
+		podUID      = "skip-handler-pod"
+		containerID = "skip-handler-container"
+	)
+
+	relativeCgroupPathHandlerLock.Lock()
+	oldHandlers := relativeCgroupPathHandlerList
+	relativeCgroupPathHandlerList = []RelativeCgroupPathHandler{
+		{
+			Name: "skip",
+			Handler: func(podUID, containerId string) (string, bool, error) {
+				return "", true, nil
+			},
+		},
+		{
+			Name: "success",
+			Handler: func(podUID, containerId string) (string, bool, error) {
+				if podUID != "skip-handler-pod" || containerId != "skip-handler-container" {
+					return "", false, fmt.Errorf("unexpected container")
+				}
+				return "/kubepods/pod/container", false, nil
+			},
+		},
+	}
+	relativeCgroupPathHandlerLock.Unlock()
+	defer func() {
+		relativeCgroupPathHandlerLock.Lock()
+		relativeCgroupPathHandlerList = oldHandlers
+		relativeCgroupPathHandlerLock.Unlock()
+	}()
+
+	cgroupPath, err := GetContainerRelativeCgroupPath(podUID, containerID)
+	as.NoError(err)
+	as.Equal("/kubepods/pod/container", cgroupPath)
 }
 
 func TestIsContainerCgroupExist(t *testing.T) {

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -254,10 +254,10 @@ type CgroupResources struct {
 
 type AbsoluteCgroupPathHandler struct {
 	Name    string
-	Handler func(subsys, podUID, containerId string) (string, error)
+	Handler func(subsys, podUID, containerId string) (string, bool, error)
 }
 
 type RelativeCgroupPathHandler struct {
 	Name    string
-	Handler func(podUID, containerId string) (string, error)
+	Handler func(podUID, containerId string) (string, bool, error)
 }


### PR DESCRIPTION
## Summary
- add skip semantics to absolute/relative cgroup path handlers
- skip non-kata runtime containers in the kata handler
- adapt default/kata handlers and affected tests

## Verification
- GO111MODULE=on GOTOOLCHAIN=local GOFLAGS=-tags=SKIPCGO go test -c ./pkg/metaserver/agent/pod
- GO111MODULE=on GOTOOLCHAIN=local GOFLAGS=-tags=SKIPCGO go test -c ./pkg/util/cgroup/common

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Cgroup path handlers now return `(path, skip, error)`.
- Absolute and relative resolution skips handlers that set `skip=true`.
- The Kata handler skips non-Kata runtime containers without returning an error.
- Kata containers retain existing path resolution and error behavior.
- Tests cover skip propagation, handler fallback, and error handling.
- The change affects agent cgroup path handling only. It does not change controller, scheduler, release wiring, configuration, or dependencies.
- Operational risk is limited to handler integration. Callers must use the expanded return signature.

### 简体中文

- Cgroup path handler 现在返回 `(path, skip, error)`。
- 当 handler 设置 `skip=true` 时，绝对路径和相对路径解析会跳过该 handler。
- Kata handler 会跳过非 Kata runtime container，且不返回错误。
- Kata container 保留现有的路径解析和错误处理行为。
- 测试覆盖 skip 传递、handler fallback 和错误处理。
- 此变更仅影响 agent 的 cgroup 路径处理。不涉及 controller、scheduler、release wiring、配置或依赖项。
- 运行风险主要限于 handler 集成。调用方必须使用扩展后的返回签名。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->