### PR TITLE
Handle small resource sets in balanced allocation scoring

### DIFF
--- a/pkg/scheduler/plugins/noderesourcetopology/balanced_allocation.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/balanced_allocation.go
@@ -41,6 +41,13 @@ func balancedAllocationScoreStrategy(requested, allocatable v1.ResourceList, res
 		resourceFractions = append(resourceFractions, resourceFraction)
 	}
 
+	if len(resourceFractions) == 0 {
+		return 0
+	}
+	// Sample variance needs two values; a single resource has no imbalance.
+	if len(resourceFractions) == 1 {
+		return framework.MaxNodeScore
+	}
 	variance := stat.Variance(resourceFractions, nil)
 
 	// Since the variance is between positive fractions, it will be positive fraction. 1-variance lets the

--- a/pkg/scheduler/plugins/noderesourcetopology/balanced_allocation_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/balanced_allocation_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesourcetopology
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestBalancedScoreFinite(t *testing.T) {
+	capacity := v1.ResourceList{v1.ResourceCPU: resource.MustParse("4"), v1.ResourceMemory: resource.MustParse("8Gi")}
+	tests := []struct {
+		name      string
+		requested v1.ResourceList
+		aligned   sets.String
+		want      int64
+	}{
+		{"empty", v1.ResourceList{}, nil, 0},
+		{"single CPU", v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}, nil, 100},
+		{"all excluded", v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")}, sets.NewString("memory"), 0},
+		{"two resources", v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("4Gi")}, nil, 100},
+		{"single resource over capacity", v1.ResourceList{v1.ResourceCPU: resource.MustParse("5")}, nil, 0},
+		{"unequal fractions", v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("6Gi")}, nil, 87},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := balancedAllocationScoreStrategy(tt.requested, capacity, nil, tt.aligned)
+			if got != tt.want {
+				t.Errorf("score = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/plugins/noderesourcetopology/score_test.go
+++ b/pkg/scheduler/plugins/noderesourcetopology/score_test.go
@@ -404,6 +404,44 @@ func TestScore(t *testing.T) {
 
 	dedicatedTestCases := []testCase{
 		{
+			name:            "balanced allocation with only CPU aligned",
+			policy:          v1alpha1.TopologyPolicySingleNUMANodeContainerLevel,
+			strategy:        consts.BalancedAllocation,
+			alignedResource: []string{"cpu"},
+			wantRes: map[string]int64{
+				"node-2numa-8c16g":                 100,
+				"node-2numa-4c8g":                  100,
+				"node-2numa-8c16g-with-allocation": 100,
+				"node-4numa-8c16g":                 100,
+			},
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+				consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+			}),
+		},
+		{
+			name:            "balanced allocation with no requested resource aligned",
+			policy:          v1alpha1.TopologyPolicySingleNUMANodeContainerLevel,
+			strategy:        consts.BalancedAllocation,
+			alignedResource: []string{"Gpu"},
+			wantRes: map[string]int64{
+				"node-2numa-8c16g":                 0,
+				"node-2numa-4c8g":                  0,
+				"node-2numa-8c16g-with-allocation": 0,
+				"node-4numa-8c16g":                 0,
+			},
+			pod: makePodByResourceList(&v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+			}, map[string]string{
+				consts.PodAnnotationQoSLevelKey:          consts.PodAnnotationQoSLevelDedicatedCores,
+				consts.PodAnnotationMemoryEnhancementKey: `{"numa_binding":"true"}`,
+			}),
+		},
+		{
 			name:            "dedicated_cores with numabinding + single numa + MostAllocated strategy",
 			policy:          v1alpha1.TopologyPolicySingleNUMANodeContainerLevel,
 			strategy:        config.MostAllocated,


### PR DESCRIPTION
#### What type of PR is this?

Bug fixes

#### What this PR does / why we need it:

With only CPU aligned, balanced allocation calls sample variance with one value and returns an invalid negative score. Empty or fully filtered resource requests have the same problem. These scores propagate through `TopologyMatch.Score`.

Return 0 when no resources contribute and `MaxNodeScore` for a single resource, which has no imbalance. The existing over-capacity check and multi-resource calculation still apply.

#### Which issue(s) this PR fixes:

Addresses the balanced-allocation case in #1216.

#### Special notes for your reviewer:

Adds six scorer cases and two cases through `TopologyMatch.Score`. Both test functions reproduce failures with the original scorer. The full `noderesourcetopology` package passes with `-race`, and `go vet` passes on Linux: [validation run](https://github.com/Hanabi9248/katalyst-core/actions/runs/34678140047).

The run checks the exact contribution commit, `9de3afe`; the validation workflow is confined to a separate fork branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### English

- Fix `balancedAllocationScoreStrategy` for empty, fully filtered, and single-resource inputs.
- Return `0` when no aligned resources contribute.
- Return `MaxNodeScore` when one resource contributes.
- Preserve over-capacity checks and multi-resource variance scoring.
- Update `TopologyMatch.Score` behavior through the corrected scorer.
- Add unit and integration coverage for CPU, GPU, NUMA, filtered, balanced, and over-capacity cases.
- Scheduler scoring behavior changes only. No configuration, dependency, agent, controller, or release wiring changes.
- Rollout risk is low. `noderesourcetopology` passes with `-race`, and `go vet` passes on Linux.

### 简体中文

- 修复 `balancedAllocationScoreStrategy` 对空输入、资源全部过滤和单资源输入的处理。
- 没有对齐资源参与时返回 `0`。
- 只有一个资源参与时返回 `MaxNodeScore`。
- 保留容量超限检查和多资源方差评分逻辑。
- 修正后的 scorer 同时修复 `TopologyMatch.Score` 的相关行为。
- 增加 CPU、GPU、NUMA、资源过滤、均衡资源和容量超限场景的单元测试与集成测试。
- 变更仅影响 scheduler 评分行为。不涉及配置、依赖、agent、controller 或 release wiring。
- 发布风险低。`noderesourcetopology` 通过 `-race`，并且 Linux 下 `go vet` 通过。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->