### PR TITLE
feat(thpmode): add static THP config policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 )
 
 replace (
+	github.com/kubewharf/katalyst-api => github.com/lubinszARM/katalyst-api v1.0.1-0.20260911084020-545ecc923aa5
 	k8s.io/api => k8s.io/api v0.24.6
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.6
 	k8s.io/apimachinery => k8s.io/apimachinery v0.24.6

--- a/go.sum
+++ b/go.sum
@@ -574,8 +574,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubewharf/katalyst-api v0.5.16-0.20260821030437-30cad9a7d51d h1:CHQRg9HbxzWl+K4S47jA2aFDSH6iL8KIHDvJLQvXtBs=
-github.com/kubewharf/katalyst-api v0.5.16-0.20260821030437-30cad9a7d51d/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3 h1:oFwpVVeDESqgzkse3iSODzHRKX495VvUgslu2hhepCc=
 github.com/kubewharf/kubelet v1.24.6-kubewharf-pre.3/go.mod h1:MxbSZUx3wXztFneeelwWWlX7NAAStJ6expqq7gY2J3c=
 github.com/kyoh86/exportloopref v0.1.7/go.mod h1:h1rDl2Kdj97+Kwh4gdz3ujE7XHmH51Q0lUiZ1z4NLj8=
@@ -587,6 +585,8 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lpabon/godbc v0.1.1/go.mod h1:Jo9QV0cf3U6jZABgiJ2skINAXb9j8m51r07g4KI92ZA=
+github.com/lubinszARM/katalyst-api v1.0.1-0.20260911084020-545ecc923aa5 h1:sPysgdCW03DvmHhT/v3vqJ7p5QhkNRDgoJHc7v3zK6E=
+github.com/lubinszARM/katalyst-api v1.0.1-0.20260911084020-545ecc923aa5/go.mod h1:BZMVGVl3EP0eCn5xsDgV41/gjYkoh43abIYxrB10e3k=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
+	apiconfig "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
 	memconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/consts"
 	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/config/agent"
@@ -52,6 +53,22 @@ func makeTHPConf(defaultConfig string, threshold int) (*coreconfig.Configuration
 	dynamicConf.GetDynamicConfiguration().FragMemConfiguration.EnableFragMem = true
 	dynamicConf.GetDynamicConfiguration().FragMemConfiguration.THPDefaultConfig = defaultConfig
 	dynamicConf.GetDynamicConfiguration().FragMemConfiguration.THPHighOrderScoreThreshold = threshold
+
+	return &coreconfig.Configuration{
+		AgentConfiguration: &agent.AgentConfiguration{
+			DynamicAgentConfiguration: dynamicConf,
+		},
+	}, dynamicConf
+}
+
+func makeStaticTHPConf(enable bool, thp apiconfig.THPMode, thpShm apiconfig.THPShmMode) (*coreconfig.Configuration, *dynamicconfig.DynamicAgentConfiguration) {
+	dynamicConf := dynamicconfig.NewDynamicAgentConfiguration()
+	dynamicConf.GetDynamicConfiguration().FragMemConfiguration.EnableFragMem = true
+	dynamicConf.GetDynamicConfiguration().FragMemConfiguration.THPStaticEnableConfig = &dynamicqrm.THPStaticEnableConfiguration{
+		Enable: enable,
+		THP:    thp,
+		THPShm: thpShm,
+	}
 
 	return &coreconfig.Configuration{
 		AgentConfiguration: &agent.AgentConfiguration{
@@ -157,6 +174,36 @@ func TestSetMemTHP(t *testing.T) {
 	check, ok := res[general.HealthzCheckName(memconsts.SetMemTHP)]
 	assert.True(t, ok)
 	assert.True(t, check.Ready)
+}
+
+func TestSetMemTHPStaticEnableConfig(t *testing.T) {
+	t.Parallel()
+
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
+
+	oldEnabledPath := thpEnabledPath
+	oldShmemPath := thpShmemEnabledPath
+	f := createTempFile(t, "always [madvise] never\n")
+	shmemFile := createTempFile(t, "always within_size [advise] never deny force\n")
+	defer os.Remove(f)
+	defer os.Remove(shmemFile)
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		thpShmemEnabledPath = oldShmemPath
+	}()
+	thpEnabledPath = f
+	thpShmemEnabledPath = shmemFile
+
+	conf, dynamicConf := makeStaticTHPConf(true, apiconfig.THPModeAlways, apiconfig.THPShmModeForce)
+	SetMemTHP(conf, nil, dynamicConf, nil, nil)
+
+	b, err := os.ReadFile(f)
+	assert.NoError(t, err)
+	assert.Equal(t, "always\n", string(b))
+	b, err = os.ReadFile(shmemFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "force\n", string(b))
 }
 
 func TestSetMemTHP_HotUpdateEnableFragMem(t *testing.T) {
@@ -351,6 +398,29 @@ func TestGetHighOrderThreshold(t *testing.T) {
 	assert.InDelta(t, 1.0, getHighOrderThreshold(&dynamicqrm.FragMemConfiguration{THPDefaultConfig: "madvise", THPHighOrderScoreThreshold: 1}), 1e-6)
 }
 
+func TestGetStaticTHPModes(t *testing.T) {
+	t.Parallel()
+
+	enabled, thpMode, thpShmMode := getStaticTHPModes(nil)
+	assert.False(t, enabled)
+	assert.Equal(t, "", thpMode)
+	assert.Equal(t, "", thpShmMode)
+
+	enabled, thpMode, thpShmMode = getStaticTHPModes(&dynamicqrm.FragMemConfiguration{
+		THPStaticEnableConfig: &dynamicqrm.THPStaticEnableConfiguration{Enable: true},
+	})
+	assert.True(t, enabled)
+	assert.Equal(t, "madvise", thpMode)
+	assert.Equal(t, "advise", thpShmMode)
+
+	enabled, thpMode, thpShmMode = getStaticTHPModes(&dynamicqrm.FragMemConfiguration{
+		THPStaticEnableConfig: &dynamicqrm.THPStaticEnableConfiguration{Enable: true, THP: apiconfig.THPModeAlways, THPShm: apiconfig.THPShmModeWithinSize},
+	})
+	assert.True(t, enabled)
+	assert.Equal(t, "always", thpMode)
+	assert.Equal(t, "within_size", thpShmMode)
+}
+
 func TestDisableTHPAtPath(t *testing.T) {
 	t.Parallel()
 
@@ -453,6 +523,18 @@ func TestSetTHPModeAtPathInvalid(t *testing.T) {
 	defer os.Remove(f)
 	err := setTHPModeAtPath(f, "invalid")
 	assert.Error(t, err)
+}
+
+func TestSetTHPModeAtPathForce(t *testing.T) {
+	t.Parallel()
+
+	f := createTempFile(t, "always within_size advise never deny [force]\n")
+	defer os.Remove(f)
+	err := setTHPModeAtPath(f, "force")
+	assert.NoError(t, err)
+	b, rerr := os.ReadFile(f)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "always within_size advise never deny [force]\n", string(b))
 }
 
 func TestDecideTHPDecision(t *testing.T) {

--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
@@ -27,6 +27,7 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 
+	apiconfig "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
 	memconsts "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/memory/consts"
 	coreconfig "github.com/kubewharf/katalyst-core/pkg/config"
 	dynamicconfig "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic"
@@ -40,12 +41,6 @@ import (
 )
 
 const (
-	thpModeAdvise  = "advise"
-	thpModeDeny    = "deny"
-	thpModeMadvise = "madvise"
-	thpModeAlways  = "always"
-	thpModeNever   = "never"
-
 	defaultHighOrderThreshold = 85.0
 
 	// hysteresisRatio adds hysteresis between disable/enable thresholds to avoid frequent toggling.
@@ -95,6 +90,14 @@ func SetMemTHP(conf *coreconfig.Configuration,
 	}
 	general.Infof("SetMemTHP: EnableFragMem enabled")
 
+	if enabled, thpMode, thpShmMode := getStaticTHPModes(fragMemConf); enabled {
+		general.Infof("SetMemTHP: static THP config enabled, thp=%s thpShm=%s", thpMode, thpShmMode)
+		if err := setTHPMode(thpMode, thpShmMode); err != nil {
+			errList = append(errList, err)
+		}
+		return
+	}
+
 	// Validation of the mode is done in setTHPModeAtPath, which is the only place before we write to the sysfs.
 	// THPDefaultConfig accepts any write-valid mode, including advise and deny.
 	mode := normalizeTHPMode(fragMemConf.THPDefaultConfig)
@@ -104,9 +107,9 @@ func SetMemTHP(conf *coreconfig.Configuration,
 		return
 	}
 	// If THPDefaultConfig is "never", fast-path to disable THP directly.
-	if mode == thpModeNever {
+	if mode == string(apiconfig.THPModeNever) {
 		general.Infof("SetMemTHP: THPDefaultConfig=never, disable THP directly")
-		if err := setTHPMode(thpModeNever, thpModeDeny); err != nil {
+		if err := setTHPMode(string(apiconfig.THPModeNever), string(apiconfig.THPShmModeDeny)); err != nil {
 			errList = append(errList, err)
 		}
 		return
@@ -163,17 +166,17 @@ func doMemTHP(conf *dynamicqrm.FragMemConfiguration, metaServer *metaserver.Meta
 	switch decision {
 	case thpDecisionDisable:
 		general.Infof("THP disable triggered: maxHighOrderScore=%.1f numa=%d threshold=%.1f", maxScore, maxNumaID, threshold)
-		return setTHPMode(thpModeNever, thpModeDeny)
+		return setTHPMode(string(apiconfig.THPModeNever), string(apiconfig.THPShmModeDeny))
 	case thpDecisionEnable:
 		// Be conservative: only try to recover when we have valid scores for all NUMA nodes.
 		// If metrics are missing on any NUMA node, keep current THP mode unchanged.
 		if validNUMACnt > 0 && missingScore == 0 {
 			mode := normalizeTHPMode(conf.THPDefaultConfig)
 			if mode == "" {
-				mode = thpModeMadvise
+				mode = string(apiconfig.THPModeMadvise)
 			}
-			general.Infof("THP enable triggered: maxHighOrderScore=%.1f enableThreshold=%.1f threshold=%.1f recoverTo=%s shmemRecoverTo=%s", maxScore, enableThreshold, threshold, mode, thpModeAdvise)
-			return setTHPMode(mode, thpModeAdvise)
+			general.Infof("THP enable triggered: maxHighOrderScore=%.1f enableThreshold=%.1f threshold=%.1f recoverTo=%s shmemRecoverTo=%s", maxScore, enableThreshold, threshold, mode, apiconfig.THPShmModeAdvise)
+			return setTHPMode(mode, string(apiconfig.THPShmModeAdvise))
 		}
 		general.Infof("THP enable skipped due to missing metrics: maxHighOrderScore=%.1f enableThreshold=%.1f threshold=%.1f missingScore=%d", maxScore, enableThreshold, threshold, missingScore)
 		return nil
@@ -181,6 +184,24 @@ func doMemTHP(conf *dynamicqrm.FragMemConfiguration, metaServer *metaserver.Meta
 		// Keep current mode to avoid flapping between disable/enable.
 		return nil
 	}
+}
+
+func getStaticTHPModes(conf *dynamicqrm.FragMemConfiguration) (bool, string, string) {
+	if conf == nil || conf.THPStaticEnableConfig == nil || !conf.THPStaticEnableConfig.Enable {
+		return false, "", ""
+	}
+
+	thpMode := normalizeTHPMode(string(conf.THPStaticEnableConfig.THP))
+	if thpMode == "" {
+		thpMode = string(apiconfig.THPModeMadvise)
+	}
+
+	thpShmMode := normalizeTHPMode(string(conf.THPStaticEnableConfig.THPShm))
+	if thpShmMode == "" {
+		thpShmMode = string(apiconfig.THPShmModeAdvise)
+	}
+
+	return true, thpMode, thpShmMode
 }
 
 func getHighOrderThreshold(conf *dynamicqrm.FragMemConfiguration) float64 {
@@ -238,9 +259,9 @@ func setTHPModeAtPathIfExists(path, mode string) error {
 func setTHPModeAtPath(path, mode string) error {
 	normalizedMode := normalizeTHPMode(mode)
 	switch normalizedMode {
-	case thpModeAdvise, thpModeDeny, thpModeMadvise, thpModeAlways, thpModeNever:
+	case string(apiconfig.THPShmModeAdvise), string(apiconfig.THPShmModeDeny), string(apiconfig.THPModeMadvise), string(apiconfig.THPModeAlways), string(apiconfig.THPModeNever), string(apiconfig.THPShmModeWithinSize), string(apiconfig.THPShmModeForce):
 	default:
-		return fmt.Errorf("invalid THP mode %q, expected one of %q/%q/%q/%q/%q", normalizedMode, thpModeAdvise, thpModeDeny, thpModeMadvise, thpModeAlways, thpModeNever)
+		return fmt.Errorf("invalid THP mode %q, expected one of %q/%q/%q/%q/%q/%q/%q", normalizedMode, apiconfig.THPShmModeAdvise, apiconfig.THPShmModeDeny, apiconfig.THPModeMadvise, apiconfig.THPModeAlways, apiconfig.THPModeNever, apiconfig.THPShmModeWithinSize, apiconfig.THPShmModeForce)
 	}
 
 	content, err := procfsm.ReadFileNoStat(path)

--- a/pkg/config/agent/dynamic/adminqos/qrm/fragmem.go
+++ b/pkg/config/agent/dynamic/adminqos/qrm/fragmem.go
@@ -16,13 +16,24 @@ limitations under the License.
 
 package qrm
 
-import "github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+import (
+	apiconfig "github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
+
+	"github.com/kubewharf/katalyst-core/pkg/config/agent/dynamic/crd"
+)
 
 type FragMemConfiguration struct {
 	EnableFragMem              bool
 	MemFragScoreAsync          int
 	THPDefaultConfig           string
 	THPHighOrderScoreThreshold int
+	THPStaticEnableConfig      *THPStaticEnableConfiguration
+}
+
+type THPStaticEnableConfiguration struct {
+	Enable bool
+	THP    apiconfig.THPMode
+	THPShm apiconfig.THPShmMode
 }
 
 func NewFragMemConfiguration() *FragMemConfiguration {
@@ -46,6 +57,20 @@ func (c *FragMemConfiguration) ApplyConfiguration(conf *crd.DynamicConfigCRD) {
 		}
 		if config.THPHighOrderScoreThreshold != nil {
 			c.THPHighOrderScoreThreshold = int(*config.THPHighOrderScoreThreshold)
+		}
+		if config.THPStaticEnableConfig != nil {
+			c.THPStaticEnableConfig = &THPStaticEnableConfiguration{}
+			if config.THPStaticEnableConfig.Enable != nil {
+				c.THPStaticEnableConfig.Enable = *config.THPStaticEnableConfig.Enable
+			}
+			if config.THPStaticEnableConfig.THP != nil {
+				c.THPStaticEnableConfig.THP = *config.THPStaticEnableConfig.THP
+			}
+			if config.THPStaticEnableConfig.THPShm != nil {
+				c.THPStaticEnableConfig.THPShm = *config.THPStaticEnableConfig.THPShm
+			}
+		} else {
+			c.THPStaticEnableConfig = nil
 		}
 	}
 }

--- a/pkg/config/agent/dynamic/adminqos/qrm/fragmem_test.go
+++ b/pkg/config/agent/dynamic/adminqos/qrm/fragmem_test.go
@@ -32,6 +32,9 @@ func TestFragMemConfigurationApplyConfiguration(t *testing.T) {
 	enable := true
 	score := int64(70)
 	mode := "always"
+	staticEnable := true
+	staticTHP := apiconfig.THPModeMadvise
+	staticTHPShm := apiconfig.THPShmModeWithinSize
 	threshold := int64(90)
 
 	conf := NewFragMemConfiguration()
@@ -46,6 +49,11 @@ func TestFragMemConfigurationApplyConfiguration(t *testing.T) {
 								MemFragScoreAsync:          &score,
 								THPDefaultConfig:           &mode,
 								THPHighOrderScoreThreshold: &threshold,
+								THPStaticEnableConfig: &apiconfig.THPStaticEnableConfig{
+									Enable: &staticEnable,
+									THP:    &staticTHP,
+									THPShm: &staticTHPShm,
+								},
 							},
 						},
 					},
@@ -58,4 +66,61 @@ func TestFragMemConfigurationApplyConfiguration(t *testing.T) {
 	as.Equal(70, conf.MemFragScoreAsync)
 	as.Equal("always", conf.THPDefaultConfig)
 	as.Equal(90, conf.THPHighOrderScoreThreshold)
+	as.NotNil(conf.THPStaticEnableConfig)
+	as.True(conf.THPStaticEnableConfig.Enable)
+	as.Equal(apiconfig.THPModeMadvise, conf.THPStaticEnableConfig.THP)
+	as.Equal(apiconfig.THPShmModeWithinSize, conf.THPStaticEnableConfig.THPShm)
+}
+
+func TestFragMemConfigurationApplyConfiguration_ResetStaticTHPConfig(t *testing.T) {
+	t.Parallel()
+
+	as := require.New(t)
+	staticEnable := true
+
+	conf := NewFragMemConfiguration()
+	conf.THPStaticEnableConfig = &THPStaticEnableConfiguration{
+		Enable: true,
+		THP:    apiconfig.THPModeAlways,
+		THPShm: apiconfig.THPShmModeForce,
+	}
+
+	conf.ApplyConfiguration(&crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &apiconfig.AdminQoSConfiguration{
+			Spec: apiconfig.AdminQoSConfigurationSpec{
+				Config: apiconfig.AdminQoSConfig{
+					QRMPluginConfig: &apiconfig.QRMPluginConfig{
+						MemoryPluginConfig: &apiconfig.MemoryPluginConfig{
+							FragMemConfig: &apiconfig.FragMemConfig{
+								THPStaticEnableConfig: &apiconfig.THPStaticEnableConfig{
+									Enable: &staticEnable,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	as.NotNil(conf.THPStaticEnableConfig)
+	as.True(conf.THPStaticEnableConfig.Enable)
+	as.Equal(apiconfig.THPMode(""), conf.THPStaticEnableConfig.THP)
+	as.Equal(apiconfig.THPShmMode(""), conf.THPStaticEnableConfig.THPShm)
+
+	conf.ApplyConfiguration(&crd.DynamicConfigCRD{
+		AdminQoSConfiguration: &apiconfig.AdminQoSConfiguration{
+			Spec: apiconfig.AdminQoSConfigurationSpec{
+				Config: apiconfig.AdminQoSConfig{
+					QRMPluginConfig: &apiconfig.QRMPluginConfig{
+						MemoryPluginConfig: &apiconfig.MemoryPluginConfig{
+							FragMemConfig: &apiconfig.FragMemConfig{},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	as.Nil(conf.THPStaticEnableConfig)
 }


### PR DESCRIPTION
#### What type of PR is this?
Enhancements

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## English

- Adds static THP policy support to the agent’s fragmem handler.
- Applies configured `THP` and `THPShm` modes when enabled. Defaults are `madvise` and `advise`.
- Skips dynamic THP tuning when static policy is active.
- Extends agent configuration and tests for propagation, defaults, reset behavior, and mode handling.
- Updates `katalyst-api` to the upstream `kubewharf` revision and removes the fork replacement.
- No controller, scheduler, or release wiring changes are included.
- Rollout risk is limited to THP behavior changes when static policy is enabled and dependency compatibility.

## 简体中文

- 为 agent 的 fragmem handler 增加静态 THP policy 支持。
- 启用静态 policy 时应用配置的 `THP` 和 `THPShm` mode。默认值为 `madvise` 和 `advise`。
- 启用静态 policy 后跳过动态 THP 调优。
- 扩展 agent 配置和测试，覆盖配置传递、默认值、重置行为和 mode 处理。
- 将 `katalyst-api` 更新到上游 `kubewharf` revision，并移除 fork replacement。
- 本次不包含 controller、scheduler 或 release wiring 变更。
- rollout 风险主要来自启用静态 policy 后的 THP 行为变化和 dependency 兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->