### PR TITLE
fix(network): isolate netclass data per container

### DIFF
--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
@@ -938,7 +938,7 @@ func (p *StaticPolicy) applyNetClass() {
 			general.Errorf("get net class id failed, pod: %s, err: %s", native.GenerateUniqObjectNameKey(pod), err)
 			continue
 		}
-		netClsData := &common.NetClsData{
+		baseNetClsData := &common.NetClsData{
 			ClassID:    classID,
 			Attributes: native.FilterPodAnnotations(p.podLevelNetAttributesAnnoKeys, pod),
 		}
@@ -962,6 +962,10 @@ func (p *StaticPolicy) applyNetClass() {
 				continue
 			}
 
+			netClsData := &common.NetClsData{
+				ClassID:    baseNetClsData.ClassID,
+				Attributes: baseNetClsData.Attributes,
+			}
 			if p.CgroupV2Env {
 				cgID, err := p.metaServer.ExternalManager.GetCgroupIDForContainer(podUID, containerID)
 				if err != nil {
@@ -973,16 +977,16 @@ func (p *StaticPolicy) applyNetClass() {
 				activeNetClsData[cgID] = netClsData
 			}
 
-			go func(podUID, containerName string, netClsData *common.NetClsData) {
-				if err = p.applyNetClassFunc(podUID, containerID, netClsData); err != nil {
+			go func(podUID, containerName, containerID string, netClsData *common.NetClsData) {
+				if applyErr := p.applyNetClassFunc(podUID, containerID, netClsData); applyErr != nil {
 					general.Errorf("apply net class failed, pod: %s, container: %s(%s), netClsData: %+v, err: %v",
-						podUID, containerName, containerID, *netClsData, err)
+						podUID, containerName, containerID, *netClsData, applyErr)
 					return
 				}
 
 				general.Infof("apply net class successfully, pod: %s, container: %s(%s), netClsData: %+v",
 					podUID, containerName, containerID, *netClsData)
-			}(string(pod.UID), container.Name, netClsData)
+			}(podUID, containerName, containerID, netClsData)
 		}
 	}
 

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy.go
@@ -93,6 +93,7 @@ type StaticPolicy struct {
 
 	CgroupV2Env                                     bool
 	qosLevelToNetClassMap                           map[string]uint32
+	isContainerCgroupExistFunc                      func(podUID, containerID string) (bool, error)
 	applyNetClassFunc                               func(podUID, containerID string, data *common.NetClsData) error
 	applyNetworkGroupsFunc                          func(map[string]*qrmgeneral.NetworkGroup) error
 	podLevelNetClassAnnoKey                         string
@@ -162,6 +163,7 @@ func NewStaticPolicy(agentCtx *agent.GenericContext, conf *config.Configuration,
 		podAnnotationKeptKeys:           conf.PodAnnotationKeptKeys,
 		podLabelKeptKeys:                conf.PodLabelKeptKeys,
 		aliveCgroupID:                   make(map[uint64]time.Time),
+		isContainerCgroupExistFunc:      common.IsContainerCgroupExist,
 	}
 
 	if common.CheckCgroup2UnifiedMode() {
@@ -953,7 +955,7 @@ func (p *StaticPolicy) applyNetClass() {
 				continue
 			}
 
-			if exist, err := common.IsContainerCgroupExist(podUID, containerID); err != nil {
+			if exist, err := p.isContainerCgroupExistFunc(podUID, containerID); err != nil {
 				general.Errorf("check if container cgroup exists failed, pod: %s, container: %s(%s), err: %v",
 					podUID, containerName, containerID, err)
 				continue

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy_test.go
@@ -1815,6 +1815,116 @@ func TestStaticPolicy_applyNetClass(t *testing.T) {
 	policy.applyNetClass()
 }
 
+func TestStaticPolicy_applyNetClassWithMultiContainerCgroupID(t *testing.T) {
+	t.Parallel()
+	defer mockey.UnPatchAll()
+
+	policy := makeStaticPolicy(t, true)
+	assert.NotNil(t, policy)
+	policy.CgroupV2Env = true
+	policy.aliveCgroupID = make(map[uint64]time.Time)
+	policy.metaServer.PodFetcher = &pod.PodFetcherStub{
+		PodList: []*v1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-name",
+					Namespace: "test-namespace",
+					UID:       "test-pod-uid",
+					Annotations: map[string]string{
+						consts.PodAnnotationNetClassKey: testSharedNetClsId,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test-container-name-1",
+						},
+						{
+							Name: "test-container-name-2",
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:        "test-container-name-1",
+							ContainerID: "test-container-id-1",
+						},
+						{
+							Name:        "test-container-name-2",
+							ContainerID: "test-container-id-2",
+						},
+					},
+				},
+			},
+		},
+	}
+	policy.metaServer.ExternalManager = &external.DummyExternalManager{
+		CgroupIDManager: &cgroupid.CgroupIDManagerStub{
+			ContainerCGroupIDMap: map[string]map[string]uint64{
+				"test-pod-uid": {
+					"test-container-id-1": 314125,
+					"test-container-id-2": 242352,
+				},
+			},
+		},
+		NetworkManager: &network.NetworkManagerStub{
+			NetClassMap: map[string]map[string]*common.NetClsData{},
+		},
+	}
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	applied := make(chan struct {
+		containerID string
+		netClsData  common.NetClsData
+		dataPtr     *common.NetClsData
+	}, 2)
+	policy.applyNetClassFunc = func(_, containerID string, data *common.NetClsData) error {
+		entered <- struct{}{}
+		<-release
+		applied <- struct {
+			containerID string
+			netClsData  common.NetClsData
+			dataPtr     *common.NetClsData
+		}{
+			containerID: containerID,
+			netClsData:  *data,
+			dataPtr:     data,
+		}
+		return nil
+	}
+
+	mockey.Mock(common.IsContainerCgroupExist).To(func(podUID, containerID string) (bool, error) {
+		return true, nil
+	}).Build()
+
+	policy.applyNetClass()
+	for i := 0; i < 2; i++ {
+		<-entered
+	}
+	close(release)
+
+	got := make(map[string]struct {
+		netClsData common.NetClsData
+		dataPtr    *common.NetClsData
+	})
+	for i := 0; i < 2; i++ {
+		record := <-applied
+		got[record.containerID] = struct {
+			netClsData common.NetClsData
+			dataPtr    *common.NetClsData
+		}{
+			netClsData: record.netClsData,
+			dataPtr:    record.dataPtr,
+		}
+	}
+
+	assert.Equal(t, uint64(314125), got["test-container-id-1"].netClsData.CgroupID)
+	assert.Equal(t, uint64(242352), got["test-container-id-2"].netClsData.CgroupID)
+	assert.NotSame(t, got["test-container-id-1"].dataPtr, got["test-container-id-2"].dataPtr)
+}
+
 type errCgroupIDManager struct {
 	cgroupid.CgroupIDManagerStub
 	errListCgroupIDsForPod error

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy_test.go
@@ -1816,7 +1816,6 @@ func TestStaticPolicy_applyNetClass(t *testing.T) {
 }
 
 func TestStaticPolicy_applyNetClassWithMultiContainerCgroupID(t *testing.T) {
-	t.Parallel()
 	defer mockey.UnPatchAll()
 
 	policy := makeStaticPolicy(t, true)
@@ -1875,6 +1874,14 @@ func TestStaticPolicy_applyNetClassWithMultiContainerCgroupID(t *testing.T) {
 
 	entered := make(chan struct{}, 2)
 	release := make(chan struct{})
+	releaseCalls := func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}
+	defer releaseCalls()
 	applied := make(chan struct {
 		containerID string
 		netClsData  common.NetClsData
@@ -1901,16 +1908,29 @@ func TestStaticPolicy_applyNetClassWithMultiContainerCgroupID(t *testing.T) {
 
 	policy.applyNetClass()
 	for i := 0; i < 2; i++ {
-		<-entered
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for applyNetClassFunc call %d", i+1)
+		}
 	}
-	close(release)
+	releaseCalls()
 
 	got := make(map[string]struct {
 		netClsData common.NetClsData
 		dataPtr    *common.NetClsData
 	})
 	for i := 0; i < 2; i++ {
-		record := <-applied
+		var record struct {
+			containerID string
+			netClsData  common.NetClsData
+			dataPtr     *common.NetClsData
+		}
+		select {
+		case record = <-applied:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for applyNetClassFunc result %d", i+1)
+		}
 		got[record.containerID] = struct {
 			netClsData common.NetClsData
 			dataPtr    *common.NetClsData

--- a/pkg/agent/qrm-plugins/network/staticpolicy/policy_test.go
+++ b/pkg/agent/qrm-plugins/network/staticpolicy/policy_test.go
@@ -201,16 +201,17 @@ func makeStaticPolicy(t *testing.T, hasNic bool) *StaticPolicy {
 			consts.PodAnnotationQoSLevelReclaimedCores: testDefaultReclaimedNetClsId,
 			consts.PodAnnotationQoSLevelDedicatedCores: testDefaultDedicatedNetClsId,
 		},
-		agentCtx:                                 agentCtx,
-		applyNetworkGroupsFunc:                   agentCtx.MetaServer.ExternalManager.ApplyNetworkGroups,
-		nicManager:                               nicManager,
-		state:                                    stateImpl,
-		residualHitMap:                           make(map[string]int64),
-		podLevelNetClassAnnoKey:                  consts.PodAnnotationNetClassKey,
-		podLevelNetAttributesAnnoKeys:            []string{},
-		ipv4ResourceAllocationAnnotationKey:      testIPv4ResourceAllocationAnnotationKey,
-		ipv6ResourceAllocationAnnotationKey:      testIPv6ResourceAllocationAnnotationKey,
-		netNSPathResourceAllocationAnnotationKey: testNetNSPathResourceAllocationAnnotationKey,
+		agentCtx:                                        agentCtx,
+		isContainerCgroupExistFunc:                      common.IsContainerCgroupExist,
+		applyNetworkGroupsFunc:                          agentCtx.MetaServer.ExternalManager.ApplyNetworkGroups,
+		nicManager:                                      nicManager,
+		state:                                           stateImpl,
+		residualHitMap:                                  make(map[string]int64),
+		podLevelNetClassAnnoKey:                         consts.PodAnnotationNetClassKey,
+		podLevelNetAttributesAnnoKeys:                   []string{},
+		ipv4ResourceAllocationAnnotationKey:             testIPv4ResourceAllocationAnnotationKey,
+		ipv6ResourceAllocationAnnotationKey:             testIPv6ResourceAllocationAnnotationKey,
+		netNSPathResourceAllocationAnnotationKey:        testNetNSPathResourceAllocationAnnotationKey,
 		netInterfaceNameResourceAllocationAnnotationKey: testNetInterfaceNameResourceAllocationAnnotationKey,
 		netClassIDResourceAllocationAnnotationKey:       testNetClassIDResourceAllocationAnnotationKey,
 		netBandwidthResourceAllocationAnnotationKey:     testNetBandwidthResourceAllocationAnnotationKey,
@@ -1816,12 +1817,15 @@ func TestStaticPolicy_applyNetClass(t *testing.T) {
 }
 
 func TestStaticPolicy_applyNetClassWithMultiContainerCgroupID(t *testing.T) {
-	defer mockey.UnPatchAll()
+	t.Parallel()
 
 	policy := makeStaticPolicy(t, true)
 	assert.NotNil(t, policy)
 	policy.CgroupV2Env = true
 	policy.aliveCgroupID = make(map[uint64]time.Time)
+	policy.isContainerCgroupExistFunc = func(_, _ string) (bool, error) {
+		return true, nil
+	}
 	policy.metaServer.PodFetcher = &pod.PodFetcherStub{
 		PodList: []*v1.Pod{
 			{
@@ -1901,10 +1905,6 @@ func TestStaticPolicy_applyNetClassWithMultiContainerCgroupID(t *testing.T) {
 		}
 		return nil
 	}
-
-	mockey.Mock(common.IsContainerCgroupExist).To(func(podUID, containerID string) (bool, error) {
-		return true, nil
-	}).Build()
 
 	policy.applyNetClass()
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
## Summary

Fix `applyNetClass` to use a per-container `NetClsData` instance when applying net class data.

In the previous implementation, `applyNetClass` built one pod-level `*NetClsData` and then overwrote `CgroupID` inside the container loop before passing the same pointer to async goroutines. On cgroup v2, `CgroupID` is container-specific, so multi-container pods could apply the wrong CgroupID, typically the last container's value.

This PR:
- builds a fresh `NetClsData` per container while preserving pod-level `ClassID` and attributes
- passes `containerID` explicitly into the goroutine
- uses a local `applyErr` instead of writing the outer `err` from goroutines
- adds a regression test for multi-container CgroupID isolation

## Validation

Passed locally:

```bash
git diff --check
go vet ./pkg/agent/qrm-plugins/network/staticpolicy
```

Also passed related package tests:

```bash
go test ./pkg/util/external/network ./pkg/metaserver/external/cgroupid -count=1
go test ./pkg/agent/qrm-plugins/network/state ./pkg/util/cgroup/common -count=1
```

Target test is added but cannot run on the current macOS environment because `mockey` fails to link with `runtime.duffcopy/runtime.duffzero` relocation errors:

```bash
go test ./pkg/agent/qrm-plugins/network/staticpolicy -run TestStaticPolicy_applyNetClassWithMultiContainerCgroupID -count=1
```

## Runtime verification

Built and deployed the generated agent binary in a validation environment, then restarted QRM.

Validation result:
- QRM restarted successfully
- the running QRM process used the newly built binary
- recent QRM logs did not show `panic|fatal|error|failed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### English
- Fixes `applyNetClass` for multi-container pods on cgroup v2.
- Creates separate `NetClsData` instances and assigns each container its own `CgroupID`.
- Preserves pod-level `ClassID` and attributes.
- Passes container context explicitly to asynchronous goroutines and uses local error handling.
- Adds a regression test for `CgroupID` isolation and data independence.
- Changes only the network static policy agent component. No configuration, dependency, controller, scheduler, or release-wiring changes.
- Risk is limited to network static policy application. Formatting checks, `go vet`, related tests, and Linux runtime verification passed. The target test could not run on macOS because of `mockey` linker relocation errors.

### 简体中文
- 修复 cgroup v2 多容器 Pod 中的 `applyNetClass`。
- 为每个容器创建独立的 `NetClsData`，并设置各自的 `CgroupID`。
- 保留 Pod 级别的 `ClassID` 和属性。
- 向异步 goroutine 显式传递容器上下文，并使用局部错误处理。
- 添加 `CgroupID` 隔离和数据独立性的回归测试。
- 仅修改 network static policy agent 组件。不涉及配置、依赖、controller、scheduler 或 release wiring。
- 风险限于 network static policy 应用逻辑。格式检查、`go vet`、相关测试和 Linux 运行时验证均已通过。目标测试因 macOS 上的 `mockey` linker relocation errors 无法运行。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->