### PR TITLE
feat: support sale mode eviction ranking

### DIFF
--- a/cmd/base/options/generic.go
+++ b/cmd/base/options/generic.go
@@ -25,6 +25,8 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog/v2"
 
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+
 	"github.com/kubewharf/katalyst-core/pkg/config/generic"
 	"github.com/kubewharf/katalyst-core/pkg/util/process"
 )
@@ -42,6 +44,7 @@ type GenericOptions struct {
 	// todo actually those auth info should be stored in secrets or somewhere like that
 	GenericEndpoint             string
 	GenericEndpointHandleChains []string
+	PodSaleModeAnnotationKey    string
 
 	qosOptions     *QoSOptions
 	metricsOptions *MetricsOptions
@@ -57,6 +60,7 @@ func NewGenericOptions() *GenericOptions {
 		EnableHealthzCheck:        false,
 		TransformedInformerForPod: false,
 		GenericEndpoint:           ":9316",
+		PodSaleModeAnnotationKey:  apiconsts.PodAnnotationSaleModeKey,
 		qosOptions:                NewQoSOptions(),
 		metricsOptions:            NewMetricsOptions(),
 		logsOptions:               NewLogsOptions(),
@@ -92,6 +96,8 @@ func (o *GenericOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 		"the endpoint of generic purpose, which will use as prometheus, health check and profiling")
 	fs.StringSliceVar(&o.GenericEndpointHandleChains, "generic-handler-chains", o.GenericEndpointHandleChains,
 		"this flag defines the handler chains that should be enabled")
+	fs.StringVar(&o.PodSaleModeAnnotationKey, "pod-sale-mode-annotation-key", o.PodSaleModeAnnotationKey,
+		"The pod annotation key used to read pod sale mode.")
 
 	o.qosOptions.AddFlags(fs)
 	o.metricsOptions.AddFlags(fs)
@@ -111,6 +117,7 @@ func (o *GenericOptions) ApplyTo(c *generic.GenericConfiguration) error {
 
 	c.GenericEndpoint = o.GenericEndpoint
 	c.GenericEndpointHandleChains = o.GenericEndpointHandleChains
+	c.PodSaleModeAnnotationKey = o.PodSaleModeAnnotationKey
 
 	errList := make([]error, 0, 1)
 	errList = append(errList, o.qosOptions.ApplyTo(c.QoSConfiguration))

--- a/cmd/base/options/generic_test.go
+++ b/cmd/base/options/generic_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/generic"
+)
+
+func TestGenericOptionsApplyToPodSaleModeAnnotationKey(t *testing.T) {
+	t.Parallel()
+
+	options := NewGenericOptions()
+	assert.Equal(t, apiconsts.PodAnnotationSaleModeKey, options.PodSaleModeAnnotationKey)
+
+	conf := generic.NewGenericConfiguration()
+	err := options.ApplyTo(conf)
+
+	assert.NoError(t, err)
+	assert.Equal(t, apiconsts.PodAnnotationSaleModeKey, conf.PodSaleModeAnnotationKey)
+	assert.Equal(t, apiconsts.PodAnnotationSaleModeKey, conf.GetPodSaleModeAnnotationKey())
+}

--- a/cmd/katalyst-agent/app/options/eviction/eviction_base.go
+++ b/cmd/katalyst-agent/app/options/eviction/eviction_base.go
@@ -56,6 +56,9 @@ type GenericEvictionOptions struct {
 	// PodMetricLabels defines the pod labels to be added into metric selector list.
 	PodMetricLabels []string
 
+	// PodMetricAnnotations defines the pod annotations to be added into metric selector list.
+	PodMetricAnnotations []string
+
 	// RecordManager specifies the eviction record manager to use
 	RecordManager string
 
@@ -120,6 +123,8 @@ func (o *GenericEvictionOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 
 	fs.StringSliceVar(&o.PodMetricLabels, "eviction-pod-metric-labels", o.PodMetricLabels,
 		"The pod labels to be added into metric selector list")
+	fs.StringSliceVar(&o.PodMetricAnnotations, "eviction-pod-metric-annotations", o.PodMetricAnnotations,
+		"The pod annotations to be added into metric selector list")
 
 	fs.StringVar(&o.RecordManager, "eviction-record-manager", o.RecordManager,
 		"the eviction record manager to use")
@@ -151,6 +156,7 @@ func (o *GenericEvictionOptions) ApplyTo(c *evictionconfig.GenericEvictionConfig
 	c.QoSPodKillers = o.QoSPodKillers
 	c.StrictAuthentication = o.StrictAuthentication
 	c.PodMetricLabels.Insert(o.PodMetricLabels...)
+	c.PodMetricAnnotations.Insert(o.PodMetricAnnotations...)
 	c.RecordManager = o.RecordManager
 	c.HostPathNotifierRootPath = o.HostPathNotifierRootPath
 	c.EvictionExplicitTriggerAnnotationKey = o.EvictionExplicitTriggerAnnotationKey

--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,5 @@ replace (
 	k8s.io/sample-controller => k8s.io/sample-controller v0.24.6
 	sigs.k8s.io/json => sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6
 )
+
+replace github.com/kubewharf/katalyst-api => github.com/junyu-peng/katalyst-api v0.0.0-20260828082458-5f5fbd1fe3aa

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/junyu-peng/katalyst-api v0.0.0-20260828082458-5f5fbd1fe3aa h1:fFzlQPM8FEI3XRMNL+pwXoglB5NKAjDEi1yiAWELnVg=
+github.com/junyu-peng/katalyst-api v0.0.0-20260828082458-5f5fbd1fe3aa/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -574,8 +576,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.16-0.20260820100240-b8e6df7d8bd4 h1:MNJ+RPao+wh1b+zIZtgVOS0AEPhmb9fvOqPDdA4raEk=
-github.com/kubewharf/katalyst-api v0.5.16-0.20260820100240-b8e6df7d8bd4/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=

--- a/pkg/agent/evictionmanager/eviction_resp_collector.go
+++ b/pkg/agent/evictionmanager/eviction_resp_collector.go
@@ -97,7 +97,8 @@ func (e *evictionRespCollector) collectEvictPods(dryRunPlugins []string, pluginN
 			e.getLogPrefix(dryRun), pluginName, evictPod.Pod.Namespace, evictPod.Pod.Name, evictPod.Reason, evictPod.ForceEvict)
 
 		if dryRun {
-			metricsPodToEvict(e.emitter, e.conf.GenericConfiguration.QoSConfiguration, pluginName, evictPod.Pod, dryRun, e.conf.GenericEvictionConfiguration.PodMetricLabels)
+			metricsPodToEvict(e.emitter, e.conf.GenericConfiguration.QoSConfiguration, pluginName, evictPod.Pod, dryRun,
+				e.conf.GenericEvictionConfiguration.PodMetricLabels, e.conf.GenericEvictionConfiguration.PodMetricAnnotations)
 		} else {
 			evictPods = append(evictPods, resp.EvictPods[i])
 		}
@@ -183,7 +184,8 @@ func (e *evictionRespCollector) collectTopSoftEvictionPods(dryRunPlugins []strin
 		general.Infof("%v plugin %v request to notify topN pod %v/%v, reason: met threshold in scope [%v]",
 			e.getLogPrefix(dryRun), pluginName, pod.Namespace, pod.Name, threshold.EvictionScope)
 		if dryRun {
-			metricsPodToEvict(e.emitter, e.conf.GenericConfiguration.QoSConfiguration, pluginName, pod, dryRun, e.conf.GenericEvictionConfiguration.PodMetricLabels)
+			metricsPodToEvict(e.emitter, e.conf.GenericConfiguration.QoSConfiguration, pluginName, pod, dryRun,
+				e.conf.GenericEvictionConfiguration.PodMetricLabels, e.conf.GenericEvictionConfiguration.PodMetricAnnotations)
 		} else {
 			targetPods = append(targetPods, resp.TargetPods[i])
 		}
@@ -219,7 +221,8 @@ func (e *evictionRespCollector) collectTopEvictionPods(dryRunPlugins []string, p
 		general.Infof("%v plugin %v request to evict topN pod %v/%v, reason: met threshold in scope [%v]",
 			e.getLogPrefix(dryRun), pluginName, pod.Namespace, pod.Name, threshold.EvictionScope)
 		if dryRun {
-			metricsPodToEvict(e.emitter, e.conf.GenericConfiguration.QoSConfiguration, pluginName, pod, dryRun, e.conf.GenericEvictionConfiguration.PodMetricLabels)
+			metricsPodToEvict(e.emitter, e.conf.GenericConfiguration.QoSConfiguration, pluginName, pod, dryRun,
+				e.conf.GenericEvictionConfiguration.PodMetricLabels, e.conf.GenericEvictionConfiguration.PodMetricAnnotations)
 		} else {
 			targetPods = append(targetPods, resp.TargetPods[i])
 		}

--- a/pkg/agent/evictionmanager/manager.go
+++ b/pkg/agent/evictionmanager/manager.go
@@ -82,7 +82,8 @@ const (
 
 	UserUnknown = "unknown"
 
-	MetricsPodLabelPrefix = "pod"
+	MetricsPodLabelPrefix      = "pod"
+	MetricsPodAnnotationPrefix = "pod_anno"
 
 	evictionManagerHealthCheckName = "eviction_manager_sync"
 	reportTaintHealthCheckName     = "eviction_manager_report_taint"
@@ -559,7 +560,8 @@ func (m *EvictionManger) doEvict(softEvictPods, forceEvictPods map[string]*rule.
 	general.Infof(" evict %d pods in evictionmanager", len(rpList))
 	_ = m.emitter.StoreInt64(MetricsNameVictimPodCNT, int64(len(rpList)), metrics.MetricTypeNameRaw,
 		metrics.MetricTag{Key: "type", Val: "total"})
-	metricPodsToEvict(m.emitter, rpList, m.conf.GenericConfiguration.QoSConfiguration, m.conf.GenericEvictionConfiguration.PodMetricLabels)
+	metricPodsToEvict(m.emitter, rpList, m.conf.GenericConfiguration.QoSConfiguration,
+		m.conf.GenericEvictionConfiguration.PodMetricLabels, m.conf.GenericEvictionConfiguration.PodMetricAnnotations)
 	return nil
 }
 
@@ -878,7 +880,9 @@ func logConfirmedThresholdMet(thresholds map[string]*pluginapi.ThresholdMetRespo
 	}
 }
 
-func metricPodsToEvict(emitter metrics.MetricEmitter, rpList rule.RuledEvictPodList, qosConfig *generic.QoSConfiguration, podMetricLabels sets.String) {
+func metricPodsToEvict(emitter metrics.MetricEmitter, rpList rule.RuledEvictPodList, qosConfig *generic.QoSConfiguration,
+	podMetricLabels, podMetricAnnotations sets.String,
+) {
 	if emitter == nil {
 		general.Errorf(" metricPodsToEvict got nil emitter")
 		return
@@ -886,12 +890,14 @@ func metricPodsToEvict(emitter metrics.MetricEmitter, rpList rule.RuledEvictPodL
 
 	for _, rp := range rpList {
 		if rp != nil && rp.EvictionPluginName != "" {
-			metricsPodToEvict(emitter, qosConfig, rp.EvictionPluginName, rp.Pod, false, podMetricLabels)
+			metricsPodToEvict(emitter, qosConfig, rp.EvictionPluginName, rp.Pod, false, podMetricLabels, podMetricAnnotations)
 		}
 	}
 }
 
-func metricsPodToEvict(emitter metrics.MetricEmitter, qosConfig *generic.QoSConfiguration, pluginName string, pod *v1.Pod, dryRun bool, podMetricLabels sets.String) {
+func metricsPodToEvict(emitter metrics.MetricEmitter, qosConfig *generic.QoSConfiguration, pluginName string, pod *v1.Pod,
+	dryRun bool, podMetricLabels, podMetricAnnotations sets.String,
+) {
 	podQosLevel := "unknown"
 	if qosConfig != nil {
 		qosLevel, err := qosConfig.GetQoSLevelForPod(pod)
@@ -923,12 +929,29 @@ func metricsPodToEvict(emitter metrics.MetricEmitter, qosConfig *generic.QoSConf
 			}
 		}
 	}
+	for _, metricAnnotation := range podMetricAnnotations.List() {
+		metricValue := UserUnknown
+		if pod.Annotations != nil {
+			if val, ok := pod.Annotations[metricAnnotation]; ok && val != "" {
+				metricValue = val
+			}
+		}
+		metricTags = append(metricTags, metrics.MetricTag{
+			Key: genPodAnnotationMetricKey(metricAnnotation),
+			Val: metricValue,
+		})
+	}
 	_ = emitter.StoreInt64(metricKey, 1, metrics.MetricTypeNameRaw, metricTags...)
 }
 
 func genPodLabelMetricKey(key string) string {
 	key = strings.ReplaceAll(key, "-", "_")
 	return strings.Join([]string{MetricsPodLabelPrefix, key}, "_")
+}
+
+func genPodAnnotationMetricKey(key string) string {
+	key = strings.ReplaceAll(key, "-", "_")
+	return strings.Join([]string{MetricsPodAnnotationPrefix, key}, "_")
 }
 
 func genPodPriorityMetricValue(pod *v1.Pod) string {

--- a/pkg/agent/evictionmanager/manager_test.go
+++ b/pkg/agent/evictionmanager/manager_test.go
@@ -104,6 +104,40 @@ var (
 	}
 )
 
+type recordingMetricEmitter struct {
+	key      string
+	val      int64
+	emitType metrics.MetricTypeName
+	tags     []metrics.MetricTag
+}
+
+func (r *recordingMetricEmitter) StoreInt64(key string, val int64, emitType metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	r.key = key
+	r.val = val
+	r.emitType = emitType
+	r.tags = append([]metrics.MetricTag(nil), tags...)
+	return nil
+}
+
+func (r *recordingMetricEmitter) StoreFloat64(_ string, _ float64, _ metrics.MetricTypeName, _ ...metrics.MetricTag) error {
+	return nil
+}
+
+func (r *recordingMetricEmitter) WithTags(unit string, commonTags ...metrics.MetricTag) metrics.MetricEmitter {
+	wrapper := &metrics.MetricTagWrapper{MetricEmitter: r}
+	return wrapper.WithTags(unit, commonTags...)
+}
+
+func (r *recordingMetricEmitter) Run(_ context.Context) {}
+
+func metricTagsToMap(tags []metrics.MetricTag) map[string]string {
+	res := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		res[tag.Key] = tag.Val
+	}
+	return res
+}
+
 func makeConf() *config.Configuration {
 	conf := config.NewConfiguration()
 	conf.EvictionManagerSyncPeriod = evictionManagerSyncPeriod
@@ -735,4 +769,36 @@ func TestEvictionManager_Run(t *testing.T) {
 	assert.Contains(t, res, general.HealthzCheckName(reportCNRTaintHealthCheckName))
 	assert.Contains(t, res, general.HealthzCheckName(reportTaintHealthCheckName))
 	assert.Contains(t, res, general.HealthzCheckName(evictionManagerHealthCheckName))
+}
+
+func TestMetricsPodToEvictAddsPodMetricAnnotations(t *testing.T) {
+	t.Parallel()
+
+	emitter := &recordingMetricEmitter{}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "pod-1",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			Annotations: map[string]string{
+				apiconsts.PodAnnotationSaleModeKey: apiconsts.PodSaleModeSpot,
+			},
+		},
+	}
+
+	metricsPodToEvict(emitter, nil, "plugin-a", pod, false,
+		sets.NewString("app"),
+		sets.NewString(apiconsts.PodAnnotationSaleModeKey, "missing.annotation"))
+
+	assert.Equal(t, MetricsNameVictimPodCNT, emitter.key)
+	assert.Equal(t, int64(1), emitter.val)
+	assert.Equal(t, metrics.MetricTypeNameRaw, emitter.emitType)
+
+	tagMap := metricTagsToMap(emitter.tags)
+	assert.Equal(t, "plugin-a", tagMap["name"])
+	assert.Equal(t, "test", tagMap["pod_app"])
+	assert.Equal(t, apiconsts.PodSaleModeSpot, tagMap["pod_anno_"+apiconsts.PodAnnotationSaleModeKey])
+	assert.Equal(t, UserUnknown, tagMap["pod_anno_missing.annotation"])
 }

--- a/pkg/agent/evictionmanager/plugin/cpu/system_pressure.go
+++ b/pkg/agent/evictionmanager/plugin/cpu/system_pressure.go
@@ -414,7 +414,7 @@ func (s *SystemPressureEvictionPlugin) GetTopEvictionPods(
 		return &v1alpha1.GetTopEvictionPodsResponse{}, nil
 	}
 
-	candidatePods := request.ActivePods
+	candidatePods := native.NewPodSourceList(request.ActivePods)
 	if dynamicConfig.CheckCPUManager {
 		cpuManagerOn, err := s.checkKubeletCPUManager()
 		if err != nil {
@@ -423,7 +423,7 @@ func (s *SystemPressureEvictionPlugin) GetTopEvictionPods(
 			return nil, err
 		}
 		if cpuManagerOn {
-			candidatePods = native.FilterPods(request.GetActivePods(), func(pod *v1.Pod) (bool, error) {
+			candidatePods = candidatePods.Filter(func(pod *v1.Pod) (bool, error) {
 				if pod == nil {
 					return false, fmt.Errorf("FilterPods got nil pod")
 				}
@@ -435,17 +435,11 @@ func (s *SystemPressureEvictionPlugin) GetTopEvictionPods(
 		}
 	}
 
-	var (
-		topN     = general.MinUInt64(request.TopN, uint64(len(candidatePods)))
-		topNPods = make([]*v1.Pod, 0)
-	)
 	s.lastEvictionTime = now
 
-	general.NewMultiSorter(s.getEvictionCmpFunc(dynamicConfig)...).Sort(native.NewPodSourceImpList(candidatePods))
-
-	for i := 0; uint64(i) < topN; i++ {
-		topNPods = append(topNPods, candidatePods[i])
-	}
+	topNPods := candidatePods.
+		Sort(s.getEvictionCmpFunc(dynamicConfig)...).
+		TopN(request.TopN)
 
 	resp := &v1alpha1.GetTopEvictionPodsResponse{
 		TargetPods: topNPods,
@@ -457,7 +451,7 @@ func (s *SystemPressureEvictionPlugin) GetTopEvictionPods(
 	}
 
 	general.Infof("cpu system eviction get top (len=%d) pods: %v, candidate pods (len=%d): %v, over metric name: %s",
-		len(topNPods), native.GetNamespacedNameListFromSlice(topNPods), len(candidatePods), native.GetNamespacedNameListFromSlice(candidatePods), s.overMetricName)
+		len(topNPods), native.GetNamespacedNameListFromSlice(topNPods), candidatePods.Len(), native.GetNamespacedNameListFromSlice(candidatePods.Pods()), s.overMetricName)
 
 	s.overMetricName = ""
 	return resp, nil
@@ -524,6 +518,8 @@ func (s *SystemPressureEvictionPlugin) getEvictionCmpFunc(dynamicConfig *evictio
 				return s.cmpKatalystQoS(p1, p2)
 			case evictionconfig.FakeMetricPriority:
 				return general.ReverseCmpFunc(native.PodPriorityCmpFunc)(p1, p2)
+			case evictionconfig.FakeMetricSaleMode:
+				return native.NewPodSaleModeCmpFunc(s.podSaleModeAnnotationKey())(p1, p2)
 			default:
 				if labelKey, ok := s.splitKeyFromFakeLabelMetric(currentMetric); ok {
 					return s.cmpSpecifiedLabels(dynamicConfig, p1, p2, labelKey)
@@ -535,6 +531,14 @@ func (s *SystemPressureEvictionPlugin) getEvictionCmpFunc(dynamicConfig *evictio
 	}
 
 	return cmpFuncs
+}
+
+func (s *SystemPressureEvictionPlugin) podSaleModeAnnotationKey() string {
+	if s.conf == nil || s.conf.GenericConfiguration == nil {
+		return ""
+	}
+
+	return s.conf.GenericConfiguration.GetPodSaleModeAnnotationKey()
 }
 
 func (s *SystemPressureEvictionPlugin) cmpMetric(metricName string, p1, p2 *v1.Pod) int {
@@ -591,7 +595,8 @@ func (s *SystemPressureEvictionPlugin) mergeCollectMetrics(dynamicConfig *evicti
 	for _, metricName := range dynamicConfig.EvictionRankingMetrics {
 		switch metricName {
 		case evictionconfig.FakeMetricPriority,
-			evictionconfig.FakeMetricQoSLevel:
+			evictionconfig.FakeMetricQoSLevel,
+			evictionconfig.FakeMetricSaleMode:
 			// skip all built-in fake metrics
 			continue
 		default:

--- a/pkg/agent/evictionmanager/plugin/cpu/system_pressure_test.go
+++ b/pkg/agent/evictionmanager/plugin/cpu/system_pressure_test.go
@@ -510,6 +510,10 @@ func TestCPUSystemPressureEvictionPlugin_collectMetrics_PodAggregated(t *testing
 
 // makeRankPod is a helper to construct a pod for ranking tests.
 func makeRankPod(name string, qosLevel string, priority *int32) *v1.Pod {
+	return makeRankPodWithSaleMode(name, qosLevel, priority, "")
+}
+
+func makeRankPodWithSaleMode(name string, qosLevel string, priority *int32, saleMode string) *v1.Pod {
 	p := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -519,10 +523,15 @@ func makeRankPod(name string, qosLevel string, priority *int32) *v1.Pod {
 			Priority: priority,
 		},
 	}
+	annotations := map[string]string{}
 	if qosLevel != "" {
-		p.Annotations = map[string]string{
-			apiconsts.PodAnnotationQoSLevelKey: qosLevel,
-		}
+		annotations[apiconsts.PodAnnotationQoSLevelKey] = qosLevel
+	}
+	if saleMode != "" {
+		annotations[apiconsts.PodAnnotationSaleModeKey] = saleMode
+	}
+	if len(annotations) > 0 {
+		p.Annotations = annotations
 	}
 	return p
 }
@@ -593,7 +602,20 @@ func TestCPUSystemPressureEvictionPlugin_GetTopEvictionPods_RankByQoSAndPriority
 			expectedFirst: "shared-low",
 		},
 		{
-			name:           "tie on QoS+Priority: fall back to overMetricName appended at the end",
+			name:           "default ranking: same QoS and priority, spot sale mode evicted first",
+			rankingMetrics: evictionconfig.DefaultEvictionRankingMetrics,
+			overMetricName: consts.MetricLoad1MinContainer,
+			pods: []*v1.Pod{
+				makeRankPodWithSaleMode("reserved", apiconsts.PodAnnotationQoSLevelSharedCores, &prioHigh, apiconsts.PodSaleModeReserved),
+				makeRankPodWithSaleMode("spot", apiconsts.PodAnnotationQoSLevelSharedCores, &prioHigh, apiconsts.PodSaleModeSpot),
+			},
+			topN: 1,
+			// even though reserved has higher metric value, spot wins by sale mode
+			metricVals:    map[string]float64{"reserved": 100, "spot": 1},
+			expectedFirst: "spot",
+		},
+		{
+			name:           "tie on QoS+Priority+SaleMode: fall back to overMetricName appended at the end",
 			rankingMetrics: evictionconfig.DefaultEvictionRankingMetrics,
 			overMetricName: consts.MetricLoad1MinContainer,
 			pods: []*v1.Pod{

--- a/pkg/agent/evictionmanager/plugin/memory/helper.go
+++ b/pkg/agent/evictionmanager/plugin/memory/helper.go
@@ -76,16 +76,18 @@ const (
 
 // EvictionHelper is a general tool collection for all memory eviction plugin
 type EvictionHelper struct {
-	metaServer         *metaserver.MetaServer
-	emitter            metrics.MetricEmitter
-	reclaimedPodFilter func(pod *v1.Pod) (bool, error)
+	metaServer                     *metaserver.MetaServer
+	emitter                        metrics.MetricEmitter
+	reclaimedPodFilter             func(pod *v1.Pod) (bool, error)
+	podSaleModeAnnotationKeyGetter native.PodSaleModeAnnotationKeyGetter
 }
 
 func NewEvictionHelper(emitter metrics.MetricEmitter, metaServer *metaserver.MetaServer, conf *config.Configuration) *EvictionHelper {
 	return &EvictionHelper{
-		metaServer:         metaServer,
-		emitter:            emitter,
-		reclaimedPodFilter: conf.CheckReclaimedQoSForPod,
+		metaServer:                     metaServer,
+		emitter:                        emitter,
+		reclaimedPodFilter:             conf.CheckReclaimedQoSForPod,
+		podSaleModeAnnotationKeyGetter: conf.GenericConfiguration,
 	}
 }
 
@@ -94,9 +96,11 @@ func (e *EvictionHelper) selectTopNPodsToEvictByMetrics(activePods []*v1.Pod, to
 ) {
 	filteredPods := e.filterPods(activePods, action)
 	if filteredPods != nil {
-		general.NewMultiSorter(e.getEvictionCmpFuncs(rankingMetrics, numaID)...).Sort(native.NewPodSourceImpList(filteredPods))
-		for i := 0; uint64(i) < general.MinUInt64(topN, uint64(len(filteredPods))); i++ {
-			podToEvictMap[string(filteredPods[i].UID)] = filteredPods[i]
+		topNPods := native.NewPodSourceList(filteredPods).
+			Sort(e.getEvictionCmpFuncs(rankingMetrics, numaID)...).
+			TopN(topN)
+		for _, pod := range topNPods {
+			podToEvictMap[string(pod.UID)] = pod
 		}
 	}
 }
@@ -142,6 +146,9 @@ func (e *EvictionHelper) getEvictionCmpFuncs(rankingMetrics []string, numaID int
 			case evictionconfig.FakeMetricPriority:
 				// prioritize evicting the pod whose priority is lower
 				return general.ReverseCmpFunc(native.PodPriorityCmpFunc)(p1, p2)
+			case evictionconfig.FakeMetricSaleMode:
+				// prioritize evicting the pod whose sale mode has lower eviction rank
+				return native.NewPodSaleModeCmpFunc(e.podSaleModeAnnotationKey())(p1, p2)
 			default:
 				p1Metric, p1Err := helper.GetPodMetric(e.metaServer.MetricsFetcher, e.emitter, p1, currentMetric, numaID)
 				p2Metric, p2Err := helper.GetPodMetric(e.metaServer.MetricsFetcher, e.emitter, p2, currentMetric, numaID)
@@ -163,6 +170,14 @@ func (e *EvictionHelper) getEvictionCmpFuncs(rankingMetrics []string, numaID int
 	}
 
 	return cmpFuncs
+}
+
+func (e *EvictionHelper) podSaleModeAnnotationKey() string {
+	if e.podSaleModeAnnotationKeyGetter == nil {
+		return ""
+	}
+
+	return e.podSaleModeAnnotationKeyGetter.GetPodSaleModeAnnotationKey()
 }
 
 // getCandidates returns pods which use memory more than minimumUsageThreshold.

--- a/pkg/agent/evictionmanager/plugin/memory/helper_test.go
+++ b/pkg/agent/evictionmanager/plugin/memory/helper_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+	evictionconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/adminqos/eviction"
 	"github.com/kubewharf/katalyst-core/pkg/consts"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent/metric"
@@ -235,4 +236,39 @@ func TestEvictionHelper_getEvictionCmpFuncs(t *testing.T) {
 	for i := range pods {
 		assert.Equal(t, wantPodNameList[i], pods[i].Name)
 	}
+}
+
+func TestEvictionHelper_getEvictionCmpFuncs_SaleMode(t *testing.T) {
+	t.Parallel()
+
+	metaServer := makeMetaServer()
+	helper, err := makeHelper(metaServer)
+	assert.NoError(t, err)
+	assert.NotNil(t, helper)
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "000001",
+				Name: "reserved",
+				Annotations: map[string]string{
+					apiconsts.PodAnnotationSaleModeKey: apiconsts.PodSaleModeReserved,
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:  "000002",
+				Name: "spot",
+				Annotations: map[string]string{
+					apiconsts.PodAnnotationSaleModeKey: apiconsts.PodSaleModeSpot,
+				},
+			},
+		},
+	}
+
+	general.NewMultiSorter(helper.getEvictionCmpFuncs([]string{evictionconfig.FakeMetricSaleMode}, nonExistNumaID)...).
+		Sort(native.NewPodSourceImpList(pods))
+
+	assert.Equal(t, []string{"spot", "reserved"}, []string{pods[0].Name, pods[1].Name})
 }

--- a/pkg/config/agent/dynamic/adminqos/eviction/eviction_base.go
+++ b/pkg/config/agent/dynamic/adminqos/eviction/eviction_base.go
@@ -22,10 +22,11 @@ import "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
 const (
 	FakeMetricQoSLevel = "qos.pod"
 	FakeMetricPriority = "priority.pod"
+	FakeMetricSaleMode = "sale_mode.pod"
 )
 
 // DefaultEvictionRankingMetrics is the default ranking metrics for eviction
-var DefaultEvictionRankingMetrics = []string{FakeMetricQoSLevel, FakeMetricPriority}
+var DefaultEvictionRankingMetrics = []string{FakeMetricQoSLevel, FakeMetricPriority, FakeMetricSaleMode}
 
 type EvictionConfiguration struct {
 	// Dryrun plugins is the list of plugins to dryrun

--- a/pkg/config/agent/eviction/eviciton_base.go
+++ b/pkg/config/agent/eviction/eviciton_base.go
@@ -55,6 +55,9 @@ type GenericEvictionConfiguration struct {
 	// PodMetricLabels defines the pod labels to be added in metric selector lists
 	PodMetricLabels sets.String
 
+	// PodMetricAnnotations defines the pod annotations to be added in metric selector lists
+	PodMetricAnnotations sets.String
+
 	// RecordManager specifies the eviction record manager to use
 	RecordManager string
 
@@ -82,6 +85,7 @@ func NewGenericEvictionConfiguration() *GenericEvictionConfiguration {
 		EvictionSkippedAnnotationKeys: sets.NewString(),
 		EvictionSkippedLabelKeys:      sets.NewString(),
 		PodMetricLabels:               sets.NewString(),
+		PodMetricAnnotations:          sets.NewString(),
 	}
 }
 

--- a/pkg/config/generic/generic_base.go
+++ b/pkg/config/generic/generic_base.go
@@ -18,6 +18,8 @@ package generic
 
 import (
 	componentbaseconfig "k8s.io/component-base/config"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 )
 
 // GenericConfiguration stores all the generic configurations needed
@@ -32,6 +34,7 @@ type GenericConfiguration struct {
 
 	GenericEndpoint             string
 	GenericEndpointHandleChains []string
+	PodSaleModeAnnotationKey    string
 
 	*QoSConfiguration
 	*MetricsConfiguration
@@ -46,10 +49,19 @@ type GenericConfiguration struct {
 // NewGenericConfiguration creates a new generic configuration.
 func NewGenericConfiguration() *GenericConfiguration {
 	return &GenericConfiguration{
-		DryRun:               false,
-		QoSConfiguration:     NewQoSConfiguration(),
-		MetricsConfiguration: NewMetricsConfiguration(),
-		AuthConfiguration:    NewAuthConfiguration(),
-		LogConfiguration:     NewLogConfiguration(),
+		DryRun:                   false,
+		PodSaleModeAnnotationKey: apiconsts.PodAnnotationSaleModeKey,
+		QoSConfiguration:         NewQoSConfiguration(),
+		MetricsConfiguration:     NewMetricsConfiguration(),
+		AuthConfiguration:        NewAuthConfiguration(),
+		LogConfiguration:         NewLogConfiguration(),
 	}
+}
+
+func (c *GenericConfiguration) GetPodSaleModeAnnotationKey() string {
+	if c == nil || c.PodSaleModeAnnotationKey == "" {
+		return apiconsts.PodAnnotationSaleModeKey
+	}
+
+	return c.PodSaleModeAnnotationKey
 }

--- a/pkg/util/native/pod_sorter.go
+++ b/pkg/util/native/pod_sorter.go
@@ -19,21 +19,96 @@ package native
 import (
 	v1 "k8s.io/api/core/v1"
 
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
+
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"k8s.io/klog/v2"
 
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
+)
+
+var (
+	podQoSRank = map[string]int{
+		apiconsts.PodAnnotationQoSLevelReclaimedCores: 0,
+		apiconsts.PodAnnotationQoSLevelSharedCores:    1,
+		apiconsts.PodAnnotationQoSLevelDedicatedCores: 2,
+		apiconsts.PodAnnotationQoSLevelSystemCores:    3,
+	}
+
+	podSaleModeRank = map[string]int{
+		apiconsts.PodSaleModeSpot:      0,
+		apiconsts.PodSaleModeScheduled: 1,
+		apiconsts.PodSaleModeReserved:  2,
+		apiconsts.PodSaleModeUnknown:   3,
+	}
 )
 
 type PodSourceList struct {
 	pods []*v1.Pod
 }
 
+type PodSaleModeAnnotationKeyGetter interface {
+	GetPodSaleModeAnnotationKey() string
+}
+
 var _ general.SourceList = &PodSourceList{}
+
+func NewPodSourceList(pods []*v1.Pod) *PodSourceList {
+	return &PodSourceList{
+		pods: append([]*v1.Pod(nil), pods...),
+	}
+}
 
 func NewPodSourceImpList(pods []*v1.Pod) general.SourceList {
 	return &PodSourceList{
 		pods: pods,
 	}
+}
+
+func (pl *PodSourceList) Filter(filterFunc func(*v1.Pod) (bool, error)) *PodSourceList {
+	if filterFunc == nil {
+		return &PodSourceList{
+			pods: append([]*v1.Pod(nil), pl.pods...),
+		}
+	}
+
+	filteredPods := make([]*v1.Pod, 0, len(pl.pods))
+	for _, pod := range pl.pods {
+		if pod == nil {
+			continue
+		}
+
+		if ok, err := filterFunc(pod); err != nil {
+			klog.Errorf("filter pod %v err: %v", pod.Name, err)
+		} else if ok {
+			filteredPods = append(filteredPods, pod)
+		}
+	}
+
+	return &PodSourceList{
+		pods: filteredPods,
+	}
+}
+
+func (pl *PodSourceList) Sort(cmp ...general.CmpFunc) *PodSourceList {
+	if len(cmp) == 0 {
+		return pl
+	}
+
+	general.NewMultiSorter(cmp...).Sort(pl)
+	return pl
+}
+
+func (pl *PodSourceList) TopN(n uint64) []*v1.Pod {
+	if n > uint64(len(pl.pods)) {
+		n = uint64(len(pl.pods))
+	}
+
+	return append([]*v1.Pod(nil), pl.pods[:n]...)
+}
+
+func (pl *PodSourceList) Pods() []*v1.Pod {
+	return append([]*v1.Pod(nil), pl.pods...)
 }
 
 func (pl *PodSourceList) Len() int {
@@ -67,6 +142,32 @@ func PodCPURequestCmpFunc(i1, i2 interface{}) int {
 	return p1CPUQuantity.Cmp(p2CPUQuantity)
 }
 
+// PodQoSCmpFunc sorts pods by eviction QoS priority.
+func PodQoSCmpFunc(i1, i2 interface{}) int {
+	p1, p2 := i1.(*v1.Pod), i2.(*v1.Pod)
+
+	return cmpRank(getPodQoSRank(p1), getPodQoSRank(p2))
+}
+
+// PodSaleModeCmpFunc sorts pods by eviction sale mode priority.
+func PodSaleModeCmpFunc(i1, i2 interface{}) int {
+	p1, p2 := i1.(*v1.Pod), i2.(*v1.Pod)
+
+	return cmpRank(getPodSaleModeRank(p1, apiconsts.PodAnnotationSaleModeKey), getPodSaleModeRank(p2, apiconsts.PodAnnotationSaleModeKey))
+}
+
+func NewPodSaleModeCmpFunc(annotationKey string) general.CmpFunc {
+	if annotationKey == "" {
+		annotationKey = apiconsts.PodAnnotationSaleModeKey
+	}
+
+	return func(i1, i2 interface{}) int {
+		p1, p2 := i1.(*v1.Pod), i2.(*v1.Pod)
+
+		return cmpRank(getPodSaleModeRank(p1, annotationKey), getPodSaleModeRank(p2, annotationKey))
+	}
+}
+
 // PodUniqKeyCmpFunc sorts uniq key of pod with greater comparison
 func PodUniqKeyCmpFunc(i1, i2 interface{}) int {
 	p1UniqKey := GenerateUniqObjectNameKey(i1.(*v1.Pod))
@@ -75,8 +176,44 @@ func PodUniqKeyCmpFunc(i1, i2 interface{}) int {
 	return general.CmpString(p1UniqKey, p2UniqKey)
 }
 
+func getPodQoSRank(pod *v1.Pod) int {
+	if pod == nil {
+		return len(podQoSRank)
+	}
+
+	if rank, ok := podQoSRank[pod.Annotations[apiconsts.PodAnnotationQoSLevelKey]]; ok {
+		return rank
+	}
+
+	return len(podQoSRank)
+}
+
+func getPodSaleModeRank(pod *v1.Pod, annotationKey string) int {
+	if pod == nil {
+		return len(podSaleModeRank)
+	}
+
+	if rank, ok := podSaleModeRank[pod.Annotations[annotationKey]]; ok {
+		return rank
+	}
+
+	return podSaleModeRank[apiconsts.PodSaleModeUnknown]
+}
+
+func cmpRank(rank1, rank2 int) int {
+	if rank1 == rank2 {
+		return 0
+	}
+	if rank1 < rank2 {
+		return -1
+	}
+	return 1
+}
+
 var (
 	_ general.CmpFunc = PodPriorityCmpFunc
 	_ general.CmpFunc = PodCPURequestCmpFunc
+	_ general.CmpFunc = PodQoSCmpFunc
+	_ general.CmpFunc = PodSaleModeCmpFunc
 	_ general.CmpFunc = PodUniqKeyCmpFunc
 )

--- a/pkg/util/native/pod_sorter_test.go
+++ b/pkg/util/native/pod_sorter_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiconsts "github.com/kubewharf/katalyst-api/pkg/consts"
 )
 
 func TestPodUniqKeyCmpFunc(t *testing.T) {
@@ -98,4 +100,124 @@ func TestPodUniqKeyCmpFunc(t *testing.T) {
 			assert.Equalf(t, tt.want, PodUniqKeyCmpFunc(tt.args.i1, tt.args.i2), "PodUniqKeyCmpFunc(%v, %v)", tt.args.i1, tt.args.i2)
 		})
 	}
+}
+
+func TestPodQoSCmpFunc(t *testing.T) {
+	t.Parallel()
+
+	pods := []*v1.Pod{
+		makePodSorterTestPod("unknown", "unknown", ""),
+		makePodSorterTestPod("system", apiconsts.PodAnnotationQoSLevelSystemCores, ""),
+		makePodSorterTestPod("dedicated", apiconsts.PodAnnotationQoSLevelDedicatedCores, ""),
+		makePodSorterTestPod("shared", apiconsts.PodAnnotationQoSLevelSharedCores, ""),
+		makePodSorterTestPod("reclaimed", apiconsts.PodAnnotationQoSLevelReclaimedCores, ""),
+	}
+
+	sortedPods := NewPodSourceList(pods).Sort(PodQoSCmpFunc).Pods()
+
+	assert.Equal(t, []string{"reclaimed", "shared", "dedicated", "system", "unknown"}, podNamesForSourceListTest(sortedPods))
+}
+
+func TestPodSaleModeCmpFunc(t *testing.T) {
+	t.Parallel()
+
+	pods := []*v1.Pod{
+		makePodSorterTestPod("unknown", "", "default"),
+		makePodSorterTestPod("reserved", "", apiconsts.PodSaleModeReserved),
+		makePodSorterTestPod("scheduled", "", apiconsts.PodSaleModeScheduled),
+		makePodSorterTestPod("spot", "", apiconsts.PodSaleModeSpot),
+	}
+
+	sortedPods := NewPodSourceList(pods).Sort(PodSaleModeCmpFunc, PodUniqKeyCmpFunc).Pods()
+
+	assert.Equal(t, []string{"spot", "scheduled", "reserved", "unknown"}, podNamesForSourceListTest(sortedPods))
+}
+
+func TestNewPodSaleModeCmpFuncUsesCustomAnnotationKey(t *testing.T) {
+	t.Parallel()
+
+	customAnnotationKey := "custom.sale.mode"
+	pods := []*v1.Pod{
+		makePodSorterTestPod("default-key-spot", "", apiconsts.PodSaleModeSpot),
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "namespace-1",
+				Name:      "custom-key-spot",
+				Annotations: map[string]string{
+					customAnnotationKey: apiconsts.PodSaleModeSpot,
+				},
+			},
+		},
+	}
+
+	sortedPods := NewPodSourceList(pods).Sort(NewPodSaleModeCmpFunc(customAnnotationKey), PodUniqKeyCmpFunc).Pods()
+
+	assert.Equal(t, []string{"custom-key-spot", "default-key-spot"}, podNamesForSourceListTest(sortedPods))
+}
+
+func TestNewPodSourceListCopiesPodsBeforeSort(t *testing.T) {
+	t.Parallel()
+
+	pods := []*v1.Pod{
+		makePodForSourceListTest("pod-c"),
+		makePodForSourceListTest("pod-a"),
+		makePodForSourceListTest("pod-b"),
+	}
+
+	sortedPods := NewPodSourceList(pods).Sort(PodUniqKeyCmpFunc).Pods()
+
+	assert.Equal(t, []string{"pod-c", "pod-b", "pod-a"}, podNamesForSourceListTest(sortedPods))
+	assert.Equal(t, []string{"pod-c", "pod-a", "pod-b"}, podNamesForSourceListTest(pods))
+}
+
+func TestPodSourceListFilterCopiesPodsBeforeSort(t *testing.T) {
+	t.Parallel()
+
+	pods := []*v1.Pod{
+		makePodForSourceListTest("pod-c"),
+		makePodForSourceListTest("pod-a"),
+		makePodForSourceListTest("pod-b"),
+	}
+
+	filteredPods := NewPodSourceList(pods).Filter(func(pod *v1.Pod) (bool, error) {
+		return pod.Name != "pod-a", nil
+	}).Sort(PodUniqKeyCmpFunc).TopN(1)
+
+	assert.Equal(t, []string{"pod-c"}, podNamesForSourceListTest(filteredPods))
+	assert.Equal(t, []string{"pod-c", "pod-a", "pod-b"}, podNamesForSourceListTest(pods))
+}
+
+func makePodForSourceListTest(name string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace-1",
+			Name:      name,
+		},
+	}
+}
+
+func makePodSorterTestPod(name, qosLevel, saleMode string) *v1.Pod {
+	annotations := map[string]string{}
+	if qosLevel != "" {
+		annotations[apiconsts.PodAnnotationQoSLevelKey] = qosLevel
+	}
+	if saleMode != "" {
+		annotations[apiconsts.PodAnnotationSaleModeKey] = saleMode
+	}
+
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "namespace-1",
+			Name:        name,
+			Annotations: annotations,
+		},
+	}
+}
+
+func podNamesForSourceListTest(pods []*v1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	return names
 }


### PR DESCRIPTION
Add sale mode as a default eviction ranking metric for CPU and memory eviction paths, with configurable annotation key support and ranking tests.

#### What type of PR is this?

Features

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Adds `FakeMetricSaleMode` to the default CPU and memory eviction ranking metrics.
- Changes eviction order by ranking pods by QoS, priority, sale mode, and fallback metrics.
- Uses `PodSourceList` for safe candidate filtering, sorting, and `TopN` selection.
- Supports custom sale mode annotation keys through `pod-sale-mode-annotation-key` and `GenericConfiguration`.
- Exports selected pod annotations in eviction metrics with the `pod_anno_` prefix. Missing values use `unknown`.
- Adds tests for ranking, custom keys, source-list behavior, default configuration, and annotation metrics.
- Updates `katalyst-api` and adds a `go.mod` replace directive for a fork. Verify dependency provenance and release reproducibility.
- The main rollout risks are changed agent eviction behavior and increased metric cardinality. Controller, scheduler, and release wiring are not affected.

### 简体中文

- 将 `FakeMetricSaleMode` 添加到 CPU 和 memory eviction 的默认 ranking metrics。
- 按 QoS、priority、sale mode 和 fallback metrics 调整 eviction 顺序。
- 使用 `PodSourceList` 安全地执行 candidate filtering、sorting 和 `TopN` 选择。
- 通过 `pod-sale-mode-annotation-key` 和 `GenericConfiguration` 支持自定义 sale mode annotation key。
- 使用 `pod_anno_` 前缀将选定的 pod annotations 导出到 eviction metrics。缺失值使用 `unknown`。
- 添加 ranking、自定义 key、source-list 行为、默认配置和 annotation metrics 测试。
- 更新 `katalyst-api`，并在 `go.mod` 中添加指向 fork 的 replace directive。需要验证依赖来源和 release 可复现性。
- 主要 rollout 风险是 agent eviction 行为变化和 metric cardinality 增加。不影响 controller、scheduler 和 release wiring。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->