### PR TITLE
gpu(qrm): add kubelet checkpoint fallback support

### DIFF
--- a/pkg/agent/qrm-plugins/gpu/baseplugin/base.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/base.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/agent"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/baseplugin/reporter"
@@ -46,6 +47,10 @@ type BasePlugin struct {
 	reporter reporter.GPUReporter
 	mu       sync.RWMutex
 	Conf     *config.Configuration
+
+	// kubeletCheckpointManager is used to sync checkpoint entries from kubelet to QRM.
+	// It makes sure that the state of both components are in sync.
+	kubeletCheckpointManager checkpointmanager.CheckpointManager
 
 	Emitter    metrics.MetricEmitter
 	MetaServer *metaserver.MetaServer
@@ -97,8 +102,14 @@ func NewBasePlugin(
 		stateInitializedCh: make(chan struct{}),
 	}
 
+	kubeletCheckpointManager, err := checkpointmanager.NewCheckpointManager(conf.KubeletDevicePluginPath)
+	if err != nil {
+		return nil, fmt.Errorf("new kubelet checkpoint manager failed: %w", err)
+	}
+	basePlugin.kubeletCheckpointManager = kubeletCheckpointManager
+
 	gpuReporter, err := reporter.NewGPUReporter(wrappedEmitter, agentCtx.MetaServer, conf, deviceTopologyRegistry, basePlugin.GetState,
-		basePlugin.deviceTypeToNames)
+		basePlugin.deviceTypeToNames, kubeletCheckpointManager)
 	if err != nil {
 		return nil, fmt.Errorf("newGPUReporterPlugin failed with error: %v", err)
 	}

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/base.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/base.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/metric"
 )
 
 const (
@@ -167,6 +168,13 @@ func (p *BasePlugin) InitState() error {
 		gpuconsts.GPUResourcePluginPolicyNameStatic, p.DefaultResourceStateGeneratorRegistry, p.Conf.SkipGPUStateCorruption, p.Emitter)
 	if err != nil {
 		return fmt.Errorf("NewCheckpointState failed with error: %v", err)
+	}
+	if err := p.hydrateKubeletGPUAllocations(stateImpl); err != nil {
+		if p.Emitter != nil {
+			_ = p.Emitter.StoreInt64(metricKubeletGPUHydrateFailed, 1, metrics.MetricTypeNameRaw,
+				metrics.MetricTag{Key: "error_message", Val: metric.MetricTagValueFormat(err)})
+		}
+		return fmt.Errorf("hydrate GPU state from kubelet checkpoint failed: %w", err)
 	}
 
 	p.mu.Lock()

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state.go
@@ -23,12 +23,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
 	gpuconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/consts"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/kubelet"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
+	qrmutil "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/util"
 	metaserverpod "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
@@ -53,50 +53,113 @@ func (p *BasePlugin) hydrateKubeletGPUAllocations(stateImpl state.State) error {
 		return nil
 	}
 
-	checkpointManager, err := checkpointmanager.NewCheckpointManager(p.Conf.KubeletDevicePluginPath)
+	allocations, err := p.readKubeletGPUAllocations()
 	if err != nil {
-		return fmt.Errorf("new kubelet checkpoint manager failed: %w", err)
-	}
-
-	// Read allocations from the kubelet device manager.
-	allocations, err := kubelet.ReadAllocations(checkpointManager, sets.NewString(p.Conf.GPUDeviceNames...))
-	if err != nil {
-		p.storeKubeletGPUInitMetric(metricKubeletGPUCheckpointReadFailed)
 		return err
 	}
 	if len(allocations) == 0 {
 		return nil
 	}
 
+	activePodMap, err := p.getActivePodMapForKubeletGPUHydration()
+	if err != nil {
+		general.Errorf("failed to get active pod list for kubelet GPU state hydration: %v", err)
+		return fmt.Errorf("failed to get active pod list for kubelet GPU state hydration: %w", err)
+	}
+
+	gpuState, gpuTopologies, err := p.getGPUStateAndTopologyForKubeletHydration(stateImpl)
+	if err != nil {
+		return err
+	}
+
+	podResourceEntries, podEntries := getGPUPodEntriesForKubeletHydration(stateImpl)
+	imported := p.collectKubeletGPUAllocations(allocations, activePodMap, podEntries, gpuState, gpuTopologies)
+	if applyKubeletGPUAllocations(podEntries, imported) == 0 {
+		return nil
+	}
+
+	return p.rebuildAndStoreGPUState(stateImpl, podResourceEntries, podEntries)
+}
+
+// readKubeletGPUAllocations reads GPU allocations from the kubelet device manager checkpoint.
+// It records the checkpoint-read failure metric when checkpoint parsing fails.
+func (p *BasePlugin) readKubeletGPUAllocations() ([]kubelet.Allocation, error) {
+	if p.kubeletCheckpointManager == nil {
+		p.storeKubeletGPUInitMetric(metricKubeletGPUCheckpointReadFailed)
+		return nil, fmt.Errorf("kubelet checkpoint manager is nil")
+	}
+
+	allocations, err := kubelet.ReadAllocations(p.kubeletCheckpointManager, sets.NewString(p.Conf.GPUDeviceNames...))
+	if err != nil {
+		p.storeKubeletGPUInitMetric(metricKubeletGPUCheckpointReadFailed)
+		return nil, err
+	}
+	return allocations, nil
+}
+
+// getActivePodMapForKubeletGPUHydration fetches active pods directly from metaserver.
+// It returns the pods keyed by UID so checkpoint allocations can be matched to live pods.
+func (p *BasePlugin) getActivePodMapForKubeletGPUHydration() (map[string]*v1.Pod, error) {
 	activePods, err := p.MetaServer.GetPodList(
 		context.WithValue(context.Background(), metaserverpod.BypassCacheKey, metaserverpod.BypassCacheTrue),
 		native.PodIsActive,
 	)
 	if err != nil {
-		general.Warningf("failed to get active pod list for kubelet GPU state hydration: %v", err)
-		return nil
+		return nil, err
 	}
-	activePodMap := native.GetPodKeyMap(activePods, func(obj metav1.Object) string {
+	return native.GetPodKeyMap(activePods, func(obj metav1.Object) string {
 		return string(obj.GetUID())
-	})
+	}), nil
+}
 
+// getGPUStateAndTopologyForKubeletHydration loads the current GPU resource state and each configured GPU topology.
+// These are used to validate checkpoint device IDs before importing them into Katalyst state.
+func (p *BasePlugin) getGPUStateAndTopologyForKubeletHydration(
+	stateImpl state.State,
+) (state.AllocationMap, map[string]*machine.DeviceTopology, error) {
 	machineState := stateImpl.GetMachineState()
 	gpuState, ok := machineState[v1.ResourceName(gpuconsts.GPUDeviceType)]
 	if !ok {
-		return fmt.Errorf("GPU device state %q is not initialized", gpuconsts.GPUDeviceType)
+		return nil, nil, fmt.Errorf("GPU device state %q is not initialized", gpuconsts.GPUDeviceType)
 	}
 
-	gpuTopology, _, err := p.DeviceTopologyRegistry.GetLatestDeviceTopology(p.Conf.GPUDeviceNames)
-	if err != nil {
-		return fmt.Errorf("get GPU topology for kubelet state hydration failed: %w", err)
+	gpuTopologies, ok := p.DeviceTopologyRegistry.GetDeviceTopologies(p.Conf.GPUDeviceNames)
+	if !ok {
+		return nil, nil, fmt.Errorf("get GPU topologies for kubelet state hydration failed")
 	}
+	return gpuState, gpuTopologies, nil
+}
 
-	// Convert kubelet allocations to be stored in katalyst GPU state.
+// getGPUPodEntriesForKubeletHydration returns cloned pod-resource entries and the GPU pod entries within them.
+// It initializes missing maps so callers can safely add imported kubelet allocations.
+func getGPUPodEntriesForKubeletHydration(stateImpl state.State) (state.PodResourceEntries, state.PodEntries) {
+	resourceName := v1.ResourceName(gpuconsts.GPUDeviceType)
+	podResourceEntries := stateImpl.GetPodResourceEntries()
+	if podResourceEntries == nil {
+		podResourceEntries = make(state.PodResourceEntries)
+	}
+	podEntries := podResourceEntries[resourceName]
+	if podEntries == nil {
+		podEntries = make(state.PodEntries)
+		podResourceEntries[resourceName] = podEntries
+	}
+	return podResourceEntries, podEntries
+}
+
+// collectKubeletGPUAllocations converts kubelet checkpoint allocations into GPU allocation infos.
+// It skips inactive pods, existing Katalyst allocations, duplicate devices, and devices missing from current state or topology.
+func (p *BasePlugin) collectKubeletGPUAllocations(
+	allocations []kubelet.Allocation,
+	activePodMap map[string]*v1.Pod,
+	podEntries state.PodEntries,
+	gpuState state.AllocationMap,
+	gpuTopologies map[string]*machine.DeviceTopology,
+) map[kubeletGPUAllocationKey]*state.AllocationInfo {
 	imported := make(map[kubeletGPUAllocationKey]*state.AllocationInfo)
 	for _, entry := range allocations {
 		key := kubeletGPUAllocationKey{podUID: entry.PodUID, containerName: entry.ContainerName}
 		// Do nothing if the allocation is already in the katalyst GPU state.
-		if stateImpl.GetAllocationInfo(v1.ResourceName(gpuconsts.GPUDeviceType), entry.PodUID, entry.ContainerName) != nil {
+		if podEntries.GetAllocationInfo(entry.PodUID, entry.ContainerName) != nil {
 			continue
 		}
 
@@ -109,12 +172,7 @@ func (p *BasePlugin) hydrateKubeletGPUAllocations(stateImpl state.State) error {
 		allocationInfo := imported[key]
 		if allocationInfo == nil {
 			allocationInfo = &state.AllocationInfo{
-				AllocationMeta: commonstate.AllocationMeta{
-					PodUid:        entry.PodUID,
-					PodNamespace:  pod.Namespace,
-					PodName:       pod.Name,
-					ContainerName: entry.ContainerName,
-				},
+				AllocationMeta:           p.generateKubeletGPUAllocationMeta(pod, entry.ContainerName),
 				DeviceName:               entry.ResourceName,
 				TopologyAwareAllocations: make(map[string]state.Allocation),
 			}
@@ -129,6 +187,12 @@ func (p *BasePlugin) hydrateKubeletGPUAllocations(stateImpl state.State) error {
 				general.Infof("GPU state does not contain device %s, skipping", deviceID)
 				continue
 			}
+			gpuTopology, ok := gpuTopologies[entry.ResourceName]
+			if !ok {
+				general.Infof("GPU topology does not exist for resource %s, skipping device %s",
+					entry.ResourceName, deviceID)
+				continue
+			}
 			device, exists := gpuTopology.Devices[deviceID]
 			if !exists {
 				general.Infof("GPU topology does not contain device %s, skipping", deviceID)
@@ -141,7 +205,15 @@ func (p *BasePlugin) hydrateKubeletGPUAllocations(stateImpl state.State) error {
 			allocationInfo.AllocatedAllocation.Quantity++
 		}
 	}
+	return imported
+}
 
+// applyKubeletGPUAllocations writes validated kubelet allocations into the cloned GPU pod entries.
+// It finalizes each allocation's aggregated NUMA nodes and returns the number of imported allocations.
+func applyKubeletGPUAllocations(
+	podEntries state.PodEntries,
+	imported map[kubeletGPUAllocationKey]*state.AllocationInfo,
+) int {
 	importedCount := 0
 	for key, allocationInfo := range imported {
 		if len(allocationInfo.TopologyAwareAllocations) == 0 {
@@ -152,33 +224,78 @@ func (p *BasePlugin) hydrateKubeletGPUAllocations(stateImpl state.State) error {
 			numaNodes.Add(allocation.NUMANodes...)
 		}
 		allocationInfo.AllocatedAllocation.NUMANodes = numaNodes.ToSliceInt()
-		stateImpl.SetAllocationInfo(
-			v1.ResourceName(gpuconsts.GPUDeviceType),
-			key.podUID,
-			key.containerName,
-			allocationInfo,
-			false,
-		)
+		podEntries.SetAllocationInfo(key.podUID, key.containerName, allocationInfo)
 
-		general.InfoS("Successfully imported allocation %s/%s", key.podUID, key.containerName)
+		general.Infof("Successfully imported allocation %s/%s", key.podUID, key.containerName)
 
 		importedCount++
 	}
-	if importedCount == 0 {
-		return nil
-	}
+	return importedCount
+}
 
-	// Rebuild and store state using the newly imported kubelet allocations.
-	podEntries := stateImpl.GetPodEntries(v1.ResourceName(gpuconsts.GPUDeviceType))
+// rebuildAndStoreGPUState rebuilds GPU resource state from updated pod entries and stores both state views.
+// It persists the checkpoint once after pod entries and resource state have been updated together.
+func (p *BasePlugin) rebuildAndStoreGPUState(
+	stateImpl state.State,
+	podResourceEntries state.PodResourceEntries,
+	podEntries state.PodEntries,
+) error {
 	rebuiltState, err := p.GenerateResourceStateFromPodEntries(gpuconsts.GPUDeviceType, podEntries)
 	if err != nil {
 		return fmt.Errorf("rebuild GPU state after kubelet hydration failed: %w", err)
 	}
+	stateImpl.SetPodResourceEntries(podResourceEntries, false)
 	stateImpl.SetResourceState(v1.ResourceName(gpuconsts.GPUDeviceType), rebuiltState, false)
 	if err := stateImpl.StoreState(); err != nil {
 		return fmt.Errorf("persist GPU state after kubelet hydration failed: %w", err)
 	}
+
+	general.Infof("Successfully restored GPU state after kubelet hydration")
 	return nil
+}
+
+// generateKubeletGPUAllocationMeta generates the important metadata for a kubelet GPU allocation.
+// This includes whitelisted pod annotations and labels and container types and container indexes.
+func (p *BasePlugin) generateKubeletGPUAllocationMeta(pod *v1.Pod, containerName string) commonstate.AllocationMeta {
+	qosLevel, err := p.Conf.QoSConfiguration.GetQoSLevelForPod(pod)
+	if err != nil {
+		general.Warningf("failed to get QoS level for pod %s/%s during kubelet GPU state hydration: %v",
+			pod.Namespace, pod.Name, err)
+	}
+
+	annotations, labels := qrmutil.FilterQoSRelatedLabelsAndAnnotations(
+		p.Conf.QoSConfiguration,
+		general.DeepCopyMap(pod.Annotations),
+		general.DeepCopyMap(pod.Labels),
+		qosLevel,
+		p.PodAnnotationKeptKeys,
+		p.PodLabelKeptKeys,
+	)
+
+	containerType := ""
+	var containerIndex uint64
+	resolvedContainerType, resolvedContainerIndex, err := qrmutil.GetContainerTypeAndIndex(
+		pod, containerName, p.Conf.MainContainerAnnotationKey,
+	)
+	if err != nil {
+		general.Warningf("failed to get container type and index for pod %s/%s container %s: %v",
+			pod.Namespace, pod.Name, containerName, err)
+	} else {
+		containerType = resolvedContainerType.String()
+		containerIndex = resolvedContainerIndex
+	}
+
+	return commonstate.AllocationMeta{
+		PodUid:         string(pod.UID),
+		PodNamespace:   pod.Namespace,
+		PodName:        pod.Name,
+		ContainerName:  containerName,
+		ContainerType:  containerType,
+		ContainerIndex: containerIndex,
+		Labels:         labels,
+		Annotations:    annotations,
+		QoSLevel:       qosLevel,
+	}
 }
 
 func (p *BasePlugin) storeKubeletGPUInitMetric(name string) {

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseplugin
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	gpuconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/consts"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/kubelet"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
+	metaserverpod "github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/general"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+const (
+	metricKubeletGPUCheckpointReadFailed = "qrm_gpu_init_kubelet_checkpoint_read_failed"
+	metricKubeletGPUHydrateFailed        = "qrm_gpu_init_kubelet_hydrate_failed"
+)
+
+type kubeletGPUAllocationKey struct {
+	podUID        string
+	containerName string
+}
+
+// hydrateKubeletGPUAllocations updates katalyst GPU state with allocations from the kubelet device manager.
+// Allocations that are present in both the kubelet device manager and the katalyst GPU state are deduplicated.
+func (p *BasePlugin) hydrateKubeletGPUAllocations(stateImpl state.State) error {
+	if !p.Conf.EnableKubeletCheckpointFallback || p.Conf.KubeletDevicePluginPath == "" {
+		return nil
+	}
+
+	checkpointManager, err := checkpointmanager.NewCheckpointManager(p.Conf.KubeletDevicePluginPath)
+	if err != nil {
+		return fmt.Errorf("new kubelet checkpoint manager failed: %w", err)
+	}
+
+	// Read allocations from the kubelet device manager.
+	allocations, err := kubelet.ReadAllocations(checkpointManager, sets.NewString(p.Conf.GPUDeviceNames...))
+	if err != nil {
+		p.storeKubeletGPUInitMetric(metricKubeletGPUCheckpointReadFailed)
+		return err
+	}
+	if len(allocations) == 0 {
+		return nil
+	}
+
+	activePods, err := p.MetaServer.GetPodList(
+		context.WithValue(context.Background(), metaserverpod.BypassCacheKey, metaserverpod.BypassCacheTrue),
+		native.PodIsActive,
+	)
+	if err != nil {
+		general.Warningf("failed to get active pod list for kubelet GPU state hydration: %v", err)
+		return nil
+	}
+	activePodMap := native.GetPodKeyMap(activePods, func(obj metav1.Object) string {
+		return string(obj.GetUID())
+	})
+
+	machineState := stateImpl.GetMachineState()
+	gpuState, ok := machineState[v1.ResourceName(gpuconsts.GPUDeviceType)]
+	if !ok {
+		return fmt.Errorf("GPU device state %q is not initialized", gpuconsts.GPUDeviceType)
+	}
+
+	gpuTopology, _, err := p.DeviceTopologyRegistry.GetLatestDeviceTopology(p.Conf.GPUDeviceNames)
+	if err != nil {
+		return fmt.Errorf("get GPU topology for kubelet state hydration failed: %w", err)
+	}
+
+	// Convert kubelet allocations to be stored in katalyst GPU state.
+	imported := make(map[kubeletGPUAllocationKey]*state.AllocationInfo)
+	for _, entry := range allocations {
+		key := kubeletGPUAllocationKey{podUID: entry.PodUID, containerName: entry.ContainerName}
+		// Do nothing if the allocation is already in the katalyst GPU state.
+		if stateImpl.GetAllocationInfo(v1.ResourceName(gpuconsts.GPUDeviceType), entry.PodUID, entry.ContainerName) != nil {
+			continue
+		}
+
+		pod, ok := activePodMap[entry.PodUID]
+		if !ok {
+			general.Infof("pod %s is inactive, skipping", entry.PodUID)
+			continue
+		}
+
+		allocationInfo := imported[key]
+		if allocationInfo == nil {
+			allocationInfo = &state.AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        entry.PodUID,
+					PodNamespace:  pod.Namespace,
+					PodName:       pod.Name,
+					ContainerName: entry.ContainerName,
+				},
+				DeviceName:               entry.ResourceName,
+				TopologyAwareAllocations: make(map[string]state.Allocation),
+			}
+			imported[key] = allocationInfo
+		}
+
+		for _, deviceID := range entry.DeviceIDs {
+			if _, exists := allocationInfo.TopologyAwareAllocations[deviceID]; exists {
+				continue
+			}
+			if _, exists := gpuState[deviceID]; !exists {
+				general.Infof("GPU state does not contain device %s, skipping", deviceID)
+				continue
+			}
+			device, exists := gpuTopology.Devices[deviceID]
+			if !exists {
+				general.Infof("GPU topology does not contain device %s, skipping", deviceID)
+				continue
+			}
+			allocationInfo.TopologyAwareAllocations[deviceID] = state.Allocation{
+				Quantity:  1,
+				NUMANodes: append([]int(nil), device.NumaNodes...),
+			}
+			allocationInfo.AllocatedAllocation.Quantity++
+		}
+	}
+
+	importedCount := 0
+	for key, allocationInfo := range imported {
+		if len(allocationInfo.TopologyAwareAllocations) == 0 {
+			continue
+		}
+		numaNodes := machine.NewCPUSet()
+		for _, allocation := range allocationInfo.TopologyAwareAllocations {
+			numaNodes.Add(allocation.NUMANodes...)
+		}
+		allocationInfo.AllocatedAllocation.NUMANodes = numaNodes.ToSliceInt()
+		stateImpl.SetAllocationInfo(
+			v1.ResourceName(gpuconsts.GPUDeviceType),
+			key.podUID,
+			key.containerName,
+			allocationInfo,
+			false,
+		)
+
+		general.InfoS("Successfully imported allocation %s/%s", key.podUID, key.containerName)
+
+		importedCount++
+	}
+	if importedCount == 0 {
+		return nil
+	}
+
+	// Rebuild and store state using the newly imported kubelet allocations.
+	podEntries := stateImpl.GetPodEntries(v1.ResourceName(gpuconsts.GPUDeviceType))
+	rebuiltState, err := p.GenerateResourceStateFromPodEntries(gpuconsts.GPUDeviceType, podEntries)
+	if err != nil {
+		return fmt.Errorf("rebuild GPU state after kubelet hydration failed: %w", err)
+	}
+	stateImpl.SetResourceState(v1.ResourceName(gpuconsts.GPUDeviceType), rebuiltState, false)
+	if err := stateImpl.StoreState(); err != nil {
+		return fmt.Errorf("persist GPU state after kubelet hydration failed: %w", err)
+	}
+	return nil
+}
+
+func (p *BasePlugin) storeKubeletGPUInitMetric(name string) {
+	if p.Emitter != nil {
+		_ = p.Emitter.StoreInt64(name, 1, metrics.MetricTypeNameCount)
+	}
+}

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseplugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
+
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
+	gpuconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/consts"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm/statedirectory"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	metaagent "github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
+	"github.com/kubewharf/katalyst-core/pkg/metrics"
+	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+type mockMetricEmitter struct {
+	metrics.DummyMetrics
+	storedInt64 map[string][]int64
+	storedTags  map[string][][]metrics.MetricTag
+}
+
+func newMockMetricEmitter() *mockMetricEmitter {
+	return &mockMetricEmitter{
+		storedInt64: make(map[string][]int64),
+		storedTags:  make(map[string][][]metrics.MetricTag),
+	}
+}
+
+func (m *mockMetricEmitter) StoreInt64(key string, val int64, _ metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	m.storedInt64[key] = append(m.storedInt64[key], val)
+	m.storedTags[key] = append(m.storedTags[key], tags)
+	return nil
+}
+
+func TestHydrateKubeletGPUAllocations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                            string
+		enableKubeletCheckpointFallback bool
+		existingState                   *state.AllocationInfo
+		wantImported                    bool
+	}{
+		{
+			name:                            "imports kubelet-only allocation",
+			enableKubeletCheckpointFallback: true,
+			wantImported:                    true,
+		},
+		{
+			name: "skips kubelet allocation when fallback is disabled",
+		},
+		{
+			name:                            "keeps existing QRM allocation",
+			enableKubeletCheckpointFallback: true,
+			existingState: &state.AllocationInfo{
+				AllocationMeta: commonstate.AllocationMeta{
+					PodUid:        "pod-uid",
+					PodNamespace:  "default",
+					PodName:       "pod",
+					ContainerName: "container",
+				},
+				TopologyAwareAllocations: map[string]state.Allocation{
+					"gpu-0": {Quantity: 1, NUMANodes: []int{0}},
+				},
+				AllocatedAllocation: state.Allocation{Quantity: 1, NUMANodes: []int{0}},
+			},
+			wantImported: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			conf := generateTestConfiguration(t)
+			conf.GPUDeviceNames = []string{"test-gpu"}
+			conf.EnableKubeletCheckpointFallback = tt.enableKubeletCheckpointFallback
+			base := &BasePlugin{
+				Conf:                                  conf,
+				Emitter:                               metrics.DummyMetrics{},
+				MetaServer:                            &metaserver.MetaServer{},
+				DeviceTopologyRegistry:                machine.NewDeviceTopologyRegistry(metrics.DummyMetrics{}),
+				DefaultResourceStateGeneratorRegistry: state.NewDefaultResourceStateGeneratorRegistry(),
+			}
+			base.MetaServer.MetaAgent = &metaagent.MetaAgent{
+				PodFetcher: &pod.PodFetcherStub{PodList: []*v1.Pod{{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "pod-uid", Namespace: "default", Name: "pod",
+					},
+				}}},
+			}
+			base.DeviceTopologyRegistry.RegisterDeviceTopologyProvider("test-gpu", machine.NewDeviceTopologyProvider())
+			require.NoError(t, base.DeviceTopologyRegistry.SetDeviceTopology("test-gpu", &machine.DeviceTopology{
+				Devices: map[string]machine.DeviceInfo{"gpu-0": {NumaNodes: []int{0}}},
+			}))
+			base.DefaultResourceStateGeneratorRegistry.RegisterResourceStateGenerator(
+				gpuconsts.GPUDeviceType,
+				state.NewGenericDefaultResourceStateGenerator(
+					conf.GPUDeviceNames, base.DeviceTopologyRegistry, 1, true,
+				),
+			)
+			stateImpl, err := state.NewGPUPluginState(conf.QRMPluginsConfiguration, base.DefaultResourceStateGeneratorRegistry)
+			require.NoError(t, err)
+			if tt.existingState != nil {
+				stateImpl.SetAllocationInfo(gpuconsts.GPUDeviceType, "pod-uid", "container", tt.existingState, false)
+			}
+
+			manager, err := checkpointmanager.NewCheckpointManager(conf.KubeletDevicePluginPath)
+			require.NoError(t, err)
+			require.NoError(t, manager.CreateCheckpoint(native.KubeletDeviceManagerCheckpoint, checkpoint.New(
+				[]checkpoint.PodDevicesEntry{{
+					PodUID: "pod-uid", ContainerName: "container", ResourceName: "test-gpu",
+					DeviceIDs: checkpoint.DevicesPerNUMA{0: {"gpu-0"}},
+				}}, nil,
+			)))
+
+			require.NoError(t, base.hydrateKubeletGPUAllocations(stateImpl))
+			allocation := stateImpl.GetAllocationInfo(gpuconsts.GPUDeviceType, "pod-uid", "container")
+			if tt.wantImported {
+				require.NotNil(t, allocation)
+				assert.Equal(t, "test-gpu", allocation.DeviceName)
+				assert.Equal(t, state.Allocation{Quantity: 1, NUMANodes: []int{0}},
+					allocation.TopologyAwareAllocations["gpu-0"])
+			} else if tt.existingState != nil {
+				assert.Equal(t, tt.existingState, allocation)
+			} else {
+				assert.Nil(t, allocation)
+			}
+		})
+	}
+}
+
+func TestBasePlugin_InitStateEmitsMetricWhenKubeletHydrationFails(t *testing.T) {
+	t.Parallel()
+
+	conf := generateTestConfiguration(t)
+	conf.EnableKubeletCheckpointFallback = true
+	conf.StateDirectoryConfiguration = &statedirectory.StateDirectoryConfiguration{
+		StateFileDirectory: t.TempDir(),
+	}
+	conf.KubeletDevicePluginPath = filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(conf.KubeletDevicePluginPath, []byte("file"), 0o644))
+
+	emitter := newMockMetricEmitter()
+	base := &BasePlugin{
+		Conf:                                  conf,
+		Emitter:                               emitter,
+		DefaultResourceStateGeneratorRegistry: state.NewDefaultResourceStateGeneratorRegistry(),
+	}
+
+	require.Error(t, base.InitState())
+	assert.Equal(t, []int64{1}, emitter.storedInt64[metricKubeletGPUHydrateFailed])
+	require.Len(t, emitter.storedTags[metricKubeletGPUHydrateFailed], 1)
+	assert.Equal(t, "error_message", emitter.storedTags[metricKubeletGPUHydrateFailed][0][0].Key)
+}

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/kubelet_state_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package baseplugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,9 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/commonstate"
 	gpuconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/consts"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
@@ -59,13 +62,47 @@ func (m *mockMetricEmitter) StoreInt64(key string, val int64, _ metrics.MetricTy
 	return nil
 }
 
+type trackingGPUState struct {
+	state.State
+
+	setAllocationInfoCalls    int
+	setPodResourceEntriesCall int
+	getAllocationInfoCalls    int
+}
+
+func (s *trackingGPUState) SetAllocationInfo(
+	resourceName v1.ResourceName, podUID, containerName string, allocationInfo *state.AllocationInfo, persist bool,
+) {
+	s.setAllocationInfoCalls++
+	s.State.SetAllocationInfo(resourceName, podUID, containerName, allocationInfo, persist)
+}
+
+func (s *trackingGPUState) SetPodResourceEntries(podResourceEntries state.PodResourceEntries, persist bool) {
+	s.setPodResourceEntriesCall++
+	s.State.SetPodResourceEntries(podResourceEntries, persist)
+}
+
+func (s *trackingGPUState) GetAllocationInfo(
+	resourceName v1.ResourceName, podUID, containerName string,
+) *state.AllocationInfo {
+	s.getAllocationInfoCalls++
+	return s.State.GetAllocationInfo(resourceName, podUID, containerName)
+}
+
 func TestHydrateKubeletGPUAllocations(t *testing.T) {
 	t.Parallel()
+
+	const (
+		keptLabelKey               = "kept-label"
+		mainContainerAnnotationKey = "main-container"
+	)
 
 	tests := []struct {
 		name                            string
 		enableKubeletCheckpointFallback bool
 		existingState                   *state.AllocationInfo
+		deviceNames                     []string
+		checkpointEntries               []checkpoint.PodDevicesEntry
 		wantImported                    bool
 	}{
 		{
@@ -93,6 +130,22 @@ func TestHydrateKubeletGPUAllocations(t *testing.T) {
 			},
 			wantImported: false,
 		},
+		{
+			name:                            "imports allocations from multiple resources",
+			enableKubeletCheckpointFallback: true,
+			deviceNames:                     []string{"test-gpu-0", "test-gpu-1"},
+			checkpointEntries: []checkpoint.PodDevicesEntry{
+				{
+					PodUID: "pod-uid", ContainerName: "container", ResourceName: "test-gpu-0",
+					DeviceIDs: checkpoint.DevicesPerNUMA{0: {"gpu-0"}},
+				},
+				{
+					PodUID: "pod-uid", ContainerName: "container", ResourceName: "test-gpu-1",
+					DeviceIDs: checkpoint.DevicesPerNUMA{1: {"gpu-1"}},
+				},
+			},
+			wantImported: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -101,26 +154,56 @@ func TestHydrateKubeletGPUAllocations(t *testing.T) {
 			t.Parallel()
 
 			conf := generateTestConfiguration(t)
-			conf.GPUDeviceNames = []string{"test-gpu"}
+			if len(tt.deviceNames) == 0 {
+				tt.deviceNames = []string{"test-gpu"}
+			}
+			conf.GPUDeviceNames = tt.deviceNames
 			conf.EnableKubeletCheckpointFallback = tt.enableKubeletCheckpointFallback
+			conf.PodLabelKeptKeys = []string{keptLabelKey}
+			conf.MainContainerAnnotationKey = mainContainerAnnotationKey
 			base := &BasePlugin{
 				Conf:                                  conf,
 				Emitter:                               metrics.DummyMetrics{},
 				MetaServer:                            &metaserver.MetaServer{},
 				DeviceTopologyRegistry:                machine.NewDeviceTopologyRegistry(metrics.DummyMetrics{}),
 				DefaultResourceStateGeneratorRegistry: state.NewDefaultResourceStateGeneratorRegistry(),
+				PodAnnotationKeptKeys:                 conf.PodAnnotationKeptKeys,
+				PodLabelKeptKeys:                      conf.PodLabelKeptKeys,
 			}
 			base.MetaServer.MetaAgent = &metaagent.MetaAgent{
 				PodFetcher: &pod.PodFetcherStub{PodList: []*v1.Pod{{
 					ObjectMeta: metav1.ObjectMeta{
-						UID: "pod-uid", Namespace: "default", Name: "pod",
+						UID:       "pod-uid",
+						Namespace: "default",
+						Name:      "pod",
+						Annotations: map[string]string{
+							apiconsts.PodAnnotationQoSLevelKey:           apiconsts.PodAnnotationQoSLevelSharedCores,
+							apiconsts.PodAnnotationAggregatedRequestsKey: "kept-annotation-value",
+							mainContainerAnnotationKey:                   "container",
+							"ignored-annotation":                         "ignored",
+						},
+						Labels: map[string]string{
+							apiconsts.PodAnnotationQoSLevelKey: apiconsts.PodAnnotationQoSLevelSharedCores,
+							keptLabelKey:                       "kept-label-value",
+							"ignored-label":                    "ignored",
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Name: "sidecar"},
+							{Name: "container"},
+						},
 					},
 				}}},
 			}
-			base.DeviceTopologyRegistry.RegisterDeviceTopologyProvider("test-gpu", machine.NewDeviceTopologyProvider())
-			require.NoError(t, base.DeviceTopologyRegistry.SetDeviceTopology("test-gpu", &machine.DeviceTopology{
-				Devices: map[string]machine.DeviceInfo{"gpu-0": {NumaNodes: []int{0}}},
-			}))
+			for index, deviceName := range conf.GPUDeviceNames {
+				base.DeviceTopologyRegistry.RegisterDeviceTopologyProvider(deviceName, machine.NewDeviceTopologyProvider())
+				require.NoError(t, base.DeviceTopologyRegistry.SetDeviceTopology(deviceName, &machine.DeviceTopology{
+					Devices: map[string]machine.DeviceInfo{
+						fmt.Sprintf("gpu-%d", index): {NumaNodes: []int{index}},
+					},
+				}))
+			}
 			base.DefaultResourceStateGeneratorRegistry.RegisterResourceStateGenerator(
 				gpuconsts.GPUDeviceType,
 				state.NewGenericDefaultResourceStateGenerator(
@@ -129,26 +212,65 @@ func TestHydrateKubeletGPUAllocations(t *testing.T) {
 			)
 			stateImpl, err := state.NewGPUPluginState(conf.QRMPluginsConfiguration, base.DefaultResourceStateGeneratorRegistry)
 			require.NoError(t, err)
+			if len(conf.GPUDeviceNames) > 1 {
+				stateImpl.SetResourceState(gpuconsts.GPUDeviceType, state.AllocationMap{
+					"gpu-0": {Allocatable: 1},
+					"gpu-1": {Allocatable: 1},
+				}, false)
+			}
 			if tt.existingState != nil {
 				stateImpl.SetAllocationInfo(gpuconsts.GPUDeviceType, "pod-uid", "container", tt.existingState, false)
 			}
+			trackingState := &trackingGPUState{State: stateImpl}
 
 			manager, err := checkpointmanager.NewCheckpointManager(conf.KubeletDevicePluginPath)
 			require.NoError(t, err)
-			require.NoError(t, manager.CreateCheckpoint(native.KubeletDeviceManagerCheckpoint, checkpoint.New(
-				[]checkpoint.PodDevicesEntry{{
+			base.kubeletCheckpointManager = manager
+			checkpointEntries := tt.checkpointEntries
+			if len(checkpointEntries) == 0 {
+				checkpointEntries = []checkpoint.PodDevicesEntry{{
 					PodUID: "pod-uid", ContainerName: "container", ResourceName: "test-gpu",
 					DeviceIDs: checkpoint.DevicesPerNUMA{0: {"gpu-0"}},
-				}}, nil,
+				}}
+			}
+			require.NoError(t, manager.CreateCheckpoint(native.KubeletDeviceManagerCheckpoint, checkpoint.New(
+				checkpointEntries, nil,
 			)))
 
-			require.NoError(t, base.hydrateKubeletGPUAllocations(stateImpl))
+			require.NoError(t, base.hydrateKubeletGPUAllocations(trackingState))
 			allocation := stateImpl.GetAllocationInfo(gpuconsts.GPUDeviceType, "pod-uid", "container")
+			assert.Zero(t, trackingState.getAllocationInfoCalls)
 			if tt.wantImported {
 				require.NotNil(t, allocation)
-				assert.Equal(t, "test-gpu", allocation.DeviceName)
+				if len(tt.deviceNames) == 1 {
+					assert.Equal(t, "test-gpu", allocation.DeviceName)
+				}
 				assert.Equal(t, state.Allocation{Quantity: 1, NUMANodes: []int{0}},
 					allocation.TopologyAwareAllocations["gpu-0"])
+				if len(tt.deviceNames) > 1 {
+					assert.Equal(t, state.Allocation{Quantity: 1, NUMANodes: []int{1}},
+						allocation.TopologyAwareAllocations["gpu-1"])
+					assert.Equal(t, float64(2), allocation.AllocatedAllocation.Quantity)
+				}
+				assert.Equal(t, commonstate.AllocationMeta{
+					PodUid:         "pod-uid",
+					PodNamespace:   "default",
+					PodName:        "pod",
+					ContainerName:  "container",
+					ContainerType:  pluginapi.ContainerType_MAIN.String(),
+					ContainerIndex: 1,
+					Annotations: map[string]string{
+						apiconsts.PodAnnotationQoSLevelKey:           apiconsts.PodAnnotationQoSLevelSharedCores,
+						apiconsts.PodAnnotationAggregatedRequestsKey: "kept-annotation-value",
+					},
+					Labels: map[string]string{
+						apiconsts.PodAnnotationQoSLevelKey: apiconsts.PodAnnotationQoSLevelSharedCores,
+						keptLabelKey:                       "kept-label-value",
+					},
+					QoSLevel: apiconsts.PodAnnotationQoSLevelSharedCores,
+				}, allocation.AllocationMeta)
+				assert.Zero(t, trackingState.setAllocationInfoCalls)
+				assert.Equal(t, 1, trackingState.setPodResourceEntriesCall)
 			} else if tt.existingState != nil {
 				assert.Equal(t, tt.existingState, allocation)
 			} else {
@@ -156,6 +278,22 @@ func TestHydrateKubeletGPUAllocations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReadKubeletGPUAllocationsWithoutCheckpointManager(t *testing.T) {
+	t.Parallel()
+
+	emitter := newMockMetricEmitter()
+	base := &BasePlugin{
+		Conf:    generateTestConfiguration(t),
+		Emitter: emitter,
+	}
+
+	allocations, err := base.readKubeletGPUAllocations()
+
+	assert.Nil(t, allocations)
+	require.ErrorContains(t, err, "kubelet checkpoint manager is nil")
+	assert.Equal(t, []int64{1}, emitter.storedInt64[metricKubeletGPUCheckpointReadFailed])
 }
 
 func TestBasePlugin_InitStateEmitsMetricWhenKubeletHydrationFails(t *testing.T) {

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -25,19 +25,18 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
-	cpmerrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 
 	nodev1alpha1 "github.com/kubewharf/katalyst-api/pkg/apis/node/v1alpha1"
 	"github.com/kubewharf/katalyst-api/pkg/plugins/registration"
 	"github.com/kubewharf/katalyst-api/pkg/plugins/skeleton"
 	"github.com/kubewharf/katalyst-api/pkg/protocol/reporterplugin/v1alpha1"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/kubelet"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/gpu/state"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	pkgconsts "github.com/kubewharf/katalyst-core/pkg/consts"
@@ -612,21 +611,13 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 		return fmt.Errorf("kubelet checkpoint manager is nil")
 	}
 
-	checkpointData, err := native.GetKubeletCheckpoint(p.checkpointManager)
+	kubeletAllocations, err := kubelet.ReadAllocations(p.checkpointManager, sets.NewString(p.gpuDeviceNames...))
 	if err != nil {
-		if errors.Is(err, cpmerrors.ErrCheckpointNotFound) {
-			general.Infof("kubelet checkpoint not found, skip")
-			return nil
-		}
-		return fmt.Errorf("failed to get kubelet checkpoint: %v", err)
+		return err
 	}
-
-	podDeviceEntries, _ := checkpointData.GetDataInLatestFormat()
-	if len(podDeviceEntries) == 0 {
+	if len(kubeletAllocations) == 0 {
 		return nil
 	}
-
-	validDeviceNames := sets.NewString(p.gpuDeviceNames...)
 
 	activePods, err := p.metaServer.GetPodList(context.WithValue(p.ctx, metaserverpod.BypassCacheKey, metaserverpod.BypassCacheTrue), native.PodIsActive)
 	if err != nil {
@@ -639,13 +630,7 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 		return string(obj.GetUID())
 	})
 
-	for _, entry := range podDeviceEntries {
-		// Check if the reported resource is a valid GPU device name.
-		// If not in gpuDeviceNames, skip it to avoid reporting invalid devices.
-		if !validDeviceNames.Has(entry.ResourceName) {
-			continue
-		}
-
+	for _, entry := range kubeletAllocations {
 		resourceName := v1.ResourceName(entry.ResourceName)
 
 		pod, ok := activePodMap[entry.PodUID]
@@ -657,30 +642,27 @@ func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[
 		// Generate consumer key using namespace, name and podUID
 		consumer := native.GenerateNamespaceNameUIDKey(pod.Namespace, pod.Name, entry.PodUID)
 
-		// Iterate through all devices per NUMA node
-		for numaNode, deviceIDs := range entry.DeviceIDs {
-			for _, deviceID := range deviceIDs {
-				if _, ok := idToAllocations[deviceID]; !ok {
-					idToAllocations[deviceID] = make(util.ZoneAllocations, 0)
-				}
-
-				// Check if there's already an allocation for this pod UID
-				if hasExistingPodAllocation(idToAllocations[deviceID], entry.PodUID) {
-					continue
-				}
-
-				// Create resource list - quantity is 1 since each device entry represents one device
-				gpuResourceList := make(v1.ResourceList)
-				gpuResourceList[resourceName] = *resource.NewQuantity(1, resource.DecimalSI)
-
-				idToAllocations[deviceID] = append(idToAllocations[deviceID], &nodev1alpha1.Allocation{
-					Consumer: consumer,
-					Requests: &gpuResourceList,
-				})
-
-				general.Infof("added allocation from checkpoint: consumer=%s, container=%s, device=%s, numa=%d",
-					consumer, entry.ContainerName, deviceID, numaNode)
+		for _, deviceID := range entry.DeviceIDs {
+			if _, ok := idToAllocations[deviceID]; !ok {
+				idToAllocations[deviceID] = make(util.ZoneAllocations, 0)
 			}
+
+			// Check if there's already an allocation for this pod UID
+			if hasExistingPodAllocation(idToAllocations[deviceID], entry.PodUID) {
+				continue
+			}
+
+			// Create resource list - quantity is 1 since each device entry represents one device
+			gpuResourceList := make(v1.ResourceList)
+			gpuResourceList[resourceName] = *resource.NewQuantity(1, resource.DecimalSI)
+
+			idToAllocations[deviceID] = append(idToAllocations[deviceID], &nodev1alpha1.Allocation{
+				Consumer: consumer,
+				Requests: &gpuResourceList,
+			})
+
+			general.Infof("added allocation from checkpoint: consumer=%s, container=%s, device=%s",
+				consumer, entry.ContainerName, deviceID)
 		}
 	}
 

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter.go
@@ -79,8 +79,10 @@ var _ GPUReporter = (*gpuReporterImpl)(nil)
 
 func NewGPUReporter(emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer,
 	conf *config.Configuration, topologyRegistry *machine.DeviceTopologyRegistry, stateGetter func() state.State, deviceTypeToNames map[string]sets.String,
+	kubeletCheckpointManager checkpointmanager.CheckpointManager,
 ) (GPUReporter, error) {
-	plugin, reporter, err := newGPUReporterPlugin(emitter, metaServer, conf, topologyRegistry, stateGetter, deviceTypeToNames)
+	plugin, reporter, err := newGPUReporterPlugin(emitter, metaServer, conf, topologyRegistry, stateGetter, deviceTypeToNames,
+		kubeletCheckpointManager)
 	if err != nil {
 		return nil, fmt.Errorf("create reporter failed: %v", err)
 	}
@@ -126,7 +128,7 @@ type gpuReporterPlugin struct {
 	reportNotifyCh                  chan struct{}
 	reportRetryInterval             time.Duration
 	lastReportContent               *v1alpha1.GetReportContentResponse
-	checkpointManager               checkpointmanager.CheckpointManager
+	kubeletCheckpointManager        checkpointmanager.CheckpointManager
 	kubeletDevicePluginPath         string
 	enableKubeletCheckpointFallback bool
 }
@@ -138,12 +140,8 @@ var (
 
 func newGPUReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer,
 	conf *config.Configuration, topologyRegistry *machine.DeviceTopologyRegistry, stateGetter func() state.State, deviceTypeToNames map[string]sets.String,
+	kubeletCheckpointManager checkpointmanager.CheckpointManager,
 ) (skeleton.GenericPlugin, *gpuReporterPlugin, error) {
-	checkpointManager, err := checkpointmanager.NewCheckpointManager(conf.KubeletDevicePluginPath)
-	if err != nil {
-		return nil, nil, fmt.Errorf("new checkpoint manager failed: %v", err)
-	}
-
 	reporter := &gpuReporterPlugin{
 		gpuDeviceNames:                  conf.GPUDeviceNames,
 		rdmaDeviceNames:                 conf.RDMADeviceNames,
@@ -155,7 +153,7 @@ func newGPUReporterPlugin(emitter metrics.MetricEmitter, metaServer *metaserver.
 		reportNotifyCh:                  make(chan struct{}, 1),
 		reportRetryInterval:             defaultReportRetryInterval,
 		metaServer:                      metaServer,
-		checkpointManager:               checkpointManager,
+		kubeletCheckpointManager:        kubeletCheckpointManager,
 		kubeletDevicePluginPath:         conf.KubeletDevicePluginPath,
 		enableKubeletCheckpointFallback: conf.EnableKubeletCheckpointFallback,
 	}
@@ -607,11 +605,11 @@ func (p *gpuReporterPlugin) addStateAllocations(topologiesMap map[string]*machin
 // into the target idToAllocations map. This prevents reporting inconsistencies where a device is already
 // allocated to a pod by kubelet, but the local QRM state has not yet fully synced or recorded the allocation.
 func (p *gpuReporterPlugin) addKubeletCheckpointAllocations(idToAllocations map[string]util.ZoneAllocations) error {
-	if p.checkpointManager == nil {
+	if p.kubeletCheckpointManager == nil {
 		return fmt.Errorf("kubelet checkpoint manager is nil")
 	}
 
-	kubeletAllocations, err := kubelet.ReadAllocations(p.checkpointManager, sets.NewString(p.gpuDeviceNames...))
+	kubeletAllocations, err := kubelet.ReadAllocations(p.kubeletCheckpointManager, sets.NewString(p.gpuDeviceNames...))
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
+++ b/pkg/agent/qrm-plugins/gpu/baseplugin/reporter/reporter_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1920,7 +1921,10 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			deviceTypeToNames := map[string]sets.String{string(resourceTypeName): sets.NewString(gpuDeviceNames...)}
 
 			stateGetter := func() state.State { return testState }
-			reporter, err := NewGPUReporter(metrics.DummyMetrics{}, generateTestMetaServer(tt.machineTopology), testConfig, topologyRegistry, stateGetter, deviceTypeToNames)
+			kubeletCheckpointManager, err := checkpointmanager.NewCheckpointManager(testConfig.KubeletDevicePluginPath)
+			require.NoError(t, err)
+			reporter, err := NewGPUReporter(metrics.DummyMetrics{}, generateTestMetaServer(tt.machineTopology), testConfig,
+				topologyRegistry, stateGetter, deviceTypeToNames, kubeletCheckpointManager)
 			assert.NoError(t, err)
 			reporterImpl, ok := reporter.(*gpuReporterImpl)
 			assert.True(t, ok)
@@ -1928,7 +1932,7 @@ func TestGpuReporterPlugin_GetReportContent(t *testing.T) {
 			assert.True(t, ok)
 			reporterPlugin, ok := pluginWrapper.GenericPlugin.(*gpuReporterPlugin)
 			assert.True(t, ok)
-			reporterPlugin.checkpointManager = &mockCheckpointManager{}
+			reporterPlugin.kubeletCheckpointManager = &mockCheckpointManager{}
 
 			reportContent, err := reporterPlugin.GetReportContent(context.Background(), nil)
 
@@ -2006,12 +2010,15 @@ func TestListAndWatchReportContent(t *testing.T) {
 		},
 	})
 
-	reporter, err := NewGPUReporter(metrics.DummyMetrics{}, metaServer, testConfig, topologyRegistry, stateGetter, deviceTypeToNames)
+	kubeletCheckpointManager, err := checkpointmanager.NewCheckpointManager(testConfig.KubeletDevicePluginPath)
+	require.NoError(t, err)
+	reporter, err := NewGPUReporter(metrics.DummyMetrics{}, metaServer, testConfig, topologyRegistry, stateGetter,
+		deviceTypeToNames, kubeletCheckpointManager)
 	assert.NoError(t, err)
 	reporterImpl := reporter.(*gpuReporterImpl)
 	pluginWrapper := reporterImpl.GenericPlugin.(*skeleton.PluginRegistrationWrapper)
 	reporterPlugin := pluginWrapper.GenericPlugin.(*gpuReporterPlugin)
-	reporterPlugin.checkpointManager = &mockCheckpointManager{}
+	reporterPlugin.kubeletCheckpointManager = &mockCheckpointManager{}
 	reporterPlugin.reportRetryInterval = 10 * time.Millisecond // Set a small interval for faster tests
 
 	_ = reporterPlugin.Start()
@@ -2113,12 +2120,15 @@ func TestListAndWatchReportContentRetry(t *testing.T) {
 		},
 	})
 
-	reporter, err := NewGPUReporter(metrics.DummyMetrics{}, metaServer, testConfig, topologyRegistry, stateGetter, deviceTypeToNames)
+	kubeletCheckpointManager, err := checkpointmanager.NewCheckpointManager(testConfig.KubeletDevicePluginPath)
+	require.NoError(t, err)
+	reporter, err := NewGPUReporter(metrics.DummyMetrics{}, metaServer, testConfig, topologyRegistry, stateGetter,
+		deviceTypeToNames, kubeletCheckpointManager)
 	assert.NoError(t, err)
 	reporterImpl := reporter.(*gpuReporterImpl)
 	pluginWrapper := reporterImpl.GenericPlugin.(*skeleton.PluginRegistrationWrapper)
 	reporterPlugin := pluginWrapper.GenericPlugin.(*gpuReporterPlugin)
-	reporterPlugin.checkpointManager = &mockCheckpointManager{}
+	reporterPlugin.kubeletCheckpointManager = &mockCheckpointManager{}
 	reporterPlugin.reportRetryInterval = 50 * time.Millisecond
 
 	_ = reporterPlugin.Start()
@@ -2451,7 +2461,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 		{
 			name: "get checkpoint fails",
 			p: &gpuReporterPlugin{
-				checkpointManager: &mockCheckpointManager{
+				kubeletCheckpointManager: &mockCheckpointManager{
 					getErr: fmt.Errorf("mock get error"),
 				},
 			},
@@ -2461,7 +2471,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 		{
 			name: "get checkpoint returns not found",
 			p: &gpuReporterPlugin{
-				checkpointManager: &mockCheckpointManager{
+				kubeletCheckpointManager: &mockCheckpointManager{
 					getErr: cpmerrors.ErrCheckpointNotFound,
 				},
 			},
@@ -2473,7 +2483,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 			p: &gpuReporterPlugin{
 				ctx:            context.TODO(),
 				gpuDeviceNames: []string{"test-resource"},
-				checkpointManager: &mockCheckpointManager{
+				kubeletCheckpointManager: &mockCheckpointManager{
 					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{
 						{
 							PodUID:        "test-pod-uid",
@@ -2513,7 +2523,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 			p: &gpuReporterPlugin{
 				ctx:            context.TODO(),
 				gpuDeviceNames: []string{"test-resource-other"},
-				checkpointManager: &mockCheckpointManager{
+				kubeletCheckpointManager: &mockCheckpointManager{
 					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{
 						{
 							PodUID:        "test-pod-uid",
@@ -2542,7 +2552,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 			p: &gpuReporterPlugin{
 				ctx:            context.TODO(),
 				gpuDeviceNames: []string{"test-resource"},
-				checkpointManager: &mockCheckpointManager{
+				kubeletCheckpointManager: &mockCheckpointManager{
 					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{
 						{
 							PodUID:        "test-pod-uid",
@@ -2582,7 +2592,7 @@ func TestAddKubeletCheckpointAllocations(t *testing.T) {
 			p: &gpuReporterPlugin{
 				ctx:            context.TODO(),
 				gpuDeviceNames: []string{"test-resource"},
-				checkpointManager: &mockCheckpointManager{
+				kubeletCheckpointManager: &mockCheckpointManager{
 					checkpointData: checkpoint.New([]checkpoint.PodDevicesEntry{
 						{
 							PodUID:        "test-pod-uid",
@@ -2807,7 +2817,7 @@ func TestGpuReporterPlugin_GetZoneAllocations_KubeletCheckpointFailureEmitsMetri
 		emitter:                         emitter,
 		gpuDeviceNames:                  []string{"test-resource"},
 		enableKubeletCheckpointFallback: true,
-		checkpointManager: &mockCheckpointManager{
+		kubeletCheckpointManager: &mockCheckpointManager{
 			getErr: checkpointErr,
 		},
 	}
@@ -2840,7 +2850,7 @@ func TestGpuReporterPlugin_GetZoneAllocations_KubeletCheckpointFailureNilEmitter
 		emitter:                         nil,
 		gpuDeviceNames:                  []string{"test-resource"},
 		enableKubeletCheckpointFallback: true,
-		checkpointManager: &mockCheckpointManager{
+		kubeletCheckpointManager: &mockCheckpointManager{
 			getErr: fmt.Errorf("checkpoint failure"),
 		},
 	}

--- a/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
+++ b/pkg/agent/qrm-plugins/gpu/customdeviceplugin/gpu/gpu_test.go
@@ -22,10 +22,14 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
 	katalyst_base "github.com/kubewharf/katalyst-core/cmd/base"
@@ -40,8 +44,10 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent/qrm/statedirectory"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
+	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/pod"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
 )
 
 const (
@@ -181,6 +187,68 @@ func TestGPUDevicePlugin_UpdateAllocatableAssociatedDevices(t *testing.T) {
 	expectedDeviceTopology.UpdateTime = deviceTopology.UpdateTime
 
 	assert.Equal(t, expectedDeviceTopology, deviceTopology)
+}
+
+func TestGPUDevicePlugin_GetAssociatedDeviceTopologyHintsFromKubeletState(t *testing.T) {
+	t.Parallel()
+
+	conf := generateTestConfiguration(t)
+	conf.GPUDeviceNames = []string{"test-gpu"}
+	conf.EnableKubeletCheckpointFallback = true
+	conf.StateDirectoryConfiguration = &statedirectory.StateDirectoryConfiguration{
+		StateFileDirectory: t.TempDir(),
+	}
+	agentCtx := generateTestGenericContext(t, conf)
+	agentCtx.MetaServer.MetaAgent.PodFetcher = &pod.PodFetcherStub{PodList: []*v1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "pod-uid", Namespace: "default", Name: "pod",
+		},
+		Status: v1.PodStatus{Phase: v1.PodRunning},
+	}}}
+
+	basePlugin, err := baseplugin.NewBasePlugin(agentCtx, conf, metrics.DummyMetrics{})
+	require.NoError(t, err)
+	devicePlugin := NewGPUDevicePlugin(basePlugin).(*GPUDevicePlugin)
+	_, err = devicePlugin.UpdateAllocatableAssociatedDevices(context.Background(), &pluginapi.UpdateAllocatableAssociatedDevicesRequest{
+		DeviceName: "test-gpu",
+		Devices: []*pluginapi.AssociatedDevice{{
+			ID:       "gpu-0",
+			Topology: &pluginapi.TopologyInfo{Nodes: []*pluginapi.NUMANode{{ID: 0}}},
+		}},
+	})
+	require.NoError(t, err)
+
+	manager, err := checkpointmanager.NewCheckpointManager(conf.KubeletDevicePluginPath)
+	require.NoError(t, err)
+	require.NoError(t, manager.CreateCheckpoint(native.KubeletDeviceManagerCheckpoint, checkpoint.New(
+		[]checkpoint.PodDevicesEntry{{
+			PodUID:        "pod-uid",
+			ContainerName: "container",
+			ResourceName:  "test-gpu",
+			DeviceIDs:     checkpoint.DevicesPerNUMA{0: {"gpu-0"}},
+		}}, nil,
+	)))
+
+	require.NoError(t, basePlugin.InitState())
+	allocationInfo := basePlugin.GetState().GetAllocationInfo(gpuconsts.GPUDeviceType, "pod-uid", "container")
+	require.NotNil(t, allocationInfo)
+	assert.Contains(t, allocationInfo.TopologyAwareAllocations, "gpu-0")
+
+	resp, err := devicePlugin.GetAssociatedDeviceTopologyHints(context.Background(), &pluginapi.AssociatedDeviceRequest{
+		ResourceRequest: &pluginapi.ResourceRequest{
+			PodUid:        "pod-uid",
+			ContainerName: "container",
+			Annotations:   map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+			Labels:        map[string]string{consts.PodAnnotationQoSLevelKey: consts.PodAnnotationQoSLevelSharedCores},
+		},
+		DeviceName:    "test-gpu",
+		DeviceRequest: []*pluginapi.DeviceRequest{{DeviceName: "test-gpu", DeviceRequest: 1}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.DeviceHints)
+	require.Len(t, resp.DeviceHints.Hints, 1)
+	assert.Equal(t, []uint64{0}, resp.DeviceHints.Hints[0].Nodes)
+	assert.True(t, resp.DeviceHints.Hints[0].Preferred)
 }
 
 func TestGPUDevicePlugin_AllocateAssociatedDevice(t *testing.T) {

--- a/pkg/agent/qrm-plugins/gpu/kubelet/checkpoint.go
+++ b/pkg/agent/qrm-plugins/gpu/kubelet/checkpoint.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	cpmerrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+
+	"github.com/kubewharf/katalyst-core/pkg/util/native"
+)
+
+// Allocation represents a GPU allocation in the kubelet device manager.
+type Allocation struct {
+	PodUID        string
+	ContainerName string
+	ResourceName  string
+	DeviceIDs     []string
+}
+
+// ReadAllocations reads allocations from the kubelet device manager checkpoint file.
+// This is to make sure that we are aware of the existing allocations in the kubelet device manager.
+func ReadAllocations(
+	manager checkpointmanager.CheckpointManager,
+	gpuDeviceNames sets.String,
+) ([]Allocation, error) {
+	checkpointData, err := native.GetKubeletCheckpoint(manager)
+	if err != nil {
+		if errors.Is(err, cpmerrors.ErrCheckpointNotFound) {
+			return []Allocation{}, nil
+		}
+		return nil, fmt.Errorf("failed to get kubelet GPU checkpoint: %w", err)
+	}
+
+	entries, _ := checkpointData.GetDataInLatestFormat()
+	allocations := make([]Allocation, 0, len(entries))
+	for _, entry := range entries {
+		if !gpuDeviceNames.Has(entry.ResourceName) {
+			continue
+		}
+
+		deviceSet := sets.NewString()
+		for _, deviceIDs := range entry.DeviceIDs {
+			deviceSet.Insert(deviceIDs...)
+		}
+		allocations = append(allocations, Allocation{
+			PodUID:        entry.PodUID,
+			ContainerName: entry.ContainerName,
+			ResourceName:  entry.ResourceName,
+			DeviceIDs:     deviceSet.List(),
+		})
+	}
+
+	return allocations, nil
+}

--- a/pkg/agent/qrm-plugins/gpu/kubelet/checkpoint_test.go
+++ b/pkg/agent/qrm-plugins/gpu/kubelet/checkpoint_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
+	cpmerrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager/checkpoint"
+)
+
+type mockCheckpointManager struct {
+	checkpoint checkpoint.DeviceManagerCheckpoint
+	err        error
+}
+
+func (m *mockCheckpointManager) GetCheckpoint(_ string, cp checkpointmanager.Checkpoint) error {
+	if m.err != nil {
+		return m.err
+	}
+	if m.checkpoint != nil {
+		data, err := m.checkpoint.MarshalCheckpoint()
+		if err != nil {
+			return err
+		}
+		return cp.UnmarshalCheckpoint(data)
+	}
+	return nil
+}
+
+func (m *mockCheckpointManager) CreateCheckpoint(_ string, _ checkpointmanager.Checkpoint) error {
+	return nil
+}
+
+func (m *mockCheckpointManager) RemoveCheckpoint(_ string) error {
+	return nil
+}
+
+func (m *mockCheckpointManager) ListCheckpoints() ([]string, error) {
+	return nil, nil
+}
+
+func TestReadAllocations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		manager checkpointmanager.CheckpointManager
+		want    []Allocation
+		wantErr bool
+	}{
+		{
+			name:    "nil manager",
+			wantErr: true,
+		},
+		{
+			name:    "checkpoint not found",
+			manager: &mockCheckpointManager{err: cpmerrors.ErrCheckpointNotFound},
+			want:    []Allocation{},
+		},
+		{
+			name:    "checkpoint read error",
+			manager: &mockCheckpointManager{err: fmt.Errorf("read failed")},
+			wantErr: true,
+		},
+		{
+			name: "filters resources and deduplicates devices",
+			manager: &mockCheckpointManager{checkpoint: checkpoint.New([]checkpoint.PodDevicesEntry{
+				{
+					PodUID:        "pod-uid",
+					ContainerName: "container",
+					ResourceName:  "gpu.example.com/device",
+					DeviceIDs:     checkpoint.DevicesPerNUMA{0: {"gpu-0", "gpu-0", "gpu-1"}},
+				},
+				{
+					PodUID:        "pod-uid",
+					ContainerName: "container",
+					ResourceName:  "other.example.com/device",
+					DeviceIDs:     checkpoint.DevicesPerNUMA{0: {"other-0"}},
+				},
+			}, nil)},
+			want: []Allocation{{
+				PodUID:        "pod-uid",
+				ContainerName: "container",
+				ResourceName:  "gpu.example.com/device",
+				DeviceIDs:     []string{"gpu-0", "gpu-1"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ReadAllocations(tt.manager, sets.NewString("gpu.example.com/device"))
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/agent/qrm-plugins/util/util.go
+++ b/pkg/agent/qrm-plugins/util/util.go
@@ -138,6 +138,35 @@ func IsReallocation(podAnnotations map[string]string) (bool, string) {
 	return exists, value
 }
 
+// FilterQoSRelatedLabelsAndAnnotations keeps configured labels and annotations,
+// together with the QoS level and QoS enhancement values.
+func FilterQoSRelatedLabelsAndAnnotations(
+	qosConf *generic.QoSConfiguration,
+	annotations, labels map[string]string,
+	qosLevel string,
+	podAnnotationKeptKeys, podLabelKeptKeys []string,
+) (map[string]string, map[string]string) {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[apiconsts.PodAnnotationQoSLevelKey] = qosLevel
+	annotations = general.MergeMap(
+		general.FilterStringToStringMapByKeys(podAnnotationKeptKeys, annotations),
+		qosConf.FilterQoSAndEnhancementMap(annotations),
+	)
+
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[apiconsts.PodAnnotationQoSLevelKey] = qosLevel
+	labels = general.MergeMap(
+		general.FilterStringToStringMapByKeys(podLabelKeptKeys, labels),
+		qosConf.FilterQoSMap(labels),
+	)
+
+	return annotations, labels
+}
+
 // GetKatalystQoSLevelFromResourceReq retrieves QoS Level for a given request
 func GetKatalystQoSLevelFromResourceReq(qosConf *generic.QoSConfiguration, req *pluginapi.ResourceRequest,
 	podAnnotationKeptKeys, podLabelKeptKeys []string,
@@ -154,20 +183,14 @@ func GetKatalystQoSLevelFromResourceReq(qosConf *generic.QoSConfiguration, req *
 		return
 	}
 
-	// setting annotations and labels to only keep katalyst QoS related values
-	if req.Annotations == nil {
-		req.Annotations = make(map[string]string)
-	}
-	req.Annotations[apiconsts.PodAnnotationQoSLevelKey] = qosLevel
-	req.Annotations = general.MergeMap(general.FilterStringToStringMapByKeys(podAnnotationKeptKeys, req.Annotations),
-		qosConf.FilterQoSAndEnhancementMap(req.Annotations))
-
-	if req.Labels == nil {
-		req.Labels = make(map[string]string)
-	}
-	req.Labels[apiconsts.PodAnnotationQoSLevelKey] = qosLevel
-	req.Labels = general.MergeMap(general.FilterStringToStringMapByKeys(podLabelKeptKeys, req.Labels),
-		qosConf.FilterQoSMap(req.Labels))
+	req.Annotations, req.Labels = FilterQoSRelatedLabelsAndAnnotations(
+		qosConf,
+		req.Annotations,
+		req.Labels,
+		qosLevel,
+		podAnnotationKeptKeys,
+		podLabelKeptKeys,
+	)
 	return
 }
 
@@ -546,6 +569,34 @@ func GetMainContainer(pod *v1.Pod, mainContainerAnnotationKey string) string {
 	}
 
 	return mainContainerName
+}
+
+// GetContainerTypeAndIndex returns the type and index of the named container in the pod.
+func GetContainerTypeAndIndex(
+	pod *v1.Pod, containerName, mainContainerAnnotationKey string,
+) (pluginapi.ContainerType, uint64, error) {
+	if pod == nil {
+		return 0, 0, fmt.Errorf("got nil pod")
+	}
+
+	for i, container := range pod.Spec.InitContainers {
+		if container.Name == containerName {
+			return pluginapi.ContainerType_INIT, uint64(i), nil
+		}
+	}
+
+	mainContainerName := GetMainContainer(pod, mainContainerAnnotationKey)
+	for i, container := range pod.Spec.Containers {
+		if container.Name != containerName {
+			continue
+		}
+		if containerName == mainContainerName {
+			return pluginapi.ContainerType_MAIN, uint64(i), nil
+		}
+		return pluginapi.ContainerType_SIDECAR, uint64(i), nil
+	}
+
+	return 0, 0, fmt.Errorf("container %q not found in pod %s/%s", containerName, pod.Namespace, pod.Name)
 }
 
 // IsNetworkAffinityRestricted returns true if allocated network interface must have affinity with allocated numa

--- a/pkg/agent/qrm-plugins/util/util_test.go
+++ b/pkg/agent/qrm-plugins/util/util_test.go
@@ -26,11 +26,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	pluginapi "k8s.io/kubelet/pkg/apis/resourceplugin/v1alpha1"
 
 	"github.com/kubewharf/katalyst-api/pkg/consts"
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
 
@@ -167,6 +169,161 @@ func TestIsAnyResourceQuantityExist(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, IsAnyResourceQuantityExist(tc.resourceRequests, tc.resourceNames))
+		})
+	}
+}
+
+func TestFilterQoSRelatedLabelsAndAnnotations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		labels          map[string]string
+		wantAnnotations map[string]string
+		wantLabels      map[string]string
+	}{
+		{
+			name: "filters and keeps qos values",
+			annotations: map[string]string{
+				"kept-annotation": "annotation-value",
+				"ignored":         "ignored-value",
+			},
+			labels: map[string]string{
+				"kept-label": "label-value",
+				"ignored":    "ignored-value",
+			},
+			wantAnnotations: map[string]string{
+				"kept-annotation":               "annotation-value",
+				consts.PodAnnotationQoSLevelKey: "shared_cores",
+			},
+			wantLabels: map[string]string{
+				"kept-label":                    "label-value",
+				consts.PodAnnotationQoSLevelKey: "shared_cores",
+			},
+		},
+		{
+			name:            "initializes nil maps",
+			wantAnnotations: map[string]string{consts.PodAnnotationQoSLevelKey: "shared_cores"},
+			wantLabels:      map[string]string{consts.PodAnnotationQoSLevelKey: "shared_cores"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			annotations, labels := FilterQoSRelatedLabelsAndAnnotations(
+				generic.NewQoSConfiguration(),
+				tc.annotations,
+				tc.labels,
+				"shared_cores",
+				[]string{"kept-annotation"},
+				[]string{"kept-label"},
+			)
+			assert.Equal(t, tc.wantAnnotations, annotations)
+			assert.Equal(t, tc.wantLabels, labels)
+		})
+	}
+}
+
+func TestGetContainerTypeAndIndex(t *testing.T) {
+	t.Parallel()
+
+	const mainContainerAnnotationKey = "main-container"
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod",
+			Annotations: map[string]string{
+				mainContainerAnnotationKey: "main",
+			},
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{{Name: "init"}},
+			Containers: []v1.Container{
+				{Name: "sidecar"},
+				{Name: "main"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		pod                *v1.Pod
+		containerName      string
+		annotationKey      string
+		wantContainerType  pluginapi.ContainerType
+		wantContainerIndex uint64
+		wantErr            bool
+	}{
+		{
+			name:               "init container",
+			pod:                pod,
+			containerName:      "init",
+			annotationKey:      mainContainerAnnotationKey,
+			wantContainerType:  pluginapi.ContainerType_INIT,
+			wantContainerIndex: 0,
+		},
+		{
+			name:               "configured main container",
+			pod:                pod,
+			containerName:      "main",
+			annotationKey:      mainContainerAnnotationKey,
+			wantContainerType:  pluginapi.ContainerType_MAIN,
+			wantContainerIndex: 1,
+		},
+		{
+			name:               "sidecar container",
+			pod:                pod,
+			containerName:      "sidecar",
+			annotationKey:      mainContainerAnnotationKey,
+			wantContainerType:  pluginapi.ContainerType_SIDECAR,
+			wantContainerIndex: 0,
+		},
+		{
+			name: "falls back to first app container",
+			pod: &v1.Pod{Spec: v1.PodSpec{
+				Containers: []v1.Container{{Name: "main"}, {Name: "sidecar"}},
+			}},
+			containerName:      "main",
+			annotationKey:      mainContainerAnnotationKey,
+			wantContainerType:  pluginapi.ContainerType_MAIN,
+			wantContainerIndex: 0,
+		},
+		{
+			name:          "nil pod",
+			containerName: "main",
+			annotationKey: mainContainerAnnotationKey,
+			wantErr:       true,
+		},
+		{
+			name:          "container not found",
+			pod:           pod,
+			containerName: "missing",
+			annotationKey: mainContainerAnnotationKey,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			containerType, containerIndex, err := GetContainerTypeAndIndex(
+				tc.pod, tc.containerName, tc.annotationKey,
+			)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantContainerType, containerType)
+			assert.Equal(t, tc.wantContainerIndex, containerIndex)
 		})
 	}
 }


### PR DESCRIPTION
Add functionality to hydrate Katalyst GPU QRM state from kubelet device manager checkpoint, ensuring existing allocations are preserved when restarting. This includes:
- New kubelet checkpoint parsing utilities to read and deduplicate GPU allocations
- Hydration logic to import kubelet allocations into local GPU state
- Unit tests for the new checkpoint parsing and hydration logic
- Metric emission for hydration success/failure cases
- Refactor existing checkpoint reading code in reporter to reuse the new utilities

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## English

- Adds kubelet device-manager checkpoint fallback for GPU QRM.
- When fallback is enabled, the agent hydrates local GPU allocation state during initialization.
- Hydration filters inactive, invalid, unknown, duplicate, and incomplete allocations.
- Hydration restores pod QoS, filtered labels and annotations, container type, and container index.
- Hydration persists the rebuilt GPU state once.
- Adds `kubelet.ReadAllocations` for checkpoint parsing, GPU resource filtering, and device-ID deduplication.
- Refactors the reporter to use the shared checkpoint manager and reader.
- Emits checkpoint-read and hydration-failure metrics when a metric emitter is available.
- Checkpoint or hydration errors can prevent plugin initialization when fallback is enabled.
- Adds unit and integration tests for parsing, hydration, metadata, state updates, metrics, and topology hints.
- No controller, scheduler, release wiring, configuration, or dependency changes.

## 简体中文

- 为 GPU QRM 增加 kubelet device-manager checkpoint fallback。
- 启用 fallback 后，agent 会在初始化期间恢复本地 GPU allocation state。
- Hydration 会过滤非活动、无效、未知、重复和不完整的 allocation。
- Hydration 会恢复 pod QoS、filtered labels、annotations、container type 和 container index。
- Hydration 只持久化一次重建后的 GPU state。
- 增加 `kubelet.ReadAllocations`，用于 checkpoint parsing、GPU resource filtering 和 device-ID deduplication。
- 重构 reporter，使其使用共享的 checkpoint manager 和 reader。
- Metric emitter 可用时，会发出 checkpoint-read 和 hydration-failure metrics。
- 启用 fallback 后，checkpoint 或 hydration error 可能阻止 plugin initialization。
- 增加 parsing、hydration、metadata、state updates、metrics 和 topology hints 的 unit 及 integration tests。
- 不涉及 controller、scheduler、release wiring、configuration 或 dependency 变更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->