### PR TITLE
feat(network): add allocatable NIC filtering

### DIFF
--- a/cmd/katalyst-agent/app/options/qrm/network_plugin.go
+++ b/cmd/katalyst-agent/app/options/qrm/network_plugin.go
@@ -39,6 +39,7 @@ type NetworkOptions struct {
 	NetClassIDResourceAllocationAnnotationKey       string
 	NetBandwidthResourceAllocationAnnotationKey     string
 	NICHealthCheckers                               []string
+	NICFilters                                      []string
 	EnableNICAllocationReactor                      bool
 }
 
@@ -115,6 +116,8 @@ func (o *NetworkOptions) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringSliceVar(&o.NICHealthCheckers, "network-resource-plugin-nic-health-checkers",
 		o.NICHealthCheckers, "list of nic health checkers, '*' run all on-by-default checkers,"+
 			"'ip' run checker 'ip', '-ip' not run checker 'ip'")
+	fs.StringSliceVar(&o.NICFilters, "network-resource-plugin-nic-filters",
+		o.NICFilters, "list of allocatable nic filters, disabled by default")
 }
 
 func (o *NetworkOptions) ApplyTo(conf *qrmconfig.NetworkQRMPluginConfig) error {
@@ -137,6 +140,7 @@ func (o *NetworkOptions) ApplyTo(conf *qrmconfig.NetworkQRMPluginConfig) error {
 	conf.NetBandwidthResourceAllocationAnnotationKey = o.NetBandwidthResourceAllocationAnnotationKey
 	conf.EnableNICAllocationReactor = o.EnableNICAllocationReactor
 	conf.NICHealthCheckers = o.NICHealthCheckers
+	conf.NICFilters = o.NICFilters
 
 	return nil
 }

--- a/pkg/agent/qrm-plugins/network/staticpolicy/nic/filter/interface.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/nic/filter/interface.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import "github.com/kubewharf/katalyst-core/pkg/util/machine"
+
+type AllocatableNICFilter interface {
+	Filter([]machine.InterfaceInfo) ([]machine.InterfaceInfo, error)
+}
+
+type AllocatableNICFilterFactory func() (AllocatableNICFilter, error)

--- a/pkg/agent/qrm-plugins/network/staticpolicy/nic/filter/registry.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/nic/filter/registry.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import "fmt"
+
+var DefaultRegistry = NewRegistry()
+
+type Registry map[string]AllocatableNICFilterFactory
+
+func NewRegistry() Registry {
+	return Registry{}
+}
+
+// Register registers a new allocatable NIC filter.
+func (r Registry) Register(name string, factory AllocatableNICFilterFactory) error {
+	if _, ok := r[name]; ok {
+		return fmt.Errorf("a filter named %v already exists", name)
+	}
+	r[name] = factory
+	return nil
+}

--- a/pkg/agent/qrm-plugins/network/staticpolicy/nic/manager.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/nic/manager.go
@@ -19,6 +19,7 @@ package nic
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/network/staticpolicy/nic/checker"
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/network/staticpolicy/nic/filter"
 	"github.com/kubewharf/katalyst-core/pkg/config"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
@@ -35,7 +37,8 @@ import (
 )
 
 const (
-	metricsNameNICUnhealthyState = "nic_unhealthy_state"
+	metricsNameNICUnhealthyState      = "nic_unhealthy_state"
+	metricsNameNetworkPluginNICFilter = "network_plugin_nic_filter"
 
 	nicHealthCheckTime     = 3
 	nicHealthCheckInterval = 5 * time.Second
@@ -55,6 +58,11 @@ type nicManagerImpl struct {
 
 func NewNICManager(metaServer *metaserver.MetaServer, emitter metrics.MetricEmitter, conf *config.Configuration) (NICManager, error) {
 	defaultAllocatableNICs := metaServer.ExtraNetworkInfo.GetAllocatableNICs(conf.MachineInfoConfiguration)
+	defaultAllocatableNICs, err := filterAllocatableNICs(filter.DefaultRegistry, defaultAllocatableNICs, conf.NICFilters, emitter)
+	if err != nil {
+		return nil, err
+	}
+
 	checkers, err := initHealthCheckers(checker.DefaultRegistry, conf.NICHealthCheckers)
 	if err != nil {
 		return nil, err
@@ -123,6 +131,130 @@ func initHealthCheckers(registry checker.Registry, enableCheckers []string) (map
 	}
 
 	return checkers, nil
+}
+
+func filterAllocatableNICs(registry filter.Registry, nics []machine.InterfaceInfo, enableFilters []string, emitter metrics.MetricEmitter) ([]machine.InterfaceInfo, error) {
+	filters, err := initAllocatableNICFilters(registry, enableFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	filteredNICs := nics
+	for _, f := range filters {
+		before := append([]machine.InterfaceInfo(nil), filteredNICs...)
+		filteredNICs, err = f.Handler.Filter(append([]machine.InterfaceInfo(nil), filteredNICs...))
+		if err != nil {
+			general.Errorf("failed to filter allocatable NICs with %s: %v", f.Name, err)
+			return nil, err
+		}
+		emitAllocatableNICFilterMetrics(emitter, f.Name, before, filteredNICs)
+	}
+
+	return filteredNICs, nil
+}
+
+func emitAllocatableNICFilterMetrics(emitter metrics.MetricEmitter, filterName string, before, after []machine.InterfaceInfo) {
+	keptNICs := make(map[string]struct{}, len(after))
+	for _, nic := range after {
+		keptNICs[nicKey(nic)] = struct{}{}
+	}
+
+	filteredNICs := make([]string, 0, len(before))
+	for _, nic := range before {
+		result := "kept"
+		if _, ok := keptNICs[nicKey(nic)]; !ok {
+			result = "filtered"
+			filteredNICs = append(filteredNICs, nicKey(nic))
+		}
+
+		if emitter == nil {
+			continue
+		}
+		_ = emitter.StoreInt64(metricsNameNetworkPluginNICFilter, 1, metrics.MetricTypeNameRaw,
+			metrics.MetricTag{Key: "filter", Val: filterName},
+			metrics.MetricTag{Key: "nic", Val: nic.Name},
+			metrics.MetricTag{Key: "netns", Val: nic.NSName},
+			metrics.MetricTag{Key: "result", Val: result},
+		)
+	}
+
+	general.Infof("allocatable NIC filter %s filtered NICs: %v", filterName, filteredNICs)
+}
+
+func nicKey(nic machine.InterfaceInfo) string {
+	if nic.NSName == "" {
+		return nic.Name
+	}
+	return nic.NSName + "/" + nic.Name
+}
+
+type namedAllocatableNICFilter struct {
+	Name    string
+	Handler filter.AllocatableNICFilter
+}
+
+func initAllocatableNICFilters(registry filter.Registry, enableFilters []string) ([]namedAllocatableNICFilter, error) {
+	filters := make([]namedAllocatableNICFilter, 0, len(enableFilters))
+	selected := sets.NewString()
+	for _, selector := range enableFilters {
+		if selector == "" || len(selector) > 0 && selector[0] == '-' {
+			continue
+		}
+
+		if selector == "*" {
+			names := make([]string, 0, len(registry))
+			for name := range registry {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			for _, name := range names {
+				if selected.Has(name) {
+					continue
+				}
+				if !general.IsNameEnabled(name, nil, enableFilters) {
+					general.Warningf("allocatable NIC filter %q is disabled", name)
+					continue
+				}
+
+				f, err := registry[name]()
+				if err != nil {
+					general.Errorf("failed to initialize allocatable NIC filter %s: %v", name, err)
+					return nil, err
+				}
+
+				filters = append(filters, namedAllocatableNICFilter{Name: name, Handler: f})
+				selected.Insert(name)
+				general.Infof("successfully registered allocatable NIC filter: %s", name)
+			}
+			continue
+		}
+
+		if selected.Has(selector) {
+			continue
+		}
+		if !general.IsNameEnabled(selector, nil, enableFilters) {
+			general.Warningf("allocatable NIC filter %q is disabled", selector)
+			continue
+		}
+
+		factory, ok := registry[selector]
+		if !ok {
+			return nil, fmt.Errorf("unknown allocatable NIC filter %q", selector)
+		}
+
+		f, err := factory()
+		if err != nil {
+			general.Errorf("failed to initialize allocatable NIC filter %s: %v", selector, err)
+			return nil, err
+		}
+
+		filters = append(filters, namedAllocatableNICFilter{Name: selector, Handler: f})
+		selected.Insert(selector)
+		general.Infof("successfully registered allocatable NIC filter: %s", selector)
+	}
+
+	return filters, nil
 }
 
 func (n *nicManagerImpl) checkNICs(nics []machine.InterfaceInfo) (*NICs, error) {

--- a/pkg/agent/qrm-plugins/network/staticpolicy/nic/manager_test.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/nic/manager_test.go
@@ -18,6 +18,9 @@ package nic
 
 import (
 	"context"
+	"errors"
+	"net"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +28,7 @@ import (
 
 	"github.com/kubewharf/katalyst-core/cmd/katalyst-agent/app/options"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/network/staticpolicy/nic/checker"
+	nicfilter "github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/network/staticpolicy/nic/filter"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver"
 	"github.com/kubewharf/katalyst-core/pkg/metaserver/agent"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
@@ -35,9 +39,89 @@ type MockNICHealthChecker struct {
 	mock.Mock
 }
 
+type mockNICFilter struct{}
+
+var defaultRegistryMu sync.Mutex
+
+func (m *mockNICFilter) Filter(nics []machine.InterfaceInfo) ([]machine.InterfaceInfo, error) {
+	filtered := make([]machine.InterfaceInfo, 0, len(nics))
+	for _, nic := range nics {
+		if nic.Name == "eth1" {
+			filtered = append(filtered, nic)
+		}
+	}
+	return filtered, nil
+}
+
+type filterFunc func(nics []machine.InterfaceInfo) ([]machine.InterfaceInfo, error)
+
+func (f filterFunc) Filter(nics []machine.InterfaceInfo) ([]machine.InterfaceInfo, error) {
+	return f(nics)
+}
+
+type metricSample struct {
+	key  string
+	val  int64
+	tags map[string]string
+}
+
+type recordMetricEmitter struct {
+	samples []metricSample
+}
+
+func (r *recordMetricEmitter) StoreInt64(key string, val int64, _ metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	sample := metricSample{
+		key:  key,
+		val:  val,
+		tags: make(map[string]string, len(tags)),
+	}
+	for _, tag := range tags {
+		sample.tags[tag.Key] = tag.Val
+	}
+	r.samples = append(r.samples, sample)
+	return nil
+}
+
+func (r *recordMetricEmitter) StoreFloat64(_ string, _ float64, _ metrics.MetricTypeName, _ ...metrics.MetricTag) error {
+	return nil
+}
+
+func (r *recordMetricEmitter) WithTags(_ string, _ ...metrics.MetricTag) metrics.MetricEmitter {
+	return r
+}
+
+func (r *recordMetricEmitter) Run(_ context.Context) {}
+
 func (m *MockNICHealthChecker) CheckHealth(nic machine.InterfaceInfo) (bool, error) {
 	args := m.Called(nic)
 	return args.Bool(0), args.Error(1)
+}
+
+func TestNICKey(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		nic  machine.InterfaceInfo
+		want string
+	}{
+		{
+			name: "empty namespace",
+			nic:  machine.InterfaceInfo{Name: "eth0"},
+			want: "eth0",
+		},
+		{
+			name: "non-empty namespace",
+			nic:  machine.InterfaceInfo{Name: "eth0", NetNSInfo: machine.NetNSInfo{NSName: "ns1"}},
+			want: "ns1/eth0",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, nicKey(tc.nic))
+		})
+	}
 }
 
 func TestNewNICManager(t *testing.T) {
@@ -56,6 +140,244 @@ func TestNewNICManager(t *testing.T) {
 	manager, err := NewNICManager(mockMetaServer, mockEmitter, mockConf)
 	assert.NoError(t, err)
 	assert.NotNil(t, manager)
+}
+
+func TestNewNICManagerWithAllocatableNICFilter(t *testing.T) {
+	t.Parallel()
+
+	const filterName = "keep-eth1"
+	defaultRegistryMu.Lock()
+	err := nicfilter.DefaultRegistry.Register(filterName, func() (nicfilter.AllocatableNICFilter, error) {
+		return &mockNICFilter{}, nil
+	})
+	assert.NoError(t, err)
+	defer func() {
+		delete(nicfilter.DefaultRegistry, filterName)
+		defaultRegistryMu.Unlock()
+	}()
+
+	ipv4 := net.ParseIP("192.168.0.2")
+	mockMetaServer := &metaserver.MetaServer{
+		MetaAgent: &agent.MetaAgent{
+			KatalystMachineInfo: &machine.KatalystMachineInfo{
+				ExtraNetworkInfo: &machine.ExtraNetworkInfo{
+					Interface: []machine.InterfaceInfo{
+						{Name: "eth0", Enable: true, Addr: &machine.IfaceAddr{IPV4: []*net.IP{&ipv4}}},
+						{Name: "eth1", Enable: true, Addr: &machine.IfaceAddr{IPV4: []*net.IP{&ipv4}}},
+					},
+				},
+			},
+		},
+	}
+	mockEmitter := &recordMetricEmitter{}
+	mockConf, err := options.NewOptions().Config()
+	assert.NoError(t, err)
+	mockConf.NICFilters = []string{filterName}
+
+	manager, err := NewNICManager(mockMetaServer, mockEmitter, mockConf)
+	assert.NoError(t, err)
+
+	nics := manager.GetNICs()
+	assert.Len(t, nics.HealthyNICs, 1)
+	assert.Equal(t, "eth1", nics.HealthyNICs[0].Name)
+	assert.True(t, hasMetricSample(mockEmitter.samples, "network_plugin_nic_filter", 1, map[string]string{"filter": filterName, "nic": "eth0", "result": "filtered"}))
+	assert.True(t, hasMetricSample(mockEmitter.samples, "network_plugin_nic_filter", 1, map[string]string{"filter": filterName, "nic": "eth1", "result": "kept"}))
+}
+
+func TestNewNICManagerWithAllocatableNICFilterError(t *testing.T) {
+	t.Parallel()
+
+	newMetaServer := func() *metaserver.MetaServer {
+		return &metaserver.MetaServer{
+			MetaAgent: &agent.MetaAgent{
+				KatalystMachineInfo: &machine.KatalystMachineInfo{
+					ExtraNetworkInfo: &machine.ExtraNetworkInfo{
+						Interface: []machine.InterfaceInfo{
+							{Name: "eth0", Enable: true},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("factory error", func(t *testing.T) {
+		t.Parallel()
+
+		const filterName = "factory-error"
+		expectedErr := errors.New("factory error")
+		defaultRegistryMu.Lock()
+		err := nicfilter.DefaultRegistry.Register(filterName, func() (nicfilter.AllocatableNICFilter, error) {
+			return nil, expectedErr
+		})
+		assert.NoError(t, err)
+		defer func() {
+			delete(nicfilter.DefaultRegistry, filterName)
+			defaultRegistryMu.Unlock()
+		}()
+
+		mockConf, err := options.NewOptions().Config()
+		assert.NoError(t, err)
+		mockConf.NICFilters = []string{filterName}
+
+		manager, err := NewNICManager(newMetaServer(), &metrics.DummyMetrics{}, mockConf)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, manager)
+	})
+
+	t.Run("filter error", func(t *testing.T) {
+		t.Parallel()
+
+		const filterName = "filter-error"
+		expectedErr := errors.New("filter error")
+		defaultRegistryMu.Lock()
+		err := nicfilter.DefaultRegistry.Register(filterName, func() (nicfilter.AllocatableNICFilter, error) {
+			return filterFunc(func([]machine.InterfaceInfo) ([]machine.InterfaceInfo, error) {
+				return nil, expectedErr
+			}), nil
+		})
+		assert.NoError(t, err)
+		defer func() {
+			delete(nicfilter.DefaultRegistry, filterName)
+			defaultRegistryMu.Unlock()
+		}()
+
+		mockConf, err := options.NewOptions().Config()
+		assert.NoError(t, err)
+		mockConf.NICFilters = []string{filterName}
+
+		manager, err := NewNICManager(newMetaServer(), &metrics.DummyMetrics{}, mockConf)
+		assert.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, manager)
+	})
+}
+
+func TestFilterAllocatableNICsWithInPlaceFilter(t *testing.T) {
+	t.Parallel()
+
+	const filterName = "in-place"
+	registry := nicfilter.Registry{
+		filterName: func() (nicfilter.AllocatableNICFilter, error) {
+			return filterFunc(func(nics []machine.InterfaceInfo) ([]machine.InterfaceInfo, error) {
+				nics[0] = nics[1]
+				return nics[:1], nil
+			}), nil
+		},
+	}
+	emitter := &recordMetricEmitter{}
+	filtered, err := filterAllocatableNICs(registry, []machine.InterfaceInfo{
+		{Name: "eth0"},
+		{Name: "eth1"},
+	}, []string{filterName}, emitter)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []machine.InterfaceInfo{{Name: "eth1"}}, filtered)
+	assert.True(t, hasMetricSample(emitter.samples, "network_plugin_nic_filter", 1, map[string]string{"filter": filterName, "nic": "eth0", "result": "filtered"}))
+	assert.True(t, hasMetricSample(emitter.samples, "network_plugin_nic_filter", 1, map[string]string{"filter": filterName, "nic": "eth1", "result": "kept"}))
+}
+
+func TestFilterAllocatableNICsPreservesConfiguredOrder(t *testing.T) {
+	t.Parallel()
+
+	registry := nicfilter.Registry{
+		"first": func() (nicfilter.AllocatableNICFilter, error) {
+			return filterFunc(func(nics []machine.InterfaceInfo) ([]machine.InterfaceInfo, error) {
+				return nics[1:], nil
+			}), nil
+		},
+		"second": func() (nicfilter.AllocatableNICFilter, error) {
+			return filterFunc(func(nics []machine.InterfaceInfo) ([]machine.InterfaceInfo, error) {
+				return nics[:1], nil
+			}), nil
+		},
+	}
+
+	filtered, err := filterAllocatableNICs(registry, []machine.InterfaceInfo{
+		{Name: "eth0"},
+		{Name: "eth1"},
+	}, []string{"second", "first"}, nil)
+
+	assert.NoError(t, err)
+	assert.Empty(t, filtered)
+}
+
+func TestInitAllocatableNICFilters(t *testing.T) {
+	t.Parallel()
+
+	newRegistry := func() nicfilter.Registry {
+		return nicfilter.Registry{
+			"first": func() (nicfilter.AllocatableNICFilter, error) {
+				return &mockNICFilter{}, nil
+			},
+			"second": func() (nicfilter.AllocatableNICFilter, error) {
+				return &mockNICFilter{}, nil
+			},
+			"third": func() (nicfilter.AllocatableNICFilter, error) {
+				return &mockNICFilter{}, nil
+			},
+		}
+	}
+
+	t.Run("explicit filters are enabled", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := initAllocatableNICFilters(newRegistry(), []string{"second", "first"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"second", "first"}, filterNames(filters))
+	})
+
+	t.Run("wildcard can disable registered filter", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := initAllocatableNICFilters(newRegistry(), []string{"*", "-second"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"first", "third"}, filterNames(filters))
+	})
+
+	t.Run("wildcard does not duplicate explicit filter", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := initAllocatableNICFilters(newRegistry(), []string{"*", "second"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"first", "second", "third"}, filterNames(filters))
+	})
+
+	t.Run("unknown explicit filter returns error", func(t *testing.T) {
+		t.Parallel()
+
+		filters, err := initAllocatableNICFilters(newRegistry(), []string{"missing"})
+		assert.Error(t, err)
+		assert.Empty(t, filters)
+	})
+}
+
+func filterNames(filters []namedAllocatableNICFilter) []string {
+	names := make([]string, 0, len(filters))
+	for _, f := range filters {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func hasMetricSample(samples []metricSample, key string, val int64, tags map[string]string) bool {
+	for _, sample := range samples {
+		if sample.key != key || sample.val != val {
+			continue
+		}
+
+		matched := true
+		for k, v := range tags {
+			if sample.tags[k] != v {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TestGetNICs(t *testing.T) {

--- a/pkg/config/agent/qrm/network_plugin.go
+++ b/pkg/config/agent/qrm/network_plugin.go
@@ -44,6 +44,8 @@ type NetworkQRMPluginConfig struct {
 	EnableNICAllocationReactor bool
 	// NICHealthCheckers is the list of enabled NIC health checkers
 	NICHealthCheckers []string
+	// NICFilters is the list of enabled allocatable NIC filters
+	NICFilters []string
 }
 
 type NetClassConfig struct {


### PR DESCRIPTION
Add a registry-based allocatable NIC filter extension point for the network resource plugin and emit per-filter NIC state metrics.

#### What type of PR is this?

Features


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### English

- Adds a registry-based extension point for allocatable NIC filters.
- Adds `NICFilters` configuration and the `network-resource-plugin-nic-filters` flag.
- Applies enabled filters sequentially during `NewNICManager` initialization.
- Fails manager initialization when filter creation or execution returns an error.
- Supports wildcard enablement, deduplication, and unknown-filter validation.
- Emits per-filter metrics and logs for retained and filtered NICs.
- Adds unit tests for filter initialization, filtering, metrics, and error handling.
- The change affects the agent network resource plugin. It does not change controller, scheduler, or release wiring.
- Filtering is disabled by default when `NICFilters` is nil. Validate filter configuration before rollout because filters can remove NICs or prevent manager initialization.

### 简体中文

- 为可分配 NIC 过滤器增加基于 registry 的扩展点。
- 增加 `NICFilters` 配置和 `network-resource-plugin-nic-filters` 参数。
- `NewNICManager` 初始化时按顺序应用已启用的过滤器。
- 当过滤器创建或执行返回错误时，manager 初始化失败。
- 支持通配符启用、去重和未知过滤器校验。
- 增加每个过滤器的指标和日志，用于记录保留及过滤的 NIC。
- 增加过滤器初始化、过滤、指标和错误处理的单元测试。
- 该变更影响 agent 的 network resource plugin。不涉及 controller、scheduler 或 release wiring。
- `NICFilters` 为 nil 时默认关闭过滤。上线前应验证过滤器配置，因为过滤器可能移除 NIC，或阻止 manager 初始化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->