### PR TITLE
fix(thpmode): remove extra validation from normalizeTHPMode

### DIFF
--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
@@ -95,6 +95,8 @@ func SetMemTHP(conf *coreconfig.Configuration,
 	}
 	general.Infof("SetMemTHP: EnableFragMem enabled")
 
+	// Validation of the mode is done in setTHPModeAtPath, which is the only place before we write to the sysfs.
+	// THPDefaultConfig accepts any write-valid mode, including advise and deny.
 	mode := normalizeTHPMode(fragMemConf.THPDefaultConfig)
 	// If THPDefaultConfig is empty, skip THP tuning entirely.
 	if mode == "" {
@@ -271,12 +273,5 @@ func setTHPModeAtPath(path, mode string) error {
 }
 
 func normalizeTHPMode(mode string) string {
-	m := strings.TrimSpace(strings.ToLower(mode))
-	switch m {
-	case "", thpModeMadvise, thpModeAlways, thpModeNever:
-		return m
-	default:
-		general.Warningf("invalid THPDefaultConfig %q, expect madvise/always/never, skip THP tuning", mode)
-		return ""
-	}
+	return strings.TrimSpace(strings.ToLower(mode))
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/Enhancements
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### English

- `normalizeTHPMode` now trims whitespace and converts input to lowercase without restricting values.
- `setTHPModeAtPath` remains responsible for validating THP modes before sysfs writes.
- This change affects the agent memory `fragmem` THP handler only.
- No controller, scheduler, release wiring, configuration, or dependency changes are included.
- Operational risk is low. Invalid modes remain rejected before application.

### 简体中文

- `normalizeTHPMode` 现在只去除空白并将输入转换为小写，不再限制输入值。
- `setTHPModeAtPath` 仍负责在写入 sysfs 前校验 THP mode。
- 此变更仅影响 agent memory `fragmem` THP handler。
- 未涉及 controller、scheduler、release wiring、配置或依赖变更。
- 运行风险较低。无效 mode 仍会在应用前被拒绝。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->