### PR TITLE
feat(gpu-qrm): add pod annotation override for virtual GPU timeslice

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/gpu_plugin.go
@@ -44,6 +44,9 @@ type GPUOptions struct {
 	GPUSelectionResultAnnotationKey             string
 	VirtualGPUDisableEnvsInjectionAnnotationKey string
 	VirtualGPUTimesliceEnvValue                 int
+	VirtualGPUTimesliceAnnotationKey            string
+	VirtualGPUTimesliceAnnotationMinValue       int
+	VirtualGPUTimesliceAnnotationMaxValue       int
 	VirtualGPUComputePolicyEnvValue             int
 
 	GPUStrategyOptions *gpustrategy.GPUStrategyOptions
@@ -64,6 +67,9 @@ func NewGPUOptions() *GPUOptions {
 		GPUSelectionResultAnnotationKey:             consts.PodAnnotationGPUSelectionResultKey,
 		VirtualGPUDisableEnvsInjectionAnnotationKey: "",
 		VirtualGPUTimesliceEnvValue:                 300,
+		VirtualGPUTimesliceAnnotationKey:            "",
+		VirtualGPUTimesliceAnnotationMinValue:       100,
+		VirtualGPUTimesliceAnnotationMaxValue:       50000,
 		VirtualGPUComputePolicyEnvValue:             0,
 	}
 }
@@ -106,6 +112,15 @@ func (o *GPUOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"If this annotation key exists on the resource request and its value is true, skip Virtual GPU env injection")
 	fs.IntVar(&o.VirtualGPUTimesliceEnvValue, "virtual-gpu-timeslice-env-value",
 		o.VirtualGPUTimesliceEnvValue, "The environment variable value for Virtual GPU timeslice")
+	fs.StringVar(&o.VirtualGPUTimesliceAnnotationKey, "virtual-gpu-timeslice-annotation-key",
+		o.VirtualGPUTimesliceAnnotationKey,
+		"The pod annotation key used to override Virtual GPU timeslice env value; empty disables override")
+	fs.IntVar(&o.VirtualGPUTimesliceAnnotationMinValue, "virtual-gpu-timeslice-annotation-min-value",
+		o.VirtualGPUTimesliceAnnotationMinValue,
+		"The minimum accepted Virtual GPU timeslice annotation value; valid values are integers in [min, max]")
+	fs.IntVar(&o.VirtualGPUTimesliceAnnotationMaxValue, "virtual-gpu-timeslice-annotation-max-value",
+		o.VirtualGPUTimesliceAnnotationMaxValue,
+		"The maximum accepted Virtual GPU timeslice annotation value; valid values are integers in [min, max]")
 	fs.IntVar(&o.VirtualGPUComputePolicyEnvValue, "virtual-gpu-compute-policy-env-value",
 		o.VirtualGPUComputePolicyEnvValue, "The environment variable value for Virtual GPU compute policy")
 	o.GPUStrategyOptions.AddFlags(fss)
@@ -136,6 +151,9 @@ func (o *GPUOptions) ApplyTo(conf *qrmconfig.GPUQRMPluginConfig) error {
 	conf.VirtualGPUTimesliceEnvName = o.VirtualGPUTimesliceEnvName
 	conf.VirtualGPUComputePolicyEnvName = o.VirtualGPUComputePolicyEnvName
 	conf.VirtualGPUTimesliceEnvValue = o.VirtualGPUTimesliceEnvValue
+	conf.VirtualGPUTimesliceAnnotationKey = o.VirtualGPUTimesliceAnnotationKey
+	conf.VirtualGPUTimesliceAnnotationMinValue = o.VirtualGPUTimesliceAnnotationMinValue
+	conf.VirtualGPUTimesliceAnnotationMaxValue = o.VirtualGPUTimesliceAnnotationMaxValue
 	conf.VirtualGPUComputePolicyEnvValue = o.VirtualGPUComputePolicyEnvValue
 	conf.GPUSelectionResultAnnotationKey = o.GPUSelectionResultAnnotationKey
 	conf.VirtualGPUDisableEnvsInjectionAnnotationKey = o.VirtualGPUDisableEnvsInjectionAnnotationKey

--- a/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu.go
+++ b/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu.go
@@ -915,7 +915,8 @@ func (p *VirtualGPUPlugin) allocate(
 		}
 
 		// Calculate the environment variables
-		envs := p.calculateEnvVariables(resName, result.AllocatedDevices, resQuantityPerGPU, resourceReq.PodUid)
+		envs := p.calculateEnvVariables(
+			resName, result.AllocatedDevices, resQuantityPerGPU, resourceReq.PodUid, resourceReq.Annotations)
 		if len(envs) > 0 {
 			resourceAllocationEnvs[string(resName)] = envs
 		}
@@ -946,14 +947,20 @@ func (p *VirtualGPUPlugin) shouldSkipEnvInjection(resourceReq *pluginapi.Resourc
 }
 
 // calculateEnvVariables computes the environment variable map for a given GPU resource.
-func (p *VirtualGPUPlugin) calculateEnvVariables(resName v1.ResourceName, allocatedDevices []string, resQuantityPerGPU float64, podUID string) map[string]string {
+func (p *VirtualGPUPlugin) calculateEnvVariables(
+	resName v1.ResourceName,
+	allocatedDevices []string,
+	resQuantityPerGPU float64,
+	podUID string,
+	annotations map[string]string,
+) map[string]string {
 	envs := make(map[string]string)
 
 	switch resName {
 	case consts.ResourceGPUMemory:
 		p.injectGPUMemoryEnvVariables(envs, allocatedDevices, resQuantityPerGPU)
 	case consts.ResourceMilliGPU:
-		p.injectMilliGPUEnvVariables(envs, allocatedDevices, resQuantityPerGPU, podUID)
+		p.injectMilliGPUEnvVariables(envs, allocatedDevices, resQuantityPerGPU, podUID, annotations)
 	}
 
 	if len(envs) > 0 {
@@ -984,12 +991,18 @@ func (p *VirtualGPUPlugin) injectGPUMemoryEnvVariables(envs map[string]string, a
 
 // injectMilliGPUEnvVariables injects the compute allocation weight, timeslice configuration, compute policy,
 // pod UID, and visible devices environment variables.
-func (p *VirtualGPUPlugin) injectMilliGPUEnvVariables(envs map[string]string, allocatedDevices []string, resQuantityPerGPU float64, podUID string) {
+func (p *VirtualGPUPlugin) injectMilliGPUEnvVariables(
+	envs map[string]string,
+	allocatedDevices []string,
+	resQuantityPerGPU float64,
+	podUID string,
+	annotations map[string]string,
+) {
 	p.injectWeightEnvVariable(envs, consts.ResourceMilliGPU, p.Conf.VirtualGPUComputeWeightEnvName, allocatedDevices, resQuantityPerGPU)
 
 	// Inject timeslice configuration for Virtual GPU isolation if the environment name is configured
 	if p.Conf.VirtualGPUTimesliceEnvName != "" {
-		envs[p.Conf.VirtualGPUTimesliceEnvName] = strconv.Itoa(p.Conf.VirtualGPUTimesliceEnvValue)
+		envs[p.Conf.VirtualGPUTimesliceEnvName] = strconv.Itoa(p.getVirtualGPUTimesliceEnvValue(annotations))
 	}
 
 	// Inject compute policy configuration for Virtual GPU isolation if the environment name is configured
@@ -1008,6 +1021,23 @@ func (p *VirtualGPUPlugin) injectMilliGPUEnvVariables(envs map[string]string, al
 			envs[env] = visibleDevices
 		}
 	}
+}
+
+// getVirtualGPUTimesliceEnvValue returns a valid annotation override or the configured static fallback.
+func (p *VirtualGPUPlugin) getVirtualGPUTimesliceEnvValue(annotations map[string]string) int {
+	key := p.Conf.VirtualGPUTimesliceAnnotationKey
+	if key == "" || annotations == nil {
+		return p.Conf.VirtualGPUTimesliceEnvValue
+	}
+
+	value, err := strconv.Atoi(annotations[key])
+	if err != nil ||
+		value < p.Conf.VirtualGPUTimesliceAnnotationMinValue ||
+		value > p.Conf.VirtualGPUTimesliceAnnotationMaxValue {
+		return p.Conf.VirtualGPUTimesliceEnvValue
+	}
+
+	return value
 }
 
 // generateDeviceRequestForMilliGPU fabricates a DeviceRequest for milligpu-only requests (which arrive

--- a/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu_test.go
+++ b/pkg/agent/qrm-plugins/gpu/resourceplugin/virtualgpu/virtual_gpu_test.go
@@ -2401,6 +2401,9 @@ func TestVirtualGPUPlugin_calculateEnvVariables(t *testing.T) {
 	basePlugin.Conf.VirtualGPUComputeWeightEnvName = "KUBE_GPU_COMPUTE_WEIGHT"
 	basePlugin.Conf.VirtualGPUTimesliceEnvName = "KUBE_GPU_TIMESLICE"
 	basePlugin.Conf.VirtualGPUTimesliceEnvValue = 1
+	basePlugin.Conf.VirtualGPUTimesliceAnnotationKey = "example.com/gpu-timeslice"
+	basePlugin.Conf.VirtualGPUTimesliceAnnotationMinValue = 100
+	basePlugin.Conf.VirtualGPUTimesliceAnnotationMaxValue = 50000
 	basePlugin.Conf.VirtualGPUComputePolicyEnvName = "KUBE_GPU_COMPUTE_POLICY"
 	basePlugin.Conf.VirtualGPUComputePolicyEnvValue = 2
 	basePlugin.Conf.VirtualGPUVisibleDevicesEnvNames = []string{"NVIDIA_VISIBLE_DEVICES"}
@@ -2416,6 +2419,7 @@ func TestVirtualGPUPlugin_calculateEnvVariables(t *testing.T) {
 		allocatedDevices  []string
 		podUID            string
 		resQuantityPerGPU float64
+		annotations       map[string]string
 		expectedEnvs      map[string]string
 	}{
 		{
@@ -2451,6 +2455,23 @@ func TestVirtualGPUPlugin_calculateEnvVariables(t *testing.T) {
 			},
 		},
 		{
+			name:              "milligpu annotation overrides timeslice",
+			resName:           consts.ResourceMilliGPU,
+			allocatedDevices:  []string{"gpu-0"},
+			podUID:            "test-pod-uid",
+			resQuantityPerGPU: 250,
+			annotations: map[string]string{
+				"example.com/gpu-timeslice": "100",
+			},
+			expectedEnvs: map[string]string{
+				"KUBE_GPU_COMPUTE_WEIGHT": "gpu-0:25",
+				"KUBE_GPU_TIMESLICE":      "100",
+				"KUBE_GPU_COMPUTE_POLICY": "2",
+				"KUBE_POD_UID":            "test-pod-uid",
+				"NVIDIA_VISIBLE_DEVICES":  "gpu-0",
+			},
+		},
+		{
 			name:              "milligpu multiple devices",
 			resName:           consts.ResourceMilliGPU,
 			allocatedDevices:  []string{"gpu-0", "gpu-1"},
@@ -2477,8 +2498,121 @@ func TestVirtualGPUPlugin_calculateEnvVariables(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			envs := plugin.calculateEnvVariables(tt.resName, tt.allocatedDevices, tt.resQuantityPerGPU, tt.podUID)
+			envs := plugin.calculateEnvVariables(tt.resName, tt.allocatedDevices, tt.resQuantityPerGPU, tt.podUID, tt.annotations)
 			assert.Equal(t, tt.expectedEnvs, envs)
+		})
+	}
+}
+
+func TestVirtualGPUPlugin_getVirtualGPUTimesliceEnvValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		key         string
+		minValue    int
+		maxValue    int
+		staticValue int
+		annotations map[string]string
+		want        int
+	}{
+		{
+			name:        "empty annotation key uses static value",
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "100"},
+			want:        300,
+		},
+		{
+			name:        "nil annotations use static value",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			want:        300,
+		},
+		{
+			name:        "missing annotation uses static value",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/other": "100"},
+			want:        300,
+		},
+		{
+			name:        "minimum annotation is valid",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "100"},
+			want:        100,
+		},
+		{
+			name:        "maximum annotation is valid",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "50000"},
+			want:        50000,
+		},
+		{
+			name:        "annotation below minimum uses static value",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "99"},
+			want:        300,
+		},
+		{
+			name:        "annotation above maximum uses static value",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "50001"},
+			want:        300,
+		},
+		{
+			name:        "non-integer annotation uses static value",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "abc"},
+			want:        300,
+		},
+		{
+			name:        "negative annotation uses static value",
+			key:         "example.com/timeslice",
+			minValue:    100,
+			maxValue:    50000,
+			staticValue: 300,
+			annotations: map[string]string{"example.com/timeslice": "-1"},
+			want:        300,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			basePlugin := makeTestBasePlugin(t)
+			basePlugin.Conf.VirtualGPUTimesliceAnnotationKey = tt.key
+			basePlugin.Conf.VirtualGPUTimesliceAnnotationMinValue = tt.minValue
+			basePlugin.Conf.VirtualGPUTimesliceAnnotationMaxValue = tt.maxValue
+			basePlugin.Conf.VirtualGPUTimesliceEnvValue = tt.staticValue
+
+			resourcePlugin := NewVirtualGPUPlugin(basePlugin)
+			plugin, ok := resourcePlugin.(*VirtualGPUPlugin)
+			if !assert.True(t, ok) {
+				return
+			}
+
+			assert.Equal(t, tt.want, plugin.getVirtualGPUTimesliceEnvValue(tt.annotations))
 		})
 	}
 }

--- a/pkg/config/agent/qrm/gpu_plugin.go
+++ b/pkg/config/agent/qrm/gpu_plugin.go
@@ -66,6 +66,15 @@ type GPUQRMPluginConfig struct {
 	VirtualGPUComputePolicyEnvName string
 	// VirtualGPUTimesliceEnvValue is the default value of the VirtualGPUTimesliceEnvName environment variable.
 	VirtualGPUTimesliceEnvValue int
+	// VirtualGPUTimesliceAnnotationKey is the pod annotation key used to override
+	// VirtualGPUTimesliceEnvValue. An empty key disables the override.
+	VirtualGPUTimesliceAnnotationKey string
+	// VirtualGPUTimesliceAnnotationMinValue is the minimum accepted annotation value.
+	// Valid annotation values are integers in the inclusive range [min, max].
+	VirtualGPUTimesliceAnnotationMinValue int
+	// VirtualGPUTimesliceAnnotationMaxValue is the maximum accepted annotation value.
+	// Valid annotation values are integers in the inclusive range [min, max].
+	VirtualGPUTimesliceAnnotationMaxValue int
 	// VirtualGPUComputePolicyEnvValue is the default value of the VirtualGPUComputePolicyEnvName environment variable.
 	VirtualGPUComputePolicyEnvValue int
 	// GPUSelectionResultAnnotationKey is the pod annotation key used to retrieve the GPU selection result


### PR DESCRIPTION
Add support to override the default virtual GPU timeslice value via pod annotations, including configurable valid value range for the annotation.
- Add new configuration fields for annotation key and value bounds
- Add command line flags to configure these new options
- Implement annotation parsing and validation logic
- Update env calculation flow to use override when available
- Add comprehensive unit tests for the new functionality

#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### English

- Adds pod annotation support to override the virtual GPU timeslice.
- Adds configurable annotation key and inclusive minimum and maximum values through `GPUOptions` and `GPUQRMPluginConfig`.
- Applies the override only when the annotation is an integer within the configured range. Otherwise, the configured default remains in use.
- Updates virtual GPU environment calculation to pass and process resource-request annotations.
- Adds unit tests for missing, invalid, out-of-range, and boundary values.
- Changes affect the agent GPU QRM plugin only. No controller, scheduler, release wiring, or dependency updates are included.
- Rollout risk is limited to pods that use the configured annotation. Invalid annotations fall back to the configured default.

### 简体中文

- 增加通过 Pod annotation 覆盖 virtual GPU timeslice 的支持。
- 在 `GPUOptions` 和 `GPUQRMPluginConfig` 中增加可配置的 annotation key，以及包含边界值的最小值和最大值。
- 仅当 annotation 值为配置范围内的整数时应用覆盖值。其他情况继续使用配置的默认值。
- 更新 virtual GPU 环境变量计算逻辑，以传递并处理 resource-request annotations。
- 增加对缺失值、无效值、超出范围值和边界值的单元测试。
- 变更仅影响 agent 的 GPU QRM plugin。不涉及 controller、scheduler、release wiring 或依赖更新。
- Rollout 风险限于使用该 annotation 的 Pod。无效 annotation 会回退到配置的默认值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->