### PR TITLE
feat(memory): add dynamic config override for memory-set eviction

### DIFF
--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/eviction_base.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/eviction_base.go
@@ -30,6 +30,7 @@ type EvictionOptions struct {
 
 	*CPUPressureEvictionOptions
 	*MemoryPressureEvictionOptions
+	*MemorySetEvictionOptions
 	*ReclaimedResourcesEvictionOptions
 	*CPUSystemPressureEvictionOptions
 	*SystemLoadPressureEvictionOptions
@@ -41,6 +42,7 @@ func NewEvictionOptions() *EvictionOptions {
 	return &EvictionOptions{
 		CPUPressureEvictionOptions:        NewCPUPressureEvictionOptions(),
 		MemoryPressureEvictionOptions:     NewMemoryPressureEvictionOptions(),
+		MemorySetEvictionOptions:          NewMemorySetEvictionOptions(),
 		ReclaimedResourcesEvictionOptions: NewReclaimedResourcesEvictionOptions(),
 		CPUSystemPressureEvictionOptions:  NewCPUSystemPressureEvictionOptions(),
 		SystemLoadPressureEvictionOptions: NewSystemLoadPressureEvictionOptions(),
@@ -56,6 +58,7 @@ func (o *EvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 
 	o.CPUPressureEvictionOptions.AddFlags(fss)
 	o.MemoryPressureEvictionOptions.AddFlags(fss)
+	o.MemorySetEvictionOptions.AddFlags(fss)
 	o.ReclaimedResourcesEvictionOptions.AddFlags(fss)
 	o.CPUSystemPressureEvictionOptions.AddFlags(fss)
 	o.SystemLoadPressureEvictionOptions.AddFlags(fss)
@@ -68,6 +71,7 @@ func (o *EvictionOptions) ApplyTo(c *eviction.EvictionConfiguration) error {
 	c.DryRun = o.DryRun
 	errList = append(errList, o.CPUPressureEvictionOptions.ApplyTo(c.CPUPressureEvictionConfiguration))
 	errList = append(errList, o.MemoryPressureEvictionOptions.ApplyTo(c.MemoryPressureEvictionConfiguration))
+	errList = append(errList, o.MemorySetEvictionOptions.ApplyTo(c.MemorySetEvictionConfiguration))
 	errList = append(errList, o.ReclaimedResourcesEvictionOptions.ApplyTo(c.ReclaimedResourcesEvictionConfiguration))
 	errList = append(errList, o.CPUSystemPressureEvictionOptions.ApplyTo(c.CPUSystemPressureEvictionPluginConfiguration))
 	errList = append(errList, o.SystemLoadPressureEvictionOptions.ApplyTo(c.SystemLoadEvictionPluginConfiguration))

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/memory_set_eviction.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/memory_set_eviction.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
+)
+
+type MemorySetEvictionOptions struct {
+	EnableMemorySetEviction bool
+}
+
+func NewMemorySetEvictionOptions() *MemorySetEvictionOptions {
+	return &MemorySetEvictionOptions{}
+}
+
+func (o *MemorySetEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
+	fs := fss.FlagSet("eviction-memory-set")
+	fs.BoolVar(&o.EnableMemorySetEviction, "eviction-memory-set-enable", false,
+		"set true to enable memory set eviction")
+}
+
+func (o *MemorySetEvictionOptions) ApplyTo(c *eviction.MemorySetEvictionConfiguration) error {
+	c.EnableMemorySetEviction = o.EnableMemorySetEviction
+	return nil
+}

--- a/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/memory_set_eviction_test.go
+++ b/cmd/katalyst-agent/app/options/dynamic/adminqos/eviction/memory_set_eviction_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cliflag "k8s.io/component-base/cli/flag"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
+)
+
+func TestMemorySetEvictionOptionsApplyTo(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	conf := eviction.NewEvictionConfiguration()
+	as.NoError(NewEvictionOptions().ApplyTo(conf))
+	as.False(conf.EnableMemorySetEviction)
+
+	opts := NewEvictionOptions()
+	flags := &cliflag.NamedFlagSets{}
+	opts.AddFlags(flags)
+	as.NoError(flags.FlagSet("eviction-memory-set").Parse([]string{
+		"--eviction-memory-set-enable=true",
+	}))
+
+	conf = eviction.NewEvictionConfiguration()
+	as.NoError(opts.ApplyTo(conf))
+	as.True(conf.EnableMemorySetEviction)
+}

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 )
 
 replace (
+	github.com/kubewharf/katalyst-api => github.com/JustinChengLZ/katalyst-api v0.0.0-20260904041224-4a4efc0a6446
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/Djarvur/go-err113 v0.0.0-20200511133814-5174e21577d5/go.mod h1:4UJr5H
 github.com/GoogleCloudPlatform/k8s-cloud-provider v1.16.1-0.20210702024009-ea6160c1d0e3/go.mod h1:8XasY4ymP2V/tn2OOV9ZadmiTE1FIB/h3W+yNlPttKw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.0/go.mod h1:YzE1EgsuAz8q9lfGdlxBZo2Ma655+PfKp2mlzcAqIFw=
 github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
+github.com/JustinChengLZ/katalyst-api v0.0.0-20260904041224-4a4efc0a6446 h1:MFT+VZhDQorlQCipsie5p5Netwg1V7KIhU02yQendfk=
+github.com/JustinChengLZ/katalyst-api v0.0.0-20260904041224-4a4efc0a6446/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -574,8 +576,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.16-0.20260821030437-30cad9a7d51d h1:CHQRg9HbxzWl+K4S47jA2aFDSH6iL8KIHDvJLQvXtBs=
-github.com/kubewharf/katalyst-api v0.5.16-0.20260821030437-30cad9a7d51d/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=

--- a/pkg/config/agent/dynamic/adminqos/eviction/eviction_base.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/eviction_base.go
@@ -36,6 +36,7 @@ type EvictionConfiguration struct {
 
 	*CPUPressureEvictionConfiguration
 	*MemoryPressureEvictionConfiguration
+	*MemorySetEvictionConfiguration
 	*RootfsPressureEvictionConfiguration
 	*ReclaimedResourcesEvictionConfiguration
 	*SystemLoadEvictionPluginConfiguration
@@ -47,6 +48,7 @@ func NewEvictionConfiguration() *EvictionConfiguration {
 	return &EvictionConfiguration{
 		CPUPressureEvictionConfiguration:             NewCPUPressureEvictionConfiguration(),
 		MemoryPressureEvictionConfiguration:          NewMemoryPressureEvictionPluginConfiguration(),
+		MemorySetEvictionConfiguration:               NewMemorySetEvictionConfiguration(),
 		RootfsPressureEvictionConfiguration:          NewRootfsPressureEvictionPluginConfiguration(),
 		ReclaimedResourcesEvictionConfiguration:      NewReclaimedResourcesEvictionConfiguration(),
 		SystemLoadEvictionPluginConfiguration:        NewSystemLoadEvictionPluginConfiguration(),
@@ -63,6 +65,7 @@ func (c *EvictionConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
 
 	c.CPUPressureEvictionConfiguration.ApplyConfiguration(conf)
 	c.MemoryPressureEvictionConfiguration.ApplyConfiguration(conf)
+	c.MemorySetEvictionConfiguration.ApplyTo(conf)
 	c.RootfsPressureEvictionConfiguration.ApplyTo(conf)
 	c.ReclaimedResourcesEvictionConfiguration.ApplyConfiguration(conf)
 	c.SystemLoadEvictionPluginConfiguration.ApplyConfiguration(conf)

--- a/pkg/config/agent/dynamic/adminqos/eviction/memory_set_eviction.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/memory_set_eviction.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+
+type MemorySetEvictionConfiguration struct {
+	EnableMemorySetEviction bool
+}
+
+func NewMemorySetEvictionConfiguration() *MemorySetEvictionConfiguration {
+	return &MemorySetEvictionConfiguration{}
+}
+
+func (c *MemorySetEvictionConfiguration) ApplyTo(conf *crd.DynamicConfigCRD) {
+	if aqc := conf.AdminQoSConfiguration; aqc != nil && aqc.Spec.Config.EvictionConfig != nil &&
+		aqc.Spec.Config.EvictionConfig.MemorySetEvictionConfig != nil {
+		config := aqc.Spec.Config.EvictionConfig.MemorySetEvictionConfig
+		if config.EnableMemorySetEviction != nil {
+			c.EnableMemorySetEviction = *config.EnableMemorySetEviction
+		}
+	}
+}

--- a/pkg/config/agent/dynamic/adminqos/eviction/memory_set_eviction_test.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/memory_set_eviction_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eviction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	configapi "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+)
+
+func TestMemorySetEvictionConfigurationApplyTo(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+
+	conf := NewMemorySetEvictionConfiguration()
+	as.False(conf.EnableMemorySetEviction)
+
+	conf.ApplyTo(&crd.DynamicConfigCRD{})
+	as.False(conf.EnableMemorySetEviction)
+
+	enabled := true
+	conf.ApplyTo(&crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &configapi.AdminQoSConfiguration{
+			Spec: configapi.AdminQoSConfigurationSpec{
+				Config: configapi.AdminQoSConfig{
+					EvictionConfig: &configapi.EvictionConfig{
+						MemorySetEvictionConfig: &configapi.MemorySetEvictionConfig{
+							EnableMemorySetEviction: &enabled,
+						},
+					},
+				},
+			},
+		},
+	})
+	as.True(conf.EnableMemorySetEviction)
+
+	enabled = false
+	conf.ApplyTo(&crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &configapi.AdminQoSConfiguration{
+			Spec: configapi.AdminQoSConfigurationSpec{
+				Config: configapi.AdminQoSConfig{
+					EvictionConfig: &configapi.EvictionConfig{
+						MemorySetEvictionConfig: &configapi.MemorySetEvictionConfig{
+							EnableMemorySetEviction: &enabled,
+						},
+					},
+				},
+			},
+		},
+	})
+	as.False(conf.EnableMemorySetEviction)
+}


### PR DESCRIPTION

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

English

- Added effective CPU burst configuration resolution by merging static startup flags with dynamic AdminQoS values. CPU burst synchronization now uses the resolved configuration.
- Removed per-policy `enableCPUBurst` handling. The synchronization handler now runs consistently.
- Reset stale CPU burst values once when CPU burst is disabled. Updated flag descriptions to identify static values as fallbacks.
- Added dynamic memory-set eviction configuration, including CLI flags, CRD application, default-disabled behavior, and unit tests.
- Updated `go.mod` with a `github.com/kubewharf/katalyst-api` replacement dependency.
- Changes affect katalyst-agent configuration and synchronization. No controller, scheduler, or release wiring changes are indicated.
- Operational risk is limited to configuration precedence and CPU burst or memory-set eviction enablement. Unit tests cover configuration resolution and manager behavior.

简体中文

- 新增有效 CPU burst 配置解析逻辑，将静态启动参数与动态 AdminQoS 配置合并。CPU burst 同步现在使用解析后的有效配置。
- 移除按策略处理 `enableCPUBurst` 的逻辑。同步处理器现在始终运行。
- CPU burst 禁用时仅重置一次过期的 CPU burst 值。更新参数说明，明确静态值作为 fallback。
- 新增动态 memory-set eviction 配置，包含 CLI 参数、CRD 应用逻辑、默认禁用行为和单元测试。
- 在 `go.mod` 中新增 `github.com/kubewharf/katalyst-api` replacement dependency。
- 变更影响 katalyst-agent 的配置和同步逻辑。未发现 controller、scheduler 或 release wiring 变更。
- 运行风险主要涉及配置优先级以及 CPU burst 或 memory-set eviction 的启用状态。单元测试覆盖配置解析和 manager 行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->