### PR TITLE
docs: use current reclaimed resource names in examples

### DIFF
--- a/docs/proposals/scheduling/20220913-katalyst-scheduler-design.md
+++ b/docs/proposals/scheduling/20220913-katalyst-scheduler-design.md
@@ -191,10 +191,10 @@ Components related to scheduling:
 
 We will introduce some new resource keys:
 
-- `katalyst.kubewharf.io/reclaimed_millicpu` represents the amount of reclaimed CPU resources requested by a container.
+- `resource.katalyst.kubewharf.io/reclaimed_millicpu` represents the amount of reclaimed CPU resources requested by a container.
   Its unit is milli-core.
 
-- `katalyst.kubewharf.io/reclaimed_memory` represents the amount of reclaimed memory resources requested by a container.
+- `resource.katalyst.kubewharf.io/reclaimed_memory` represents the amount of reclaimed memory resources requested by a container.
   Its unit is byte.
 
 If a user wants to create a Pod with a `reclaimed_cores` QoS class which requests 4 CPU cores and 8 GiB of memory,
@@ -213,11 +213,11 @@ spec:
   - ...
     resources:
       requests:
-        "katalyst.kubewharf.io/reclaimed_millicpu": "4k"
-        "katalyst.kubewharf.io/reclaimed_memory": 8Gi
+        "resource.katalyst.kubewharf.io/reclaimed_millicpu": "4k"
+        "resource.katalyst.kubewharf.io/reclaimed_memory": 8Gi
       limits:
-        "katalyst.kubewharf.io/reclaimed_millicpu": "4k"
-        "katalyst.kubewharf.io/reclaimed_memory": 8Gi
+        "resource.katalyst.kubewharf.io/reclaimed_millicpu": "4k"
+        "resource.katalyst.kubewharf.io/reclaimed_memory": 8Gi
 ```
 
 #### Report Allocatable Reclaimed Resources
@@ -237,11 +237,11 @@ spec:
 status:
   ...
   resourceAllocatable:
-    katalyst.kubewharf.io/reclaimed_memory: "107374182400"
-    katalyst.kubewharf.io/reclaimed_millicpu: 40k
+    resource.katalyst.kubewharf.io/reclaimed_memory: "107374182400"
+    resource.katalyst.kubewharf.io/reclaimed_millicpu: 40k
   resourceCapacity:
-    katalyst.kubewharf.io/reclaimed_memory: "107374182400"
-    katalyst.kubewharf.io/reclaimed_millicpu: 40k
+    resource.katalyst.kubewharf.io/reclaimed_memory: "107374182400"
+    resource.katalyst.kubewharf.io/reclaimed_millicpu: 40k
 ```
 
 ### Design Details
@@ -348,7 +348,7 @@ The native **NodeResourcesFit** plugin filters and scores nodes based on the amo
 node. Reclaimed resources should not interfere with this process.
 
 We use the NodeResourcesFit plugin's ignoredResourceGroups feature, introduced in K8s v1.19, to make the plugin ignore
-resource types prefixed with `katalyst.kubewharf.io` when filtering nodes:
+resource types prefixed with `resource.katalyst.kubewharf.io` when filtering nodes:
 
 ```yaml
 apiVersion: kubescheduler.config.k8s.io/v1beta3
@@ -358,7 +358,7 @@ profiles:
   - name: NodeResourcesFit
     args:
       ignoredResourceGroups:
-      - katalyst.kubewharf.io
+      - resource.katalyst.kubewharf.io
 ... 
 ```
 
@@ -507,7 +507,7 @@ Compatibility matrix:
           - name: NodeResourcesFit
             args:
               ignoredResourceGroups:
-              - katalyst.kubewharf.io
+              - resource.katalyst.kubewharf.io
           - name: QoSAwareNodeResourcesFit # optional
             args:
               scoringStrategy:
@@ -518,9 +518,9 @@ Compatibility matrix:
                 - name: memory
                   weight: 1
                 reclaimedResources:
-                - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                   weight: 1
-                - name: "katalyst.kubewharf.io/reclaimed_memory"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                   weight: 1  
           - name: QoSAwareNodeResourcesBalancedAllocation # optional
             args:
@@ -530,9 +530,9 @@ Compatibility matrix:
               - name: memory
                 weight: 1
               reclaimedResources:
-              - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                 weight: 1
-              - name: "katalyst.kubewharf.io/reclaimed_memory"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                 weight: 1  
         ```
 
@@ -573,7 +573,7 @@ Compatibility matrix:
         - name: NodeResourcesFit
           args:
             ignoredResourceGroups:
-            - katalyst.kubewharf.io
+            - resource.katalyst.kubewharf.io
         - name: QoSAwareNodeResourcesFit
           args:
             scoringStrategy:
@@ -584,9 +584,9 @@ Compatibility matrix:
               - name: memory
                 weight: 1
               reclaimedResources:
-              - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                 weight: 1
-              - name: "katalyst.kubewharf.io/reclaimed_memory"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                 weight: 1  
         - name: QoSAwareNodeResourcesBalancedAllocation # optional
           args:
@@ -596,9 +596,9 @@ Compatibility matrix:
             - name: memory
               weight: 1
             reclaimedResources:
-            - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
               weight: 1
-            - name: "katalyst.kubewharf.io/reclaimed_memory"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
               weight: 1  
       ```
 
@@ -639,7 +639,7 @@ Compatibility matrix:
         - name: NodeResourcesFit
           args:
             ignoredResourceGroups:
-            - katalyst.kubewharf.io
+            - resource.katalyst.kubewharf.io
         - name: QoSAwareNodeResourcesFit
           args:
             scoringStrategy:
@@ -662,9 +662,9 @@ Compatibility matrix:
               - name: memory
                 weight: 1
               reclaimedResources:
-              - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                 weight: 1
-              - name: "katalyst.kubewharf.io/reclaimed_memory"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                 weight: 1  
         - name: QoSAwareNodeResourcesBalancedAllocation # optional
           args:
@@ -674,9 +674,9 @@ Compatibility matrix:
             - name: memory
               weight: 1
             reclaimedResources:
-            - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
               weight: 1
-            - name: "katalyst.kubewharf.io/reclaimed_memory"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
               weight: 1  
       ```
 
@@ -717,7 +717,7 @@ Compatibility matrix:
           - name: NodeResourcesFit
             args:
               ignoredResourceGroups:
-              - katalyst.kubewharf.io
+              - resource.katalyst.kubewharf.io
           - name: QoSAwareNodeResourcesFit
             args:
               scoringStrategy:
@@ -728,9 +728,9 @@ Compatibility matrix:
                 - name: memory
                   weight: 1
                 reclaimedResources:
-                - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                   weight: 1
-                - name: "katalyst.kubewharf.io/reclaimed_memory"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                   weight: 1  
           - name: QoSAwareNodeResourcesBalancedAllocation # optional
             args:
@@ -740,9 +740,9 @@ Compatibility matrix:
               - name: memory
                 weight: 1
               reclaimedResources:
-              - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                 weight: 1
-              - name: "katalyst.kubewharf.io/reclaimed_memory"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                 weight: 1  
         ```
 
@@ -783,7 +783,7 @@ Compatibility matrix:
         - name: NodeResourcesFit
           args:
             ignoredResourceGroups:
-            - katalyst.kubewharf.io
+            - resource.katalyst.kubewharf.io
         - name: QoSAwareNodeResourcesFit
           args:
             scoringStrategy:
@@ -794,9 +794,9 @@ Compatibility matrix:
               - name: memory
                 weight: 1
               reclaimedResources:
-              - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                 weight: 1
-              - name: "katalyst.kubewharf.io/reclaimed_memory"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                 weight: 1  
         - name: QoSAwareNodeResourcesBalancedAllocation # optional
           args:
@@ -806,9 +806,9 @@ Compatibility matrix:
             - name: memory
               weight: 1
             reclaimedResources:
-            - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
               weight: 1
-            - name: "katalyst.kubewharf.io/reclaimed_memory"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
               weight: 1  
       ```
 
@@ -849,7 +849,7 @@ Compatibility matrix:
         - name: NodeResourcesFit
           args:
             ignoredResourceGroups:
-            - katalyst.kubewharf.io
+            - resource.katalyst.kubewharf.io
         - name: QoSAwareNodeResourcesFit
           args:
             scoringStrategy:
@@ -872,9 +872,9 @@ Compatibility matrix:
               - name: memory
                 weight: 1
               reclaimedResources:
-              - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                 weight: 1
-              - name: "katalyst.kubewharf.io/reclaimed_memory"
+              - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                 weight: 1  
         - name: QoSAwareNodeResourcesBalancedAllocation # optional
           args:
@@ -884,9 +884,9 @@ Compatibility matrix:
             - name: memory
               weight: 1
             reclaimedResources:
-            - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
               weight: 1
-            - name: "katalyst.kubewharf.io/reclaimed_memory"
+            - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
               weight: 1  
       ```
 
@@ -897,7 +897,7 @@ Compatibility matrix:
     <table>
     <tr>
         <td></td>
-        <td><code><b>katalyst.kubewharf.io</b></code></td>
+        <td><code><b>resource.katalyst.kubewharf.io</b></code></td>
         <td><code><b>*kubernetes.io</b></code></td>
     </tr>
     <tr>
@@ -946,7 +946,7 @@ Compatibility matrix:
     </tr>
     </table>
 
-Considering that currently in the Katalyst system, the demand for Pod-level over-commitment of offline Pods is not strong. Also, by using `katalyst.kubewharf.io`, the cost to modify the scheduler and kubelet is much lower. **Therefore, we chose `katalyst.kubewharf.io`.**
+Considering that currently in the Katalyst system, the demand for Pod-level over-commitment of offline Pods is not strong. Also, by using `resource.katalyst.kubewharf.io`, the cost to modify the scheduler and kubelet is much lower. **Therefore, we chose `resource.katalyst.kubewharf.io`.**
 
 ## References
 

--- a/docs/tutorial/colocation.md
+++ b/docs/tutorial/colocation.md
@@ -27,11 +27,11 @@ When you refer to CNR, reclaimed resources will be as follows, and it means that
 ```
 status:
     resourceAllocatable:
-        katalyst.kubewharf.io/reclaimed_memory: "195257901056"
-        katalyst.kubewharf.io/reclaimed_millicpu: 44k
+        resource.katalyst.kubewharf.io/reclaimed_memory: "195257901056"
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 44k
     resourceCapacity:
-        katalyst.kubewharf.io/reclaimed_memory: "195257901056"
-        katalyst.kubewharf.io/reclaimed_millicpu: 44k
+        resource.katalyst.kubewharf.io/reclaimed_memory: "195257901056"
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 44k
 ```
 
 Submit several pods with shared_cores, and put pressure on those workloads to make reclaimed resources fluctuate along with the running state of workload.
@@ -46,9 +46,9 @@ After successfully scheduled, the pod starts running with cpu-usage ~= 1cores an
 ```
 status:
     resourceAllocatable:
-        katalyst.kubewharf.io/reclaimed_millicpu: 42k
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 42k
     resourceCapacity:
-        katalyst.kubewharf.io/reclaimed_millicpu: 42k
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 42k
 ```
    
 You can then put pressure on those pods to simulate requested peaks with `stress`, and the cpu-load will rise to approximately 3 to make the reclaimed cpu shrink to 40k.
@@ -59,9 +59,9 @@ $ kubectl exec shared-normal-pod -it -- stress -c 2
 ```
 status:
     resourceAllocatable:
-        katalyst.kubewharf.io/reclaimed_millicpu: 40k
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 40k
     resourceCapacity:
-        katalyst.kubewharf.io/reclaimed_millicpu: 40k
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 40k
 ```
 
 ### Scheduling Strategy
@@ -199,14 +199,14 @@ $ kubectl exec shared-large-pod-2 -it -- stress -c 40
 ```
 status:
     resourceAllocatable:
-        katalyst.kubewharf.io/reclaimed_millicpu: 4k
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 4k
     resourceCapacity:
-        katalyst.kubewharf.io/reclaimed_millicpu: 4k
+        resource.katalyst.kubewharf.io/reclaimed_millicpu: 4k
 ```
 ```
 $ kubectl get event -A | grep evict
-default     43s         Normal   EvictCreated     pod/reclaimed-large-pod-2   Successfully create eviction; reason: met threshold in scope: katalyst.kubewharf.io/reclaimed_millicpu from plugin: reclaimed-resource-pressure-eviction-plugin
-default     8s          Normal   EvictSucceeded   pod/reclaimed-large-pod-2   Evicted pod has been deleted physically; reason: met threshold in scope: katalyst.kubewharf.io/reclaimed_millicpu from plugin: reclaimed-resource-pressure-eviction-plugin
+default     43s         Normal   EvictCreated     pod/reclaimed-large-pod-2   Successfully create eviction; reason: met threshold in scope: resource.katalyst.kubewharf.io/reclaimed_millicpu from plugin: reclaimed-resource-pressure-eviction-plugin
+default     8s          Normal   EvictSucceeded   pod/reclaimed-large-pod-2   Evicted pod has been deleted physically; reason: met threshold in scope: resource.katalyst.kubewharf.io/reclaimed_millicpu from plugin: reclaimed-resource-pressure-eviction-plugin
 ```
 
 The default threshold for reclaimed resources 5, you can change it dynamically with KCC.

--- a/docs/tutorial/colocation.md
+++ b/docs/tutorial/colocation.md
@@ -203,7 +203,7 @@ status:
     resourceCapacity:
         resource.katalyst.kubewharf.io/reclaimed_millicpu: 4k
 ```
-```
+```text
 $ kubectl get event -A | grep evict
 default     43s         Normal   EvictCreated     pod/reclaimed-large-pod-2   Successfully create eviction; reason: met threshold in scope: resource.katalyst.kubewharf.io/reclaimed_millicpu from plugin: reclaimed-resource-pressure-eviction-plugin
 default     8s          Normal   EvictSucceeded   pod/reclaimed-large-pod-2   Evicted pod has been deleted physically; reason: met threshold in scope: resource.katalyst.kubewharf.io/reclaimed_millicpu from plugin: reclaimed-resource-pressure-eviction-plugin

--- a/examples/kcc-eviction-reclaimed-resource-config.yaml
+++ b/examples/kcc-eviction-reclaimed-resource-config.yaml
@@ -32,5 +32,5 @@ spec:
     evictionPluginsConfig:
       reclaimedResourcesEvictionPluginConfig:
         evictionThreshold:
-          "katalyst.kubewharf.io/reclaimed_millicpu": 10
-          "katalyst.kubewharf.io/reclaimed_memory": 10
+          "resource.katalyst.kubewharf.io/reclaimed_millicpu": 10
+          "resource.katalyst.kubewharf.io/reclaimed_memory": 10

--- a/examples/scheduler-policy-binpack.yaml
+++ b/examples/scheduler-policy-binpack.yaml
@@ -53,7 +53,7 @@ data:
           - name: NodeResourcesFit
             args:
               ignoredResourceGroups:
-                - katalyst.kubewharf.io
+                - resource.katalyst.kubewharf.io
           - name: QoSAwareNodeResourcesFit
             args:
               scoringStrategy:
@@ -64,9 +64,9 @@ data:
                   - name: memory
                     weight: 1
                 reclaimedResources:
-                  - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                  - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                     weight: 1
-                  - name: "katalyst.kubewharf.io/reclaimed_memory"
+                  - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                     weight: 1
           - name: QoSAwareNodeResourcesBalancedAllocation
             args:
@@ -76,7 +76,7 @@ data:
                 - name: memory
                   weight: 1
               reclaimedResources:
-                - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                   weight: 1
-                - name: "katalyst.kubewharf.io/reclaimed_memory"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                   weight: 1  

--- a/examples/scheduler-policy-custom.yaml
+++ b/examples/scheduler-policy-custom.yaml
@@ -53,7 +53,7 @@ data:
           - name: NodeResourcesFit
             args:
               ignoredResourceGroups:
-                - katalyst.kubewharf.io
+                - resource.katalyst.kubewharf.io
           - name: QoSAwareNodeResourcesFit
             args:
               scoringStrategy:
@@ -76,9 +76,9 @@ data:
                   - name: memory
                     weight: 1
                 reclaimedResources:
-                  - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                  - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                     weight: 1
-                  - name: "katalyst.kubewharf.io/reclaimed_memory"
+                  - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                     weight: 1
           - name: QoSAwareNodeResourcesBalancedAllocation
             args:
@@ -88,7 +88,7 @@ data:
                 - name: memory
                   weight: 1
               reclaimedResources:
-                - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                   weight: 1
-                - name: "katalyst.kubewharf.io/reclaimed_memory"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                   weight: 1  

--- a/examples/scheduler-policy-spread.yaml
+++ b/examples/scheduler-policy-spread.yaml
@@ -53,7 +53,7 @@ data:
           - name: NodeResourcesFit
             args:
               ignoredResourceGroups:
-                - katalyst.kubewharf.io
+                - resource.katalyst.kubewharf.io
           - name: QoSAwareNodeResourcesFit
             args:
               scoringStrategy:
@@ -64,9 +64,9 @@ data:
                   - name: memory
                     weight: 1
                 reclaimedResources:
-                  - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                  - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                     weight: 1
-                  - name: "katalyst.kubewharf.io/reclaimed_memory"
+                  - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                     weight: 1
           - name: QoSAwareNodeResourcesBalancedAllocation
             args:
@@ -76,7 +76,7 @@ data:
                 - name: memory
                   weight: 1
               reclaimedResources:
-                - name: "katalyst.kubewharf.io/reclaimed_millicpu"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_millicpu"
                   weight: 1
-                - name: "katalyst.kubewharf.io/reclaimed_memory"
+                - name: "resource.katalyst.kubewharf.io/reclaimed_memory"
                   weight: 1  


### PR DESCRIPTION
#### What type of PR is this?

Bug fix / documentation

#### What this PR does / why we need it:

The reclaimed resource constants and the reclaimed Pod examples use:

- `resource.katalyst.kubewharf.io/reclaimed_millicpu`
- `resource.katalyst.kubewharf.io/reclaimed_memory`

However, the scheduler policies, scheduler design proposal, colocation tutorial, and reclaimed-resource eviction example still use the former `katalyst.kubewharf.io` resource group.

The QoS-aware scheduler scorer only recognizes the current constants. With the example policies, the former resource names are omitted from score calculation, so reclaimed-resource scoring does not reflect the node's reclaimed CPU or memory.

This updates the six affected documentation/example files, including the related `ignoredResourceGroups` entries. It follows up on #330 and #351, which updated the Pod examples and disabled the native fit plugin respectively.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Validation:

- parsed all 21 repository YAML files (26 documents)
- parsed the embedded scheduler configuration in all three scheduler policy ConfigMaps
- asserted no former reclaimed resource names or doubled prefixes remain
- `go test ./pkg/scheduler/... ./cmd/katalyst-scheduler/... -count=1` in a Linux container
- `GOOS=linux GOARCH=amd64 go vet ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## English

- Updated scheduler policies, design documentation, colocation tutorial, and eviction examples to use:
  - `resource.katalyst.kubewharf.io/reclaimed_millicpu`
  - `resource.katalyst.kubewharf.io/reclaimed_memory`
- Updated `ignoredResourceGroups` and QoS-aware scheduler scoring examples.
- No agent, controller, release wiring, dependency, or runtime code changes.
- Runtime behavior changes only when users apply the updated configurations. The main risk is a mismatch between configured and recognized resource names.
- Validation included YAML and embedded scheduler configuration parsing, obsolete-name checks, scheduler tests, and `go vet`.

## 简体中文

- 更新了 scheduler policy、设计文档、colocation tutorial 和 eviction 示例，统一使用：
  - `resource.katalyst.kubewharf.io/reclaimed_millicpu`
  - `resource.katalyst.kubewharf.io/reclaimed_memory`
- 更新了 `ignoredResourceGroups` 和 QoS-aware scheduler scoring 示例。
- 未修改 agent、controller、release wiring、依赖或运行时代码。
- 只有在用户应用更新后的配置时，运行时行为才会变化。主要风险是配置名称与系统识别的 resource 名称不匹配。
- 已完成 YAML 和内嵌 scheduler 配置解析、旧名称检查、scheduler tests 以及 `go vet` 验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->