### PR TITLE
fix(thpmode): preserve vm.min_free_kbytes when enabling madvise

### DIFF
--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
@@ -395,6 +395,84 @@ func TestEnableTHPMadviseAtPath(t *testing.T) {
 	assert.Equal(t, "madvise\n", string(b))
 }
 
+func TestEnableTHPMadviseAtPathRestoreMinFreeKbytes(t *testing.T) {
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
+
+	oldEnabledPath := thpEnabledPath
+	oldMinFreeKbytesPath := minFreeKbytesPath
+	oldApplyTHPModeAtPath := applyTHPModeAtPath
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		minFreeKbytesPath = oldMinFreeKbytesPath
+		applyTHPModeAtPath = oldApplyTHPModeAtPath
+	}()
+
+	thpFile := createTempFile(t, "always madvise [never]\n")
+	minFreeFile := createTempFile(t, "12345\n")
+	defer os.Remove(thpFile)
+	defer os.Remove(minFreeFile)
+
+	thpEnabledPath = thpFile
+	minFreeKbytesPath = minFreeFile
+	applyTHPModeAtPath = func(path, mode string) error {
+		if err := os.WriteFile(path, []byte(mode+"\n"), 0o644); err != nil {
+			return err
+		}
+		return os.WriteFile(minFreeFile, []byte("54321\n"), 0o644)
+	}
+
+	err := setTHPModeAtPath(thpFile, "madvise")
+	assert.NoError(t, err)
+
+	b, rerr := os.ReadFile(thpFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "madvise\n", string(b))
+
+	b, rerr = os.ReadFile(minFreeFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "12345\n", string(b))
+}
+
+func TestSetTHPModeAtPathNonMadviseDoesNotRestoreMinFreeKbytes(t *testing.T) {
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
+
+	oldEnabledPath := thpEnabledPath
+	oldMinFreeKbytesPath := minFreeKbytesPath
+	oldApplyTHPModeAtPath := applyTHPModeAtPath
+	defer func() {
+		thpEnabledPath = oldEnabledPath
+		minFreeKbytesPath = oldMinFreeKbytesPath
+		applyTHPModeAtPath = oldApplyTHPModeAtPath
+	}()
+
+	thpFile := createTempFile(t, "always [madvise] never\n")
+	minFreeFile := createTempFile(t, "12345\n")
+	defer os.Remove(thpFile)
+	defer os.Remove(minFreeFile)
+
+	thpEnabledPath = thpFile
+	minFreeKbytesPath = minFreeFile
+	applyTHPModeAtPath = func(path, mode string) error {
+		if err := os.WriteFile(path, []byte(mode+"\n"), 0o644); err != nil {
+			return err
+		}
+		return os.WriteFile(minFreeFile, []byte("54321\n"), 0o644)
+	}
+
+	err := setTHPModeAtPath(thpFile, "never")
+	assert.NoError(t, err)
+
+	b, rerr := os.ReadFile(thpFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "never\n", string(b))
+
+	b, rerr = os.ReadFile(minFreeFile)
+	assert.NoError(t, rerr)
+	assert.Equal(t, "54321\n", string(b))
+}
+
 func TestEnableTHPAdviseAtPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_linux_test.go
@@ -354,6 +354,9 @@ func TestGetHighOrderThreshold(t *testing.T) {
 func TestDisableTHPAtPath(t *testing.T) {
 	t.Parallel()
 
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
+
 	// already disabled
 	f1 := createTempFile(t, "always madvise [never]\n")
 	defer os.Remove(f1)
@@ -376,6 +379,9 @@ func TestDisableTHPAtPath(t *testing.T) {
 func TestEnableTHPMadviseAtPath(t *testing.T) {
 	t.Parallel()
 
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
+
 	// already madvise
 	f1 := createTempFile(t, "always [madvise] never\n")
 	defer os.Remove(f1)
@@ -396,6 +402,8 @@ func TestEnableTHPMadviseAtPath(t *testing.T) {
 }
 
 func TestEnableTHPMadviseAtPathRestoreMinFreeKbytes(t *testing.T) {
+	t.Parallel()
+
 	setMemTHPTestMu.Lock()
 	defer setMemTHPTestMu.Unlock()
 
@@ -435,6 +443,8 @@ func TestEnableTHPMadviseAtPathRestoreMinFreeKbytes(t *testing.T) {
 }
 
 func TestSetTHPModeAtPathNonMadviseDoesNotRestoreMinFreeKbytes(t *testing.T) {
+	t.Parallel()
+
 	setMemTHPTestMu.Lock()
 	defer setMemTHPTestMu.Unlock()
 
@@ -476,6 +486,9 @@ func TestSetTHPModeAtPathNonMadviseDoesNotRestoreMinFreeKbytes(t *testing.T) {
 func TestEnableTHPAdviseAtPath(t *testing.T) {
 	t.Parallel()
 
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
+
 	// already advise
 	f1 := createTempFile(t, "always within_size [advise] never deny force\n")
 	defer os.Remove(f1)
@@ -497,6 +510,9 @@ func TestEnableTHPAdviseAtPath(t *testing.T) {
 
 func TestDisableTHPDenyAtPath(t *testing.T) {
 	t.Parallel()
+
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
 
 	// already deny
 	f1 := createTempFile(t, "always within_size advise never [deny] force\n")
@@ -526,6 +542,9 @@ func TestSetTHPModeAtPathIfExistsMissing(t *testing.T) {
 
 func TestSetTHPModeAtPathInvalid(t *testing.T) {
 	t.Parallel()
+
+	setMemTHPTestMu.Lock()
+	defer setMemTHPTestMu.Unlock()
 
 	f := createTempFile(t, "always [madvise] never\n")
 	defer os.Remove(f)

--- a/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
+++ b/pkg/agent/qrm-plugins/memory/handlers/fragmem/fragmem_thp_linux.go
@@ -60,6 +60,14 @@ var thpEnabledPath = procfsm.TransparentHugepageEnabledPath
 // It is a var (not const) so tests can override it with a temp file.
 var thpShmemEnabledPath = procfsm.TransparentHugepageShmemEnabledPath
 
+// minFreeKbytesPath is the procfs path for vm.min_free_kbytes.
+// It is a var (not const) so tests can override it with a temp file.
+var minFreeKbytesPath = procfsm.VMMinFreeKbytesPath
+
+// applyTHPModeAtPath writes THP mode to sysfs.
+// It is a var (not const) so tests can stub side effects around THP changes.
+var applyTHPModeAtPath = procfsm.ApplyTransparentHugepageEnabledAtPath
+
 type thpDecision int
 
 const (
@@ -235,7 +243,7 @@ func setTHPModeAtPathIfExists(path, mode string) error {
 	return err
 }
 
-func setTHPModeAtPath(path, mode string) error {
+func setTHPModeAtPath(path, mode string) (retErr error) {
 	normalizedMode := normalizeTHPMode(mode)
 	switch normalizedMode {
 	case thpModeAdvise, thpModeDeny, thpModeMadvise, thpModeAlways, thpModeNever:
@@ -258,7 +266,23 @@ func setTHPModeAtPath(path, mode string) error {
 		return nil
 	}
 
-	if err := procfsm.ApplyTransparentHugepageEnabledAtPath(path, normalizedMode); err != nil {
+	if shouldPreserveMinFreeKbytes(path, normalizedMode) {
+		restoreMinFreeKbytes, err := saveMinFreeKbytes()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := restoreMinFreeKbytes(); err != nil {
+				if retErr == nil {
+					retErr = err
+				} else {
+					retErr = k8serrors.NewAggregate([]error{retErr, err})
+				}
+			}
+		}()
+	}
+
+	if err := applyTHPModeAtPath(path, normalizedMode); err != nil {
 		return fmt.Errorf("set THP mode failed, write %q to %s: %w", normalizedMode, path, err)
 	}
 
@@ -270,6 +294,29 @@ func setTHPModeAtPath(path, mode string) error {
 
 	general.Infof("THP set to %s by writing %q to %s", normalizedMode, normalizedMode, path)
 	return nil
+}
+
+func shouldPreserveMinFreeKbytes(path, mode string) bool {
+	return path == thpEnabledPath && mode == thpModeMadvise
+}
+
+func saveMinFreeKbytes() (func() error, error) {
+	content, err := procfsm.ReadFileNoStat(minFreeKbytesPath)
+	if err != nil {
+		return nil, fmt.Errorf("read vm.min_free_kbytes %s failed: %w", minFreeKbytesPath, err)
+	}
+
+	saved := append([]byte(nil), content...)
+	savedDisplay := strings.TrimSpace(string(saved))
+	general.Infof("saved vm.min_free_kbytes=%q before setting THP to %s", savedDisplay, thpModeMadvise)
+
+	return func() error {
+		if err := os.WriteFile(minFreeKbytesPath, saved, 0o644); err != nil {
+			return fmt.Errorf("restore vm.min_free_kbytes %s to %q failed: %w", minFreeKbytesPath, savedDisplay, err)
+		}
+		general.Infof("restored vm.min_free_kbytes=%q after setting THP to %s", savedDisplay, thpModeMadvise)
+		return nil
+	}, nil
 }
 
 func normalizeTHPMode(mode string) string {

--- a/pkg/util/procfs/manager/procfs_linux.go
+++ b/pkg/util/procfs/manager/procfs_linux.go
@@ -43,6 +43,8 @@ const (
 	VMWatermarkBoostFactorPath = "/proc/sys/vm/watermark_boost_factor"
 	// VMExtFragThresholdPath is a procfs sysctl to configure extfrag threshold.
 	VMExtFragThresholdPath = "/proc/sys/vm/extfrag_threshold"
+	// VMMinFreeKbytesPath is a procfs sysctl to configure vm.min_free_kbytes.
+	VMMinFreeKbytesPath = "/proc/sys/vm/min_free_kbytes"
 
 	// TransparentHugepageEnabledPath is a kernel sysfs interface to configure THP behavior.
 	TransparentHugepageEnabledPath = "/sys/kernel/mm/transparent_hugepage/enabled"


### PR DESCRIPTION
Restore vm.min_free_kbytes after switching THP back to madvise so the kernel side effect does not leave host reclaim settings unexpectedly changed.

#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fix the memory agent’s THP handling. When the main THP path switches to `madvise`, preserve and restore `vm.min_free_kbytes`. Return restoration errors with write errors. Add tests for both `madvise` and non-`madvise` behavior. Serialize tests that modify shared THP path overrides with `setMemTHPTestMu`. This prevents unintended host reclaim setting changes. No configuration, dependency, controller, scheduler, or release wiring changes.

修复 memory agent 的 THP 处理逻辑。当主 THP 路径切换为 `madvise` 时，保存并恢复 `vm.min_free_kbytes`。将恢复错误与写入错误一起返回。新增 `madvise` 和非 `madvise` 行为测试。使用 `setMemTHPTestMu` 串行化修改共享 THP 路径覆盖值的测试。此变更可防止意外修改主机 reclaim 设置。未修改配置、依赖、controller、scheduler 或 release wiring。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->