### PR TITLE
feat(cgroup): support skipping path handlers

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/policy_irq_tuner_test.go
@@ -71,14 +71,14 @@ func registerRelativeCgroupPathHandler(podUID string) {
 	registerRelativeCgroupPathHandlerOnce.Do(func() {
 		cgroupcommon.RegisterRelativeCgroupPathHandler(cgroupcommon.RelativeCgroupPathHandler{
 			Name: "unit_test",
-			Handler: func(pUID, containerID string) (string, error) {
+			Handler: func(pUID, containerID string) (string, bool, error) {
 				if pUID != podUID {
-					return "", fmt.Errorf("pod uid mismatch")
+					return "", false, fmt.Errorf("pod uid mismatch")
 				}
 				if containerID != "cid0" && containerID != "cid1" {
-					return "", fmt.Errorf("container id mismatch")
+					return "", false, fmt.Errorf("container id mismatch")
 				}
-				return fmt.Sprintf("/unit-test/%s/%s", pUID, containerID), nil
+				return fmt.Sprintf("/unit-test/%s/%s", pUID, containerID), false, nil
 			},
 		})
 	})

--- a/pkg/metaserver/agent/pod/kata.go
+++ b/pkg/metaserver/agent/pod/kata.go
@@ -62,56 +62,69 @@ func RegisterKataContainerFetcher(runtimePodFetcher RuntimePodFetcher) {
 
 // getKataContainerAbsoluteCgroupPath attempts to get the absolute cgroup path of a kata container
 // and returns an error if it fails to do so.
-func (k *KataContainerFetcher) getKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, error) {
+func (k *KataContainerFetcher) getKataContainerAbsoluteCgroupPath(subsys, podUID, containerId string) (string, bool, error) {
+	cgroupPathSuffix, skip, err := k.getKataCgroupPathSuffix(podUID, containerId)
+	if skip {
+		return "", true, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
+	}
+
 	// First check if the cgroup exists for pod level
-	_, err := common.GetPodAbsCgroupPath(subsys, podUID)
+	_, err = common.GetPodAbsCgroupPath(subsys, podUID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get absolute path for pod %s, err: %v", podUID, err)
+		return "", false, fmt.Errorf("failed to get absolute path for pod %s, err: %v", podUID, err)
 	}
-	cgroupPathSuffix, err := k.getKataCgroupPathSuffix(podUID, containerId)
-	if err != nil {
-		return "", fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
-	}
-	return common.GetKubernetesAnyExistAbsCgroupPath(subsys, cgroupPathSuffix)
+	cgroupPath, err := common.GetKubernetesAnyExistAbsCgroupPath(subsys, cgroupPathSuffix)
+	return cgroupPath, false, err
 }
 
 // getKataContainerRelativeCgroupPath attempts to get the relative cgroup path of a kata container
 // and returns an error if it fails to do so.
-func (k *KataContainerFetcher) getKataContainerRelativeCgroupPath(podUID, containerId string) (string, error) {
+func (k *KataContainerFetcher) getKataContainerRelativeCgroupPath(podUID, containerId string) (string, bool, error) {
+	cgroupPathSuffix, skip, err := k.getKataCgroupPathSuffix(podUID, containerId)
+	if skip {
+		return "", true, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
+	}
+
 	// First check if the cgroup exists for pod level
-	_, err := common.GetPodRelativeCgroupPath(podUID)
+	_, err = common.GetPodRelativeCgroupPath(podUID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get relative cgroup path for pod %s, err: %v", podUID, err)
+		return "", false, fmt.Errorf("failed to get relative cgroup path for pod %s, err: %v", podUID, err)
 	}
-	cgroupPathSuffix, err := k.getKataCgroupPathSuffix(podUID, containerId)
-	if err != nil {
-		return "", fmt.Errorf("failed to get kata cgroup path suffix: %v", err)
-	}
-	return common.GetKubernetesAnyExistRelativeCgroupPath(cgroupPathSuffix)
+	cgroupPath, err := common.GetKubernetesAnyExistRelativeCgroupPath(cgroupPathSuffix)
+	return cgroupPath, false, err
 }
 
 // getKataCgroupPathSuffix retrieves the sandbox id of the kata container and
 // then constructs the cgroup path suffix.
-func (k *KataContainerFetcher) getKataCgroupPathSuffix(podUID, containerId string) (string, error) {
+func (k *KataContainerFetcher) getKataCgroupPathSuffix(podUID, containerId string) (string, bool, error) {
 	infoRaw, err := k.runtimePodFetcher.GetContainerInfo(containerId)
 	if err != nil {
-		return "", fmt.Errorf("failed to get container info, err: %v", err)
+		return "", false, fmt.Errorf("failed to get container info, err: %v", err)
 	}
 
 	var info ContainerInfo
 	if err := json.Unmarshal([]byte(infoRaw["info"]), &info); err != nil {
-		return "", fmt.Errorf("failed to unmarshal info of container into its sandbox id and runtime type, err: %v", err)
+		return "", false, fmt.Errorf("failed to unmarshal info of container into its sandbox id and runtime type, err: %v", err)
 	}
 	runtimeType := info.RuntimeType
+	if runtimeType == "" {
+		return "", false, fmt.Errorf("failed to get runtime type of container")
+	}
 	if !strings.Contains(runtimeType, kataRuntimeType) {
-		return "", fmt.Errorf("runtime type of container is not kata runtime: %s", runtimeType)
+		return "", true, nil
 	}
 
 	sandboxId := info.SandboxID
 	if sandboxId == "" {
-		return "", fmt.Errorf("failed to get sandbox id of container")
+		return "", false, fmt.Errorf("failed to get sandbox id of container")
 	}
 
 	kataPathSuffix := fmt.Sprintf("kata_%s", sandboxId)
-	return path.Join(fmt.Sprintf("%s%s", common.PodCgroupPathPrefix, podUID), kataPathSuffix), nil
+	return path.Join(fmt.Sprintf("%s%s", common.PodCgroupPathPrefix, podUID), kataPathSuffix), false, nil
 }

--- a/pkg/metaserver/agent/pod/kata_test.go
+++ b/pkg/metaserver/agent/pod/kata_test.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	testKataJsonInfo    = `{"sandboxID": "12345678", "pid": 1234, "runtimeType": "io.containerd.kata.v2"}`
-	testInvalidJsonInfo = `{"pid: 2345"}` // no sandbox id field
-	testNonKataJsonInfo = `{"sandboxID": "234567890", "pid": "2345", "runtimeType": "docker"}`
+	testKataJsonInfo       = `{"sandboxID": "12345678", "pid": 1234, "runtimeType": "io.containerd.kata.v2"}`
+	testInvalidJsonInfo    = `{"pid: 2345"}` // no sandbox id field
+	testMissingRuntimeInfo = `{"sandboxID": "12345678", "pid": 2345}`
+	testNonKataJsonInfo    = `{"sandboxID": "234567890", "pid": "2345", "runtimeType": "docker"}`
 )
 
 func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
@@ -41,6 +42,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 		name                 string
 		fields               fields
 		wantCgroupPathSuffix string
+		wantSkip             bool
 		wantErr              bool
 	}{
 		{
@@ -55,6 +57,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -69,6 +72,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -83,6 +87,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -97,6 +102,22 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "",
+			wantSkip:             true,
+			wantErr:              false,
+		},
+		{
+			name: "Missing runtime type",
+			fields: fields{
+				podUid:      "12345678",
+				containerId: "container1234",
+				containerIdToInfo: map[string]map[string]string{
+					"container1234": {
+						"info": testMissingRuntimeInfo,
+					},
+				},
+			},
+			wantCgroupPathSuffix: "",
+			wantSkip:             false,
 			wantErr:              true,
 		},
 		{
@@ -111,6 +132,7 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 				},
 			},
 			wantCgroupPathSuffix: "pod12345678/kata_12345678",
+			wantSkip:             false,
 			wantErr:              false,
 		},
 	}
@@ -123,16 +145,43 @@ func TestKataContainerFetcher_getKataCgroupPathSuffix(t *testing.T) {
 					containerIdToInfo: tt.fields.containerIdToInfo,
 				},
 			}
-			pathSuffix, err := kataContainerFetcher.getKataCgroupPathSuffix(tt.fields.podUid, tt.fields.containerId)
+			pathSuffix, skip, err := kataContainerFetcher.getKataCgroupPathSuffix(tt.fields.podUid, tt.fields.containerId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getKataCgroupPathSuffix() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if skip != tt.wantSkip {
+				t.Errorf("getKataCgroupPathSuffix() skip = %v, want %v", skip, tt.wantSkip)
 			}
 			if pathSuffix != tt.wantCgroupPathSuffix {
 				t.Errorf("getKataCgroupPathSuffix() pathSuffix = %v, want %v", pathSuffix, tt.wantCgroupPathSuffix)
 			}
 		})
 	}
+}
+
+func TestKataContainerFetcher_getKataContainerCgroupPathSkipsNonKataRuntime(t *testing.T) {
+	t.Parallel()
+
+	kataContainerFetcher := &KataContainerFetcher{
+		runtimePodFetcher: &runtimePodFetcherStub{
+			containerIdToInfo: map[string]map[string]string{
+				"container1234": {
+					"info": testNonKataJsonInfo,
+				},
+			},
+		},
+	}
+
+	absPath, skip, err := kataContainerFetcher.getKataContainerAbsoluteCgroupPath("cpu", "12345", "container1234")
+	assert.Empty(t, absPath)
+	assert.True(t, skip)
+	assert.NoError(t, err)
+
+	relPath, skip, err := kataContainerFetcher.getKataContainerRelativeCgroupPath("12345", "container1234")
+	assert.Empty(t, relPath)
+	assert.True(t, skip)
+	assert.NoError(t, err)
 }
 
 func TestKataContainerFetcher_getKataContainerAbsoluteCgroupPath(t *testing.T) {
@@ -150,8 +199,9 @@ func TestKataContainerFetcher_getKataContainerAbsoluteCgroupPath(t *testing.T) {
 		},
 	}
 
-	absPath, err := kataContainerFetcher.getKataContainerAbsoluteCgroupPath("cpu", "12345", "123456")
+	absPath, skip, err := kataContainerFetcher.getKataContainerAbsoluteCgroupPath("cpu", "12345", "123456")
 	assert.Equal(t, absPath, "")
+	assert.False(t, skip)
 	assert.NotNil(t, err)
 }
 
@@ -170,7 +220,8 @@ func TestKataContainerFetcher_getKataContainerRelativeCgroupPath(t *testing.T) {
 		},
 	}
 
-	absPath, err := kataContainerFetcher.getKataContainerRelativeCgroupPath("12345", "123456")
+	absPath, skip, err := kataContainerFetcher.getKataContainerRelativeCgroupPath("12345", "123456")
 	assert.Equal(t, absPath, "")
+	assert.False(t, skip)
 	assert.NotNil(t, err)
 }

--- a/pkg/util/cgroup/common/path.go
+++ b/pkg/util/cgroup/common/path.go
@@ -184,28 +184,68 @@ func GetPodRelativeCgroupPath(podUID string) (string, error) {
 	return GetKubernetesAnyExistRelativeCgroupPath(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID))
 }
 
-func getContainerDefaultAbsCgroupPath(subsys, podUID, containerId string) (string, error) {
-	return GetKubernetesAnyExistAbsCgroupPath(subsys, path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+func getContainerDefaultAbsCgroupPath(subsys, podUID, containerId string) (string, bool, error) {
+	cgroupPath, err := GetKubernetesAnyExistAbsCgroupPath(subsys, path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+	return cgroupPath, false, err
 }
 
-func getContainerDefaultRelativeAbsCgroupPath(podUID, containerId string) (string, error) {
-	return GetKubernetesAnyExistRelativeCgroupPath(path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+func getContainerDefaultRelativeAbsCgroupPath(podUID, containerId string) (string, bool, error) {
+	cgroupPath, err := GetKubernetesAnyExistRelativeCgroupPath(path.Join(fmt.Sprintf("%s%s", PodCgroupPathPrefix, podUID), containerId))
+	return cgroupPath, false, err
+}
+
+func resolveContainerAbsCgroupPath(handlers []AbsoluteCgroupPathHandler, subsys, podUID, containerId string) (string, error) {
+	var errors []error
+	handled := false
+	for _, handler := range handlers {
+		if handler.Handler == nil {
+			handled = true
+			errors = append(errors, fmt.Errorf("absolute cgroup path Handler for %s is nil", handler.Name))
+			continue
+		}
+		cgroupPath, skip, err := handler.Handler(subsys, podUID, containerId)
+		if skip {
+			continue
+		}
+		handled = true
+		if err == nil {
+			return cgroupPath, nil
+		}
+		errors = append(errors, fmt.Errorf("get absolute cgroup path by Handler %s failed, err: %v", handler.Name, err))
+	}
+	if !handled {
+		return "", fmt.Errorf("all absolute cgroup path handlers skipped for pod %s container %s", podUID, containerId)
+	}
+	return "", utilerrors.NewAggregate(errors)
 }
 
 // GetContainerAbsCgroupPath returns absolute cgroup path for container level
 // It uses all the handlers in absoluteCgroupPathHandlerMap and returns the first non-empty path.
 func GetContainerAbsCgroupPath(subsys, podUID, containerId string) (string, error) {
+	return resolveContainerAbsCgroupPath(absoluteCgroupPathHandlerList, subsys, podUID, containerId)
+}
+
+func resolveContainerRelativeCgroupPath(handlers []RelativeCgroupPathHandler, podUID, containerId string) (string, error) {
 	var errors []error
-	for _, handler := range absoluteCgroupPathHandlerList {
+	handled := false
+	for _, handler := range handlers {
 		if handler.Handler == nil {
-			errors = append(errors, fmt.Errorf("absolute cgroup path Handler for %s is nil", handler.Name))
+			handled = true
+			errors = append(errors, fmt.Errorf("relative cgroup path Handler for %s is nil", handler.Name))
 			continue
 		}
-		cgroupPath, err := handler.Handler(subsys, podUID, containerId)
+		cgroupPath, skip, err := handler.Handler(podUID, containerId)
+		if skip {
+			continue
+		}
+		handled = true
 		if err == nil {
 			return cgroupPath, nil
 		}
-		errors = append(errors, fmt.Errorf("get absolute cgroup path by Handler %s failed, err: %v", handler.Name, err))
+		errors = append(errors, fmt.Errorf("get relative cgroup path by Handler %s failed, err: %v", handler.Name, err))
+	}
+	if !handled {
+		return "", fmt.Errorf("all relative cgroup path handlers skipped for pod %s container %s", podUID, containerId)
 	}
 	return "", utilerrors.NewAggregate(errors)
 }
@@ -213,19 +253,7 @@ func GetContainerAbsCgroupPath(subsys, podUID, containerId string) (string, erro
 // GetContainerRelativeCgroupPath returns relative cgroup path for container level
 // It uses all the handlers in relativeCgroupPathHandlerMap and returns the first non-empty path.
 func GetContainerRelativeCgroupPath(podUID, containerId string) (string, error) {
-	var errors []error
-	for _, handler := range relativeCgroupPathHandlerList {
-		if handler.Handler == nil {
-			errors = append(errors, fmt.Errorf("relative cgroup path Handler for %s is nil", handler.Name))
-			continue
-		}
-		cgroupPath, err := handler.Handler(podUID, containerId)
-		if err == nil {
-			return cgroupPath, nil
-		}
-		errors = append(errors, fmt.Errorf("get relative cgroup path by Handler %s failed, err: %v", handler.Name, err))
-	}
-	return "", utilerrors.NewAggregate(errors)
+	return resolveContainerRelativeCgroupPath(relativeCgroupPathHandlerList, podUID, containerId)
 }
 
 func IsContainerCgroupExist(podUID, containerID string) (bool, error) {

--- a/pkg/util/cgroup/common/path_test.go
+++ b/pkg/util/cgroup/common/path_test.go
@@ -70,6 +70,94 @@ func TestGetContainerAbsCgroupPath(t *testing.T) {
 	as.NotNil(err)
 }
 
+func TestGetContainerAbsCgroupPathSkipsHandlers(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	handlers := []AbsoluteCgroupPathHandler{
+		{
+			Name: "skip",
+			Handler: func(subsys, podUID, containerId string) (string, bool, error) {
+				return "", true, nil
+			},
+		},
+		{
+			Name: "success",
+			Handler: func(subsys, podUID, containerId string) (string, bool, error) {
+				return "/sys/fs/cgroup/cpu/pod/container", false, nil
+			},
+		},
+	}
+
+	cgroupPath, err := resolveContainerAbsCgroupPath(handlers, "cpu", "pod", "container")
+	as.NoError(err)
+	as.Equal("/sys/fs/cgroup/cpu/pod/container", cgroupPath)
+}
+
+func TestGetContainerAbsCgroupPathReturnsErrorIfAllHandlersSkip(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	handlers := []AbsoluteCgroupPathHandler{
+		{
+			Name: "skip",
+			Handler: func(subsys, podUID, containerId string) (string, bool, error) {
+				return "", true, nil
+			},
+		},
+	}
+
+	_, err := resolveContainerAbsCgroupPath(handlers, "cpu", "pod", "container")
+	as.Error(err)
+	as.Contains(err.Error(), "all absolute cgroup path handlers skipped")
+}
+
+func TestGetContainerRelativeCgroupPathSkipsHandlers(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	handlers := []RelativeCgroupPathHandler{
+		{
+			Name: "skip",
+			Handler: func(podUID, containerId string) (string, bool, error) {
+				return "", true, nil
+			},
+		},
+		{
+			Name: "success",
+			Handler: func(podUID, containerId string) (string, bool, error) {
+				return "/kubepods/pod/container", false, nil
+			},
+		},
+	}
+
+	cgroupPath, err := resolveContainerRelativeCgroupPath(handlers, "pod", "container")
+	as.NoError(err)
+	as.Equal("/kubepods/pod/container", cgroupPath)
+}
+
+func TestGetContainerRelativeCgroupPathReturnsErrorIfAllHandlersSkip(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	handlers := []RelativeCgroupPathHandler{
+		{
+			Name: "skip",
+			Handler: func(podUID, containerId string) (string, bool, error) {
+				return "", true, nil
+			},
+		},
+	}
+
+	_, err := resolveContainerRelativeCgroupPath(handlers, "pod", "container")
+	as.Error(err)
+	as.Contains(err.Error(), "all relative cgroup path handlers skipped")
+}
+
 func TestIsContainerCgroupExist(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/util/cgroup/common/types.go
+++ b/pkg/util/cgroup/common/types.go
@@ -254,10 +254,10 @@ type CgroupResources struct {
 
 type AbsoluteCgroupPathHandler struct {
 	Name    string
-	Handler func(subsys, podUID, containerId string) (string, error)
+	Handler func(subsys, podUID, containerId string) (string, bool, error)
 }
 
 type RelativeCgroupPathHandler struct {
 	Name    string
-	Handler func(podUID, containerId string) (string, error)
+	Handler func(podUID, containerId string) (string, bool, error)
 }


### PR DESCRIPTION
## Summary
- add skip semantics to absolute/relative cgroup path handlers
- skip non-kata runtime containers in the kata handler
- adapt default/kata handlers and affected tests

## Verification
- GO111MODULE=on GOTOOLCHAIN=local GOOS=linux GOARCH=amd64 GOFLAGS=-tags=SKIPCGO go test -c ./pkg/util/cgroup/common
- Previous CI on kubewharf/katalyst-core#1228 passed: Format, Vet, Lint, Build, Parallel, Unit Test, License, CodeQL, CodeRabbit, Codecov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Added skip semantics to absolute and relative cgroup path handlers.
- Skipped handlers now allow later handlers to resolve the path.
- Resolution returns an error when all handlers skip.
- Updated `kata.go` to skip non-Kata runtime containers without returning an error.
- Updated handler contracts, default and Kata handlers, and related tests.
- No configuration, dependency, or agent, controller, scheduler, or release wiring changes.
- Operational risk is limited to cgroup path resolution. Verification includes Linux amd64 compilation with `SKIPCGO`; prior CI checks also passed.

### 简体中文

- 为绝对和相对 cgroup 路径处理器增加 skip 语义。
- 当处理器跳过时，路径解析会继续使用后续处理器。
- 当所有处理器都跳过时，路径解析会返回错误。
- 更新 `kata.go`，使非 Kata runtime 容器跳过处理且不返回错误。
- 更新处理器契约、默认处理器、Kata 处理器及相关测试。
- 未修改配置、依赖或 agent、controller、scheduler、release wiring。
- 运行风险仅涉及 cgroup 路径解析。已使用 `SKIPCGO` 完成 Linux amd64 编译验证，之前的 CI 检查也已通过。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->