### PR TITLE
feat(irqtuner): support aarch64 balance-fair tuning

### DIFF
--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/consts.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/consts.go
@@ -28,6 +28,7 @@ const (
 const (
 	NewIrqTuningControllerFailed                            string = "NewIrqTuningControllerFailed"
 	InvalidDynamicConfig                                    string = "InvalidDynamicConfig"
+	UnsupportedIrqTuningPolicyFallback                      string = "UnsupportedIrqTuningPolicyFallback"
 	ListHostActiveUplinkNicsFailed                          string = "ListHostActiveUplinkNicsFailed"
 	UpdateNicIrqTuningManagersFailed                        string = "UpdateNicIrqTuningManagersFailed"
 	SyncContainersFailed                                    string = "SyncContainersFailed"

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux.go
@@ -482,6 +482,20 @@ type IrqTuningController struct {
 	IrqAffinityChanges map[int]*IrqAffinityChange // nic ifindex as map key. used to record irq affinity changes in each periodicTuning, and will be reset at the beginning of periodicTuning
 }
 
+func fallbackUnsupportedIrqTuningPolicy(conf *config.IrqTuningConfig) (config.IrqTuningPolicy, bool) {
+	requestedPolicy := conf.IrqTuningPolicy
+	if conf.IrqTuningPolicy == config.IrqTuningAuto ||
+		conf.IrqTuningPolicy == config.IrqTuningIrqCoresExclusive {
+		conf.IrqTuningPolicy = config.IrqTuningBalanceFair
+		return requestedPolicy, true
+	}
+	return requestedPolicy, false
+}
+
+func useCCDBalance(vendor cpuid.Vendor) bool {
+	return vendor == cpuid.AMD
+}
+
 func NewNicIrqTuningManager(conf *config.IrqTuningConfig, nic *machine.NicBasicInfo, assignedSockets []int, order ExclusiveIrqCoresSelectOrder) (*NicIrqTuningManager, error) {
 	nicInfo, err := GetNicInfo(nic)
 	if err != nil {
@@ -585,12 +599,20 @@ func NewIrqTuningController(agentConf *agent.AgentConfiguration, irqStateAdapter
 		general.Errorf("%s GetDynamicConfiguration return nil", IrqTuningLogPrefix)
 	}
 	conf := config.ConvertDynamicConfigToIrqTuningConfig(dynConf)
-
 	cpuInfo := machineInfo.CPUTopology.CPUInfo
+	requestedPolicy, fallback := fallbackUnsupportedIrqTuningPolicy(conf)
+	if fallback {
+		general.Errorf("%s irq tuning policy %s is unsupported, fallback to %s",
+			IrqTuningLogPrefix, requestedPolicy, conf.IrqTuningPolicy)
+		_ = emitter.StoreInt64(metricUtil.MetricNameIrqTuningErr, irqtuner.IrqTuningError, metrics.MetricTypeNameRaw,
+			metrics.MetricTag{Key: "reason", Val: irqtuner.UnsupportedIrqTuningPolicyFallback},
+			metrics.MetricTag{Key: "requested_policy", Val: string(requestedPolicy)},
+			metrics.MetricTag{Key: "effective_policy", Val: string(conf.IrqTuningPolicy)})
+	}
 
 	if cpuInfo == nil {
 		if cpuid.CPU.VendorID != cpuid.Intel && cpuid.CPU.VendorID != cpuid.AMD {
-			general.Infof("%s unsupported cpu arch: %s", IrqTuningLogPrefix, cpuInfo.CPUVendor)
+			general.Infof("%s unsupported cpu vendor %s", IrqTuningLogPrefix, cpuid.CPU.VendorID)
 			return nil, nil
 		}
 		retErr = fmt.Errorf("machineInfo.CPUTopology.CPUInfo is nil")
@@ -1412,28 +1434,32 @@ func (ic *IrqTuningController) String() string {
 		msg = fmt.Sprintf("%s%s    CPUVendor: %s\n", msg, indent, ic.CPUInfo.CPUVendor)
 
 		msg = fmt.Sprintf("%s%s    Sockets:\n", msg, indent)
-		for i := 0; i < len(ic.CPUInfo.Sockets); i++ {
-			socket := ic.CPUInfo.Sockets[i]
+		for _, socketID := range ic.CPUInfo.GetSocketSlice() {
+			socket := ic.CPUInfo.Sockets[socketID]
 			indent = spaces + spaces
-			msg = fmt.Sprintf("%s%s    Sockets[%d]:\n", msg, indent, i)
+			msg = fmt.Sprintf("%s%s    Sockets[%d]:\n", msg, indent, socketID)
 
 			indent = spaces + spaces + spaces
 			msg = fmt.Sprintf("%s%s    NumaIDs: %+v\n", msg, indent, socket.NumaIDs)
 			msg = fmt.Sprintf("%s%s    CPUs: %+v\n", msg, indent, socket.CPUs)
 
-			if ic.CPUInfo.CPUVendor == cpuid.Intel {
-				msg = fmt.Sprintf("%s%s    IntelNumas:\n", msg, indent)
-				for _, j := range socket.NumaIDs {
-					numa := socket.IntelNumas[j]
+			if socket.Numas != nil {
+				msg = fmt.Sprintf("%s%s    Numas:\n", msg, indent)
+				for _, numaID := range socket.NumaIDs {
+					numa := socket.Numas[numaID]
+					if numa == nil {
+						continue
+					}
+
 					indent = spaces + spaces + spaces + spaces
-					msg = fmt.Sprintf("%s%s    IntelNumas[%d]:\n", msg, indent, j)
+					msg = fmt.Sprintf("%s%s    Numas[%d]:\n", msg, indent, numaID)
 
 					indent = spaces + spaces + spaces + spaces + spaces
 					for _, phyCore := range numa.PhyCores {
 						msg = fmt.Sprintf("%s%s    CPUs: %+v\n", msg, indent, phyCore.CPUs)
 					}
 				}
-			} else if ic.CPUInfo.CPUVendor == cpuid.AMD {
+			} else if socket.AMDNumas != nil {
 				msg = fmt.Sprintf("%s%s    AMDNumas:\n", msg, indent)
 				for _, j := range socket.NumaIDs {
 					numa := socket.AMDNumas[j]
@@ -3112,13 +3138,7 @@ func (ic *IrqTuningController) tuneNicIrqsAffinityCCDsFairly(nic *NicInfo, irqs 
 }
 
 func (ic *IrqTuningController) tuneNicIrqsAffinityLLCDomainsFairly(nic *NicInfo, assignedSockets []int) error {
-	if ic.CPUInfo.CPUVendor == cpuid.Intel {
-		return ic.tuneNicIrqsAffinityNumasFairly(nic, assignedSockets, false)
-	} else if ic.CPUInfo.CPUVendor == cpuid.AMD {
-		return ic.tuneNicIrqsAffinityNumasFairly(nic, assignedSockets, true)
-	} else {
-		return fmt.Errorf("unsupport cpu arch: %s", ic.CPUInfo.CPUVendor)
-	}
+	return ic.tuneNicIrqsAffinityNumasFairly(nic, assignedSockets, useCCDBalance(ic.CPUInfo.CPUVendor))
 }
 
 func (ic *IrqTuningController) tuneNicIrqsAffinityFairly(nic *NicInfo, assignedSockets []int) error {
@@ -3356,13 +3376,10 @@ func (ic *IrqTuningController) balanceNicIrqsInCCDFairly(nic *NicInfo, assignedS
 }
 
 func (ic *IrqTuningController) balanceNicIrqsInLLCDomainFairly(nic *NicInfo, assignedSockets []int) error {
-	if ic.CPUInfo.CPUVendor == cpuid.Intel {
-		return ic.balanceNicIrqsInNumaFairly(nic, assignedSockets)
-	} else if ic.CPUInfo.CPUVendor == cpuid.AMD {
+	if useCCDBalance(ic.CPUInfo.CPUVendor) {
 		return ic.balanceNicIrqsInCCDFairly(nic, assignedSockets)
-	} else {
-		return fmt.Errorf("unsupport cpu arch: %s", ic.CPUInfo.CPUVendor)
 	}
+	return ic.balanceNicIrqsInNumaFairly(nic, assignedSockets)
 }
 
 func (ic *IrqTuningController) balanceNicIrqsFairly(nic *NicInfo, assignedSockets []int) error {
@@ -3976,7 +3993,7 @@ func (ic *IrqTuningController) selectExclusiveIrqCoresFromNuma(irqCoresNum int, 
 	}
 
 	var phyCores []machine.PhyCore
-	if ic.CPUInfo.CPUVendor == cpuid.AMD {
+	if socket.AMDNumas != nil {
 		numa, ok := socket.AMDNumas[numaID]
 		if !ok {
 			return nil, fmt.Errorf("invalid numa id %d", numaID)
@@ -3985,8 +4002,8 @@ func (ic *IrqTuningController) selectExclusiveIrqCoresFromNuma(irqCoresNum int, 
 		for _, ccd := range numa.CCDs {
 			phyCores = append(phyCores, ccd.PhyCores...)
 		}
-	} else if ic.CPUInfo.CPUVendor == cpuid.Intel {
-		numa, ok := socket.IntelNumas[numaID]
+	} else {
+		numa, ok := socket.Numas[numaID]
 		if !ok {
 			return nil, fmt.Errorf("invalid numa id %d", numaID)
 		}
@@ -5392,13 +5409,10 @@ func (ic *IrqTuningController) setRPSInCCDForNic(nic *NicIrqTuningManager, assig
 }
 
 func (ic *IrqTuningController) setRPSForNic(nic *NicIrqTuningManager) error {
-	if ic.CPUInfo.CPUVendor == cpuid.Intel {
-		return ic.setRPSInNumaForNic(nic, nic.AssignedSockets)
-	} else if ic.CPUInfo.CPUVendor == cpuid.AMD {
+	if useCCDBalance(ic.CPUInfo.CPUVendor) {
 		return ic.setRPSInCCDForNic(nic, nic.AssignedSockets)
-	} else {
-		return fmt.Errorf("unsupport cpu arch: %s", ic.CPUInfo.CPUVendor)
 	}
+	return ic.setRPSInNumaForNic(nic, nic.AssignedSockets)
 }
 
 func (ic *IrqTuningController) setRPSForNics(nics []*NicIrqTuningManager) error {
@@ -5839,7 +5853,18 @@ func (ic *IrqTuningController) syncDynamicConfig() {
 	}
 
 	conf := config.ConvertDynamicConfigToIrqTuningConfig(dynConf)
-	if !ic.conf.Equal(conf) {
+	requestedPolicy, fallback := fallbackUnsupportedIrqTuningPolicy(conf)
+	if fallback {
+		ic.emitErrMetric(irqtuner.UnsupportedIrqTuningPolicyFallback, irqtuner.IrqTuningError,
+			metrics.MetricTag{Key: "requested_policy", Val: string(requestedPolicy)},
+			metrics.MetricTag{Key: "effective_policy", Val: string(conf.IrqTuningPolicy)})
+	}
+	configChanged := ic.conf == nil || !ic.conf.Equal(conf)
+	if configChanged {
+		if fallback {
+			general.Errorf("%s irq tuning policy %s is unsupported, fallback to %s",
+				IrqTuningLogPrefix, requestedPolicy, conf.IrqTuningPolicy)
+		}
 		general.Infof("%s new config: %s", IrqTuningLogPrefix, conf)
 	}
 

--- a/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux_test.go
+++ b/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/controller/controller_linux_test.go
@@ -25,12 +25,169 @@ import (
 	"testing"
 
 	. "github.com/bytedance/mockey"
+	"github.com/klauspost/cpuid/v2"
+	"github.com/kubewharf/katalyst-api/pkg/apis/config/v1alpha1"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner"
 	"github.com/kubewharf/katalyst-core/pkg/agent/qrm-plugins/cpu/dynamicpolicy/irqtuner/config"
+	"github.com/kubewharf/katalyst-core/pkg/config/agent"
 	"github.com/kubewharf/katalyst-core/pkg/metrics"
 	"github.com/kubewharf/katalyst-core/pkg/util/machine"
 )
+
+type recordingMetricsEmitter struct {
+	metrics.DummyMetrics
+	records []metricRecord
+}
+
+type metricRecord struct {
+	key  string
+	val  int64
+	tags []metrics.MetricTag
+}
+
+func (e *recordingMetricsEmitter) StoreInt64(key string, val int64, _ metrics.MetricTypeName, tags ...metrics.MetricTag) error {
+	e.records = append(e.records, metricRecord{key: key, val: val, tags: tags})
+	return nil
+}
+
+func TestFallbackUnsupportedIrqTuningPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		policy    config.IrqTuningPolicy
+		effective config.IrqTuningPolicy
+		fallback  bool
+	}{
+		{
+			name:      "auto",
+			policy:    config.IrqTuningAuto,
+			effective: config.IrqTuningBalanceFair,
+			fallback:  true,
+		},
+		{
+			name:      "exclusive",
+			policy:    config.IrqTuningIrqCoresExclusive,
+			effective: config.IrqTuningBalanceFair,
+			fallback:  true,
+		},
+		{
+			name:      "balance",
+			policy:    config.IrqTuningBalanceFair,
+			effective: config.IrqTuningBalanceFair,
+			fallback:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			conf := config.NewConfiguration()
+			conf.EnableIrqTuning = true
+			conf.IrqTuningPolicy = tt.policy
+
+			requested, fallback := fallbackUnsupportedIrqTuningPolicy(conf)
+
+			assert.Equal(t, tt.policy, requested)
+			assert.Equal(t, tt.fallback, fallback)
+			assert.True(t, conf.EnableIrqTuning)
+			assert.Equal(t, tt.effective, conf.IrqTuningPolicy)
+		})
+	}
+}
+
+func TestSyncDynamicConfigFallsBackUnsupportedPolicy(t *testing.T) {
+	agentConf := agent.NewAgentConfiguration()
+	agentConf.GetDynamicConfiguration().IRQTuningConfiguration.EnableTuner = true
+	agentConf.GetDynamicConfiguration().IRQTuningConfiguration.TuningPolicy =
+		v1alpha1.TuningPolicyExclusive
+	emitter := &recordingMetricsEmitter{}
+
+	controller := &IrqTuningController{
+		agentConf: agentConf,
+		conf:      config.NewConfiguration(),
+		emitter:   emitter,
+	}
+
+	controller.syncDynamicConfig()
+
+	assert.True(t, controller.conf.EnableIrqTuning)
+	assert.Equal(t, config.IrqTuningBalanceFair, controller.conf.IrqTuningPolicy)
+	assert.Len(t, emitter.records, 1)
+	assert.Equal(t, irqtuner.UnsupportedIrqTuningPolicyFallback, emitter.records[0].tags[0].Val)
+}
+
+func TestUseCCDBalance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		vendor   cpuid.Vendor
+		expected bool
+	}{
+		{
+			name:     "AMD uses CCD",
+			vendor:   cpuid.AMD,
+			expected: true,
+		},
+		{
+			name:     "Intel uses NUMA",
+			vendor:   cpuid.Intel,
+			expected: false,
+		},
+		{
+			name:     "arm64 unknown vendor uses NUMA",
+			vendor:   cpuid.VendorUnknown,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, useCCDBalance(tt.vendor))
+		})
+	}
+}
+
+func TestIrqTuningControllerStringWithNUMA(t *testing.T) {
+	t.Parallel()
+
+	controller := &IrqTuningController{
+		CPUInfo: &machine.CPUInfo{
+			CPUVendor: cpuid.Intel,
+			Sockets: map[int]*machine.CPUSocket{
+				2: {
+					NumaIDs: []int{3},
+					CPUs:    []int64{4, 5},
+					Numas: map[int]*machine.LLCDomain{
+						3: {
+							PhyCores: []machine.PhyCore{
+								{CPUs: []int64{4}},
+								{CPUs: []int64{5}},
+							},
+						},
+					},
+				},
+			},
+			CPU2Socket: map[int64]int{4: 2, 5: 2},
+			CPUOnline:  map[int64]bool{4: true, 5: true},
+		},
+	}
+
+	output := controller.String()
+
+	assert.Contains(t, output, "Sockets[2]:")
+	assert.Contains(t, output, "Numas:")
+	assert.Contains(t, output, "Numas[3]:")
+	assert.Contains(t, output, "CPUs: [4]")
+	assert.Contains(t, output, "CPUs: [5]")
+}
 
 func Test_controller_linux(t *testing.T) {
 	t.Parallel()

--- a/pkg/util/machine/architecture_linux.go
+++ b/pkg/util/machine/architecture_linux.go
@@ -1,0 +1,42 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2026 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func getMachineArchitecture() (string, error) {
+	var utsname syscall.Utsname
+	if err := syscall.Uname(&utsname); err != nil {
+		return "", fmt.Errorf("uname failed: %w", err)
+	}
+
+	machine := make([]byte, 0, len(utsname.Machine))
+	for _, c := range utsname.Machine {
+		if c == 0 {
+			break
+		}
+		machine = append(machine, byte(c))
+	}
+
+	return normalizeMachineArchitecture(string(machine)), nil
+}

--- a/pkg/util/machine/architecture_unsupported.go
+++ b/pkg/util/machine/architecture_unsupported.go
@@ -1,0 +1,26 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2026 The Katalyst Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import "runtime"
+
+func getMachineArchitecture() (string, error) {
+	return runtime.GOARCH, nil
+}

--- a/pkg/util/machine/cpu.go
+++ b/pkg/util/machine/cpu.go
@@ -193,10 +193,10 @@ type AMDNuma struct {
 }
 
 type CPUSocket struct {
-	NumaIDs    []int
-	CPUs       []int64
-	IntelNumas map[int]*LLCDomain // numa id as map key
-	AMDNumas   map[int]*AMDNuma   // numa id as map key
+	NumaIDs  []int
+	CPUs     []int64
+	Numas    map[int]*LLCDomain // numa id as map key
+	AMDNumas map[int]*AMDNuma   // numa id as map key
 }
 
 // CPUInfo is the cpu info, generally all cpus shown in below files are online, i.e. CPUInfo managed all CPUs are online,
@@ -209,6 +209,11 @@ type CPUInfo struct {
 	Sockets    map[int]*CPUSocket
 	CPU2Socket map[int64]int  // cpu id as map key, socket id as map value
 	CPUOnline  map[int64]bool // cpu id as map key, CPUOnline contains all online cpus, but not contains any offline cpu
+}
+
+type numaNodeCPUListFile struct {
+	nodeID      int
+	cpuListFile string
 }
 
 // CPUStat is the cpu stat info
@@ -346,7 +351,7 @@ func GetNumaPackageID(nodeID int) (int, error) {
 		return -1, fmt.Errorf("failed to GetCPUPackageID(%d), err %v", cpuList[0], err)
 	}
 
-	return phyPackageId, nil
+	return normalizePackageID(phyPackageId), nil
 }
 
 func GetCPUOnlineStatus(cpuID int64) (bool, error) {
@@ -425,7 +430,7 @@ func getLLCDomain(cpuListFile string) (*LLCDomain, error) {
 	return &llcDomain, nil
 }
 
-func getIntelNumaTopo(nodeCPUListFile string) (*LLCDomain, error) {
+func getNumaTopo(nodeCPUListFile string) (*LLCDomain, error) {
 	return getLLCDomain(nodeCPUListFile)
 }
 
@@ -464,18 +469,48 @@ func getAMDNumaTopo(nodeCPUListFile string) (*AMDNuma, error) {
 	return &numa, nil
 }
 
-func getSocketCPUList(socket *CPUSocket, cpuVendor cpuid.Vendor) []int64 {
+func addLLCDomainNuma(cpuInfo *CPUInfo, nodeID int, numa *LLCDomain) error {
+	if len(numa.PhyCores) == 0 || len(numa.PhyCores[0].CPUs) == 0 {
+		return nil
+	}
+
+	packageID, err := GetCPUPackageID(numa.PhyCores[0].CPUs[0])
+	if err != nil {
+		return fmt.Errorf("failed to GetCPUPackageID(%d), err %v", numa.PhyCores[0].CPUs[0], err)
+	}
+	packageID = normalizePackageID(packageID)
+
+	socket, ok := cpuInfo.Sockets[packageID]
+	if !ok {
+		socket = &CPUSocket{
+			Numas: make(map[int]*LLCDomain),
+		}
+		cpuInfo.Sockets[packageID] = socket
+	}
+
+	socket.Numas[nodeID] = numa
+	socket.NumaIDs = append(socket.NumaIDs, nodeID)
+	return nil
+}
+
+func getSocketCPUList(socket *CPUSocket) []int64 {
 	var cpuList []int64
-	if cpuVendor == cpuid.Intel {
+	if socket.Numas != nil {
 		for _, numaID := range socket.NumaIDs {
-			numa := socket.IntelNumas[numaID]
+			numa := socket.Numas[numaID]
+			if numa == nil {
+				continue
+			}
 			for _, phyCore := range numa.PhyCores {
 				cpuList = append(cpuList, phyCore.CPUs...)
 			}
 		}
-	} else if cpuVendor == cpuid.AMD {
+	} else if socket.AMDNumas != nil {
 		for _, numaID := range socket.NumaIDs {
 			numa := socket.AMDNumas[numaID]
+			if numa == nil {
+				continue
+			}
 			for _, ccd := range numa.CCDs {
 				for _, phyCore := range ccd.PhyCores {
 					cpuList = append(cpuList, phyCore.CPUs...)
@@ -498,56 +533,35 @@ func GetCPUInfoWithTopo() (*CPUInfo, error) {
 		CPUOnline:  make(map[int64]bool),
 	}
 
-	// TODO: arm will be supported in the future
-	if cpuInfo.CPUVendor != cpuid.Intel && cpuInfo.CPUVendor != cpuid.AMD {
-		general.Infof("unsupported cpu arch: %s", cpuInfo.CPUVendor)
+	architecture, err := getMachineArchitecture()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine architecture, err %v", err)
+	}
+	if architecture != "arm64" && cpuInfo.CPUVendor != cpuid.Intel && cpuInfo.CPUVendor != cpuid.AMD {
+		general.Infof("unsupported cpu vendor %s on architecture %s", cpuInfo.CPUVendor, architecture)
 		return nil, nil
 	}
 
-	dirEnts, err := os.ReadDir(nodeSysDir)
+	nodeCPUListFiles, err := getNUMANodeCPUListFiles()
 	if err != nil {
-		return nil, fmt.Errorf("failed to ReadDir(%s), err %v", nodeSysDir, err)
+		return nil, err
 	}
 
-	for _, d := range dirEnts {
-		if !d.IsDir() {
-			continue
-		}
-
-		if !strings.HasPrefix(d.Name(), "node") {
-			continue
-		}
-
-		nodeID, err := strconv.Atoi(strings.TrimPrefix(d.Name(), "node"))
-		if err != nil {
-			continue
-		}
-
-		nodeCPUListFile := filepath.Join(nodeSysDir, d.Name(), "cpulist")
+	for _, nodeCPUList := range nodeCPUListFiles {
+		nodeID := nodeCPUList.nodeID
+		nodeCPUListFile := nodeCPUList.cpuListFile
 		if _, err := os.Stat(nodeCPUListFile); err != nil && os.IsNotExist(err) {
 			return nil, fmt.Errorf("%s not exists", nodeCPUListFile)
 		}
 
-		if cpuInfo.CPUVendor == cpuid.Intel {
-			numa, err := getIntelNumaTopo(nodeCPUListFile)
+		if architecture == "arm64" || cpuInfo.CPUVendor == cpuid.Intel {
+			numa, err := getNumaTopo(nodeCPUListFile)
 			if err != nil {
-				return nil, fmt.Errorf("getIntelNumaTopo(%d), err %v", nodeID, err)
+				return nil, fmt.Errorf("getNumaTopo(%d), err %v", nodeID, err)
 			}
-			if len(numa.PhyCores) > 0 && len(numa.PhyCores[0].CPUs) > 0 {
-				phyPackageId, err := GetCPUPackageID(numa.PhyCores[0].CPUs[0])
-				if err != nil {
-					return nil, fmt.Errorf("failed to GetCPUPackageID(%d), err %v", numa.PhyCores[0].CPUs[0], err)
-				}
-				if _, ok := cpuInfo.Sockets[phyPackageId]; !ok {
-					cpuInfo.Sockets[phyPackageId] = &CPUSocket{
-						IntelNumas: make(map[int]*LLCDomain),
-					}
-				}
-				socket := cpuInfo.Sockets[phyPackageId]
-				socket.IntelNumas[nodeID] = numa
-				socket.NumaIDs = append(socket.NumaIDs, nodeID)
+			if err := addLLCDomainNuma(cpuInfo, nodeID, numa); err != nil {
+				return nil, err
 			}
-
 		} else if cpuInfo.CPUVendor == cpuid.AMD {
 			numa, err := getAMDNumaTopo(nodeCPUListFile)
 			if err != nil {
@@ -559,6 +573,7 @@ func GetCPUInfoWithTopo() (*CPUInfo, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to GetCPUPackageID(%d), err %v", numa.CCDs[0].PhyCores[0].CPUs[0], err)
 				}
+				phyPackageId = normalizePackageID(phyPackageId)
 				if _, ok := cpuInfo.Sockets[phyPackageId]; !ok {
 					cpuInfo.Sockets[phyPackageId] = &CPUSocket{
 						AMDNumas: make(map[int]*AMDNuma),
@@ -573,7 +588,7 @@ func GetCPUInfoWithTopo() (*CPUInfo, error) {
 
 	for socketID, socket := range cpuInfo.Sockets {
 		sort.Ints(socket.NumaIDs)
-		socketCPUList := getSocketCPUList(socket, cpuInfo.CPUVendor)
+		socketCPUList := getSocketCPUList(socket)
 		socket.CPUs = socketCPUList
 
 		for _, cpuID := range socketCPUList {
@@ -591,6 +606,59 @@ func GetCPUInfoWithTopo() (*CPUInfo, error) {
 	}
 
 	return cpuInfo, nil
+}
+
+func normalizeMachineArchitecture(machine string) string {
+	switch machine {
+	case "x86_64":
+		return "amd64"
+	case "aarch64":
+		return "arm64"
+	case "i386", "i486", "i586", "i686":
+		return "386"
+	default:
+		if strings.HasPrefix(machine, "armv") {
+			return "arm"
+		}
+		return machine
+	}
+}
+
+func getNUMANodeCPUListFiles() ([]numaNodeCPUListFile, error) {
+	dirEnts, err := os.ReadDir(nodeSysDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ReadDir(%s), err %v", nodeSysDir, err)
+	}
+
+	var files []numaNodeCPUListFile
+	for _, d := range dirEnts {
+		if !d.IsDir() || !strings.HasPrefix(d.Name(), "node") {
+			continue
+		}
+
+		nodeID, err := strconv.Atoi(strings.TrimPrefix(d.Name(), "node"))
+		if err != nil {
+			continue
+		}
+
+		files = append(files, numaNodeCPUListFile{
+			nodeID:      nodeID,
+			cpuListFile: filepath.Join(nodeSysDir, d.Name(), "cpulist"),
+		})
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no NUMA nodes found in %s", nodeSysDir)
+	}
+
+	return files, nil
+}
+
+func normalizePackageID(packageID int) int {
+	if packageID < 0 {
+		return 0
+	}
+	return packageID
 }
 
 func CollectCpuStats() (map[int64]*CPUStat, error) {
@@ -724,14 +792,15 @@ func getAMDSocketPhysicalCores(socket *CPUSocket) []PhyCore {
 	return phyCores
 }
 
-func getIntelSocketPhysicalCores(socket *CPUSocket) []PhyCore {
+func getNumaSocketPhysicalCores(socket *CPUSocket) []PhyCore {
 	var phyCores []PhyCore
 
 	// socket.NumaIDs is sorted by ascending order
 	for _, numaID := range socket.NumaIDs {
-		numa := socket.IntelNumas[numaID]
-		phyCores = append(phyCores, numa.PhyCores...)
-
+		numa := socket.Numas[numaID]
+		if numa != nil {
+			phyCores = append(phyCores, numa.PhyCores...)
+		}
 	}
 
 	return phyCores
@@ -749,17 +818,17 @@ func (c *CPUInfo) GetSocketSlice() []int {
 }
 
 func (c *CPUInfo) GetSocketPhysicalCores(socketID int) []PhyCore {
-	if socketID < 0 || socketID > len(c.Sockets) {
+	socket, ok := c.Sockets[socketID]
+	if socketID < 0 || !ok {
 		return nil
 	}
 
-	if c.CPUVendor == cpuid.AMD {
-		return getAMDSocketPhysicalCores(c.Sockets[socketID])
-	} else if c.CPUVendor == cpuid.Intel {
-		return getIntelSocketPhysicalCores(c.Sockets[socketID])
-	} else {
-		return nil
+	if socket.Numas != nil {
+		return getNumaSocketPhysicalCores(socket)
+	} else if socket.AMDNumas != nil {
+		return getAMDSocketPhysicalCores(socket)
 	}
+	return nil
 }
 
 func (c *CPUInfo) GetNodeCPUList(nodeID int) []int64 {
@@ -782,16 +851,20 @@ func (c *CPUInfo) GetNodeCPUList(nodeID int) []int64 {
 	}
 
 	var cpuList []int64
-	if c.CPUVendor == cpuid.Intel {
-		numa := socket.IntelNumas[nodeID]
-		for _, phyCore := range numa.PhyCores {
-			cpuList = append(cpuList, phyCore.CPUs...)
-		}
-	} else if c.CPUVendor == cpuid.AMD {
-		numa := socket.AMDNumas[nodeID]
-		for _, ccd := range numa.CCDs {
-			for _, phyCore := range ccd.PhyCores {
+	if socket.Numas != nil {
+		numa := socket.Numas[nodeID]
+		if numa != nil {
+			for _, phyCore := range numa.PhyCores {
 				cpuList = append(cpuList, phyCore.CPUs...)
+			}
+		}
+	} else if socket.AMDNumas != nil {
+		numa := socket.AMDNumas[nodeID]
+		if numa != nil {
+			for _, ccd := range numa.CCDs {
+				for _, phyCore := range ccd.PhyCores {
+					cpuList = append(cpuList, phyCore.CPUs...)
+				}
 			}
 		}
 	}

--- a/pkg/util/machine/cpu_linux_test.go
+++ b/pkg/util/machine/cpu_linux_test.go
@@ -40,6 +40,7 @@ import (
 func Test_GetCPUInfoWithTopo(t *testing.T) {
 	mockey.PatchConvey("Test GetCPUInfoWithTopo", t, func() {
 		mockey.Mock(os.Stat).Return(nil, nil).Build()
+		mockey.Mock(getMachineArchitecture).Return("amd64", nil).Build()
 		mockey.PatchConvey("Scenario 1: Successfully obtaining Intel CPU topology", func() {
 			// Arrange: Simulate an Intel CPU environment
 			mockey.MockValue(&cpuid.CPU.VendorID).To(cpuid.Intel)
@@ -53,8 +54,8 @@ func Test_GetCPUInfoWithTopo(t *testing.T) {
 					{CPUs: []int64{1, 3}}, // Physical core 1, containing logical core 1 and 3
 				},
 			}
-			mockey.Mock(getIntelNumaTopo).Return(mockIntelDomain, nil).Build()
-			mockey.Mock(GetCPUPackageID).Return(0, nil).Build()
+			mockey.Mock(getNumaTopo).Return(mockIntelDomain, nil).Build()
+			mockey.Mock(GetCPUPackageID).Return(-1, nil).Build()
 			mockey.Mock(GetCPUOnlineStatus).Return(true, nil).Build()
 
 			// Act: call the function to be tested
@@ -91,7 +92,7 @@ func Test_GetCPUInfoWithTopo(t *testing.T) {
 				},
 			}
 			mockey.Mock(getAMDNumaTopo).Return(mockAmdNuma, nil).Build()
-			mockey.Mock(GetCPUPackageID).Return(0, nil).Build()
+			mockey.Mock(GetCPUPackageID).Return(-1, nil).Build()
 			mockey.Mock(GetCPUOnlineStatus).Return(true, nil).Build()
 
 			// Act: call the function to be tested
@@ -108,16 +109,45 @@ func Test_GetCPUInfoWithTopo(t *testing.T) {
 			So(info.CPUOnline[8], ShouldBeTrue)
 		})
 
-		mockey.PatchConvey("Scenario 3: CPU manufacturers are not supported", func() {
+		mockey.PatchConvey("Scenario 3: Successfully obtaining arm64 CPU topology", func() {
+			mockey.MockValue(&cpuid.CPU.VendorID).To(cpuid.Intel)
+			mockey.Mock(getMachineArchitecture).Return("arm64", nil).Build()
+			mockNode0 := &mockDirEntry{entryName: "node0", isDir: true}
+			mockey.Mock(os.ReadDir).Return([]fs.DirEntry{mockNode0}, nil).Build()
+
+			genericNuma := &LLCDomain{
+				PhyCores: []PhyCore{
+					{CPUs: []int64{0}},
+					{CPUs: []int64{1}},
+				},
+			}
+			mockey.Mock(getNumaTopo).Return(genericNuma, nil).Build()
+			mockey.Mock(GetCPUPackageID).Return(-1, nil).Build()
+			mockey.Mock(GetCPUOnlineStatus).Return(true, nil).Build()
+
+			info, err := GetCPUInfoWithTopo()
+
+			So(err, ShouldBeNil)
+			So(info, ShouldNotBeNil)
+			So(info.CPUVendor, ShouldEqual, cpuid.Intel)
+			So(info.Sockets[0].NumaIDs, ShouldResemble, []int{0})
+			So(info.Sockets[0].Numas[0], ShouldResemble, genericNuma)
+			So(info.Sockets[0].CPUs, ShouldResemble, []int64{0, 1})
+			So(info.CPU2Socket, ShouldResemble, map[int64]int{0: 0, 1: 0})
+			So(info.CPUOnline, ShouldResemble, map[int64]bool{0: true, 1: true})
+		})
+
+		mockey.PatchConvey("Scenario 4: Unsupported CPU architecture is disabled", func() {
 			mockey.MockValue(&cpuid.CPU.VendorID).To(cpuid.VendorUnknown)
-			// Act: call the function to be tested
+			mockey.Mock(getMachineArchitecture).Return("ppc64le", nil).Build()
+
 			info, err := GetCPUInfoWithTopo()
 
 			So(info, ShouldBeNil)
 			So(err, ShouldBeNil)
 		})
 
-		mockey.PatchConvey("Scenario 4: Failed to read the node directory", func() {
+		mockey.PatchConvey("Scenario 5: Failed to read the node directory", func() {
 			mockey.MockValue(&cpuid.CPU.VendorID).To(cpuid.Intel)
 			expectedErr := errors.New("permission denied")
 			mockey.Mock(os.ReadDir).Return(nil, expectedErr).Build()
@@ -130,14 +160,14 @@ func Test_GetCPUInfoWithTopo(t *testing.T) {
 			So(err.Error(), ShouldContainSubstring, expectedErr.Error())
 		})
 
-		mockey.PatchConvey("Scenario 5: The offline CPU exists when obtaining the CPU's online status", func() {
+		mockey.PatchConvey("Scenario 6: The offline CPU exists when obtaining the CPU's online status", func() {
 			mockey.MockValue(&cpuid.CPU.VendorID).To(cpuid.Intel)
 			mockNode0 := &mockDirEntry{entryName: "node0", isDir: true}
 			mockey.Mock(os.ReadDir).Return([]fs.DirEntry{mockNode0}, nil).Build()
 			mockIntelDomain := &LLCDomain{
 				PhyCores: []PhyCore{{CPUs: []int64{0, 1}}},
 			}
-			mockey.Mock(getIntelNumaTopo).Return(mockIntelDomain, nil).Build()
+			mockey.Mock(getNumaTopo).Return(mockIntelDomain, nil).Build()
 			mockey.Mock(GetCPUPackageID).Return(0, nil).Build()
 			mockey.Mock(GetCPUOnlineStatus).To(func(cpuID int64) (bool, error) {
 				if cpuID == 1 {
@@ -154,14 +184,14 @@ func Test_GetCPUInfoWithTopo(t *testing.T) {
 			So(err.Error(), ShouldEqual, fmt.Sprintf("offline cpu %d exists in /sys/devices/system/node/nodeX/cpu_list", 1))
 		})
 
-		mockey.PatchConvey("Scenario 6: Failed to obtain CPU Package ID", func() {
+		mockey.PatchConvey("Scenario 7: Failed to obtain CPU Package ID", func() {
 			mockey.MockValue(&cpuid.CPU.VendorID).To(cpuid.Intel)
 			mockNode0 := &mockDirEntry{entryName: "node0", isDir: true}
 			mockey.Mock(os.ReadDir).Return([]fs.DirEntry{mockNode0}, nil).Build()
 			mockIntelDomain := &LLCDomain{
 				PhyCores: []PhyCore{{CPUs: []int64{0}}},
 			}
-			mockey.Mock(getIntelNumaTopo).Return(mockIntelDomain, nil).Build()
+			mockey.Mock(getNumaTopo).Return(mockIntelDomain, nil).Build()
 
 			expectedErr := errors.New("failed to read package id")
 			mockey.Mock(GetCPUPackageID).Return(-1, expectedErr).Build()
@@ -318,7 +348,18 @@ func TestGetNumaPackageID(t *testing.T) {
 			So(id, ShouldEqual, 1)
 		})
 
-		mockey.PatchConvey("Scenario 4: cpulist is not empty, and the package id is failed", func() {
+		mockey.PatchConvey("Scenario 4: unknown package id is normalized to socket 0", func() {
+			mockey.Mock(os.Stat).Return(nil, nil).Build()
+			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{4}, nil).Build()
+			mockey.Mock(GetCPUPackageID).Return(-1, nil).Build()
+
+			id, err := GetNumaPackageID(0)
+
+			So(err, ShouldBeNil)
+			So(id, ShouldEqual, 0)
+		})
+
+		mockey.PatchConvey("Scenario 5: cpulist is not empty, and the package id is failed", func() {
 			// Arrange: Simulate parsing the CPU list, but fails to get the package id
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{4}, nil).Build()
@@ -334,7 +375,7 @@ func TestGetNumaPackageID(t *testing.T) {
 			So(err.Error(), ShouldContainSubstring, "failed to GetCPUPackageID")
 		})
 
-		mockey.PatchConvey("Scenario 5: cpulist is empty, failed to get the socket number", func() {
+		mockey.PatchConvey("Scenario 6: cpulist is empty, failed to get the socket number", func() {
 			// Arrange: Simulate parsing an empty CPU list and failing to get the number of sockets
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{}, nil).Build()
@@ -350,7 +391,7 @@ func TestGetNumaPackageID(t *testing.T) {
 			So(err.Error(), ShouldContainSubstring, "failed to GetSocketCount")
 		})
 
-		mockey.PatchConvey("Scenario 6: cpulist is empty, socket number is 0", func() {
+		mockey.PatchConvey("Scenario 7: cpulist is empty, socket number is 0", func() {
 			// Arrange: Simulate to parse empty CPU list, and the number of sockets is 0
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{}, nil).Build()
@@ -365,7 +406,7 @@ func TestGetNumaPackageID(t *testing.T) {
 			So(err.Error(), ShouldEqual, "socket count is 0")
 		})
 
-		mockey.PatchConvey("Scene 7: cpulist is empty, socket number is 1", func() {
+		mockey.PatchConvey("Scenario 8: cpulist is empty, socket number is 1", func() {
 			// Arrange: Simulate to parse empty CPU list, and the number of sockets is 1
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{}, nil).Build()
@@ -379,7 +420,7 @@ func TestGetNumaPackageID(t *testing.T) {
 			So(id, ShouldEqual, 0)
 		})
 
-		mockey.PatchConvey("Scenario 8: cpulist is empty, the number of sockets is greater than 1, and the number of nodes is failed", func() {
+		mockey.PatchConvey("Scenario 9: cpulist is empty, the number of sockets is greater than 1, and the number of nodes is failed", func() {
 			// Arrange: Simulate parsing an empty CPU list, the number of sockets is greater than 1, but the number of nodes is failed
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{}, nil).Build()
@@ -396,7 +437,7 @@ func TestGetNumaPackageID(t *testing.T) {
 			So(err.Error(), ShouldContainSubstring, "failed to GetNodeCount")
 		})
 
-		mockey.PatchConvey("Scenario 9: cpulist is empty, the number of sockets is greater than 1, the package id is successfully calculated", func() {
+		mockey.PatchConvey("Scenario 10: cpulist is empty, the number of sockets is greater than 1, the package id is successfully calculated", func() {
 			// Arrange: Simulate and parse the empty CPU list, the number of sockets is greater than 1, and the calculation is successful
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return([]int64{}, nil).Build()
@@ -881,9 +922,9 @@ func Test_GetSocketCount(t *testing.T) {
 	})
 }
 
-func Test_getIntelNumaTopo(t *testing.T) {
+func Test_getNumaTopo(t *testing.T) {
 	const fakeNodeCPUListFile = "/tmp/node0_cpulist"
-	mockey.PatchConvey("Test getIntelNumaTopo", t, func() {
+	mockey.PatchConvey("Test getNumaTopo", t, func() {
 		mockey.PatchConvey("Scene 1: Get the LLC Domain normally", func() {
 			// Mock general.ParseLinuxListFormatFromFile
 			mockey.Mock(general.ParseLinuxListFormatFromFile).To(func(file string) ([]int64, error) {
@@ -902,7 +943,7 @@ func Test_getIntelNumaTopo(t *testing.T) {
 			mockey.Mock(os.Stat).Return(nil, nil).Build()
 
 			// Act: call the function to be tested
-			llcDomain, err := getIntelNumaTopo(fakeNodeCPUListFile)
+			llcDomain, err := getNumaTopo(fakeNodeCPUListFile)
 
 			// Assert: assertion results
 			So(err, ShouldBeNil)
@@ -921,14 +962,14 @@ func Test_getIntelNumaTopo(t *testing.T) {
 			mockey.Mock(general.ParseLinuxListFormatFromFile).Return(nil, expectedErr).Build()
 
 			// Act: call the function to be tested
-			llcDomain, err := getIntelNumaTopo(fakeNodeCPUListFile)
+			llcDomain, err := getNumaTopo(fakeNodeCPUListFile)
 
 			So(llcDomain, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, expectedErr.Error())
 		})
 
-		mockey.PatchConvey("Scenario 3: The CPU topology file of the physical core does not exist", func() {
+		mockey.PatchConvey("Scenario 3: Missing physical core topology is skipped", func() {
 			mockey.Mock(os.Stat).To(func(name string) (os.FileInfo, error) {
 				if name == filepath.Join(cpuSysDir, "cpu4/topology/thread_siblings_list") {
 					return nil, os.ErrNotExist
@@ -949,7 +990,7 @@ func Test_getIntelNumaTopo(t *testing.T) {
 			}).Build()
 
 			// Act: call the function to be tested
-			llcDomain, err := getIntelNumaTopo(fakeNodeCPUListFile)
+			llcDomain, err := getNumaTopo(fakeNodeCPUListFile)
 
 			So(err, ShouldBeNil)
 			So(llcDomain, ShouldNotBeNil)
@@ -973,7 +1014,7 @@ func Test_getIntelNumaTopo(t *testing.T) {
 			}).Build()
 
 			// Act: call the function to be tested
-			llcDomain, err := getIntelNumaTopo(fakeNodeCPUListFile)
+			llcDomain, err := getNumaTopo(fakeNodeCPUListFile)
 
 			So(llcDomain, ShouldBeNil)
 			So(err, ShouldNotBeNil)
@@ -991,7 +1032,7 @@ func Test_getIntelNumaTopo(t *testing.T) {
 			}).Build()
 
 			// Act: call the function to be tested
-			llcDomain, err := getIntelNumaTopo(fakeNodeCPUListFile)
+			llcDomain, err := getNumaTopo(fakeNodeCPUListFile)
 
 			So(llcDomain, ShouldBeNil)
 			So(err, ShouldNotBeNil)

--- a/pkg/util/machine/cpu_test.go
+++ b/pkg/util/machine/cpu_test.go
@@ -31,6 +31,51 @@ import (
 	"github.com/kubewharf/katalyst-core/pkg/util/general"
 )
 
+func TestGetNUMANodeCPUListFiles(t *testing.T) {
+	mockey.PatchConvey("missing node sysfs returns an error", t, func() {
+		mockey.Mock(os.ReadDir).Return(nil, os.ErrNotExist).Build()
+
+		files, err := getNUMANodeCPUListFiles()
+
+		So(files, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "failed to ReadDir")
+	})
+
+	mockey.PatchConvey("zero NUMA nodes returns an error", t, func() {
+		mockey.Mock(os.ReadDir).Return([]os.DirEntry{}, nil).Build()
+
+		files, err := getNUMANodeCPUListFiles()
+
+		So(files, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "no NUMA nodes found")
+	})
+}
+
+func TestNormalizePackageID(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, normalizePackageID(-1))
+	assert.Equal(t, 2, normalizePackageID(2))
+}
+
+func TestNormalizeMachineArchitecture(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"x86_64":  "amd64",
+		"aarch64": "arm64",
+		"armv7l":  "arm",
+		"i686":    "386",
+		"riscv64": "riscv64",
+	}
+
+	for machine, expected := range tests {
+		assert.Equal(t, expected, normalizeMachineArchitecture(machine))
+	}
+}
+
 func TestGetCoreNumReservedForReclaim(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -164,10 +209,10 @@ func Test_getSocketCPUList(t *testing.T) {
 			})
 		}).Build()
 
-		mockey.PatchConvey("Scenario 1: When the CPU manufacturer is Intel", func() {
+		mockey.PatchConvey("Scenario 1: Flat NUMA topology", func() {
 			socket := &CPUSocket{
 				NumaIDs: []int{0, 1},
-				IntelNumas: map[int]*LLCDomain{
+				Numas: map[int]*LLCDomain{
 					0: {
 						PhyCores: []PhyCore{
 							{CPUs: []int64{3, 1}}, // intentionally use out of order data
@@ -186,7 +231,7 @@ func Test_getSocketCPUList(t *testing.T) {
 			expectedCPUList := []int64{0, 1, 2, 3, 8, 9, 10, 11}
 
 			// Act: call the function to be tested
-			cpuList := getSocketCPUList(socket, cpuid.Intel)
+			cpuList := getSocketCPUList(socket)
 
 			So(cpuList, ShouldResemble, expectedCPUList)
 		})
@@ -194,8 +239,8 @@ func Test_getSocketCPUList(t *testing.T) {
 		mockey.PatchConvey("Scenario 2: When the CPU manufacturer is AMD", func() {
 			// Arrange: Construct the topology of an AMD CPU
 			socket := &CPUSocket{
-				NumaIDs:    []int{0},
-				IntelNumas: nil,
+				NumaIDs: []int{0},
+				Numas:   nil,
 				AMDNumas: map[int]*AMDNuma{
 					0: {
 						CCDs: []*LLCDomain{
@@ -218,14 +263,14 @@ func Test_getSocketCPUList(t *testing.T) {
 			expectedCPUList := []int64{4, 5, 6, 7, 12, 13, 14, 15}
 
 			// Act: call the function to be tested
-			cpuList := getSocketCPUList(socket, cpuid.AMD)
+			cpuList := getSocketCPUList(socket)
 			So(cpuList, ShouldResemble, expectedCPUList)
 		})
 
-		mockey.PatchConvey("Scenario 3: When the CPU manufacturer is unknown", func() {
+		mockey.PatchConvey("Scenario 3: Flat NUMA topology does not depend on CPU vendor", func() {
 			socket := &CPUSocket{
 				NumaIDs: []int{0},
-				IntelNumas: map[int]*LLCDomain{
+				Numas: map[int]*LLCDomain{
 					0: {
 						PhyCores: []PhyCore{
 							{CPUs: []int64{0, 1}},
@@ -234,19 +279,36 @@ func Test_getSocketCPUList(t *testing.T) {
 				},
 			}
 
-			cpuList := getSocketCPUList(socket, cpuid.VendorUnknown)
-			So(cpuList, ShouldBeEmpty)
+			cpuList := getSocketCPUList(socket)
+			So(cpuList, ShouldResemble, []int64{0, 1})
 		})
 
 		mockey.PatchConvey("Scenario 4: When there is no NUMA node in the Socket", func() {
 			socket := &CPUSocket{
-				NumaIDs:    []int{},
-				IntelNumas: map[int]*LLCDomain{},
-				AMDNumas:   map[int]*AMDNuma{},
+				NumaIDs:  []int{},
+				Numas:    map[int]*LLCDomain{},
+				AMDNumas: map[int]*AMDNuma{},
 			}
 
-			cpuList := getSocketCPUList(socket, cpuid.Intel)
+			cpuList := getSocketCPUList(socket)
 			So(cpuList, ShouldBeEmpty)
+		})
+
+		mockey.PatchConvey("Scenario 5: NUMA topology is independent of vendor", func() {
+			socket := &CPUSocket{
+				NumaIDs: []int{0},
+				Numas: map[int]*LLCDomain{
+					0: {
+						PhyCores: []PhyCore{
+							{CPUs: []int64{1}},
+							{CPUs: []int64{0}},
+						},
+					},
+				},
+			}
+
+			cpuList := getSocketCPUList(socket)
+			So(cpuList, ShouldResemble, []int64{0, 1})
 		})
 	})
 }
@@ -351,12 +413,12 @@ func Test_getAMDSocketPhysicalCores(t *testing.T) {
 	})
 }
 
-func Test_getIntelSocketPhysicalCores(t *testing.T) {
-	mockey.PatchConvey("Test_getIntelSocketPhysicalCores", t, func() {
+func Test_getNumaSocketPhysicalCores(t *testing.T) {
+	mockey.PatchConvey("Test_getNumaSocketPhysicalCores", t, func() {
 		mockey.PatchConvey("Normal scenario: When the socket contains multiple valid NUMA nodes", func() {
 			socket := &CPUSocket{
 				NumaIDs: []int{0, 1},
-				IntelNumas: map[int]*LLCDomain{
+				Numas: map[int]*LLCDomain{
 					0: {
 						PhyCores: []PhyCore{
 							{CPUs: []int64{0, 1}},
@@ -377,7 +439,7 @@ func Test_getIntelSocketPhysicalCores(t *testing.T) {
 			}
 
 			// Act: call the function to be tested
-			result := getIntelSocketPhysicalCores(socket)
+			result := getNumaSocketPhysicalCores(socket)
 
 			So(result, ShouldNotBeNil)
 			So(result, ShouldResemble, expectedCores)
@@ -386,7 +448,7 @@ func Test_getIntelSocketPhysicalCores(t *testing.T) {
 		mockey.PatchConvey("Boundary Scenario: When NumaIDs are empty", func() {
 			socket := &CPUSocket{
 				NumaIDs: []int{},
-				IntelNumas: map[int]*LLCDomain{
+				Numas: map[int]*LLCDomain{
 					0: {
 						PhyCores: []PhyCore{{CPUs: []int64{0, 1}}},
 					},
@@ -394,7 +456,7 @@ func Test_getIntelSocketPhysicalCores(t *testing.T) {
 			}
 
 			// Act: call the function to be tested
-			result := getIntelSocketPhysicalCores(socket)
+			result := getNumaSocketPhysicalCores(socket)
 
 			So(result, ShouldBeEmpty)
 		})
@@ -402,7 +464,7 @@ func Test_getIntelSocketPhysicalCores(t *testing.T) {
 		mockey.PatchConvey("Boundary scenario: When the PhyCores of a NUMA node is empty", func() {
 			socket := &CPUSocket{
 				NumaIDs: []int{0, 1},
-				IntelNumas: map[int]*LLCDomain{
+				Numas: map[int]*LLCDomain{
 					0: {
 						PhyCores: []PhyCore{
 							{CPUs: []int64{0, 1}},
@@ -418,35 +480,33 @@ func Test_getIntelSocketPhysicalCores(t *testing.T) {
 			}
 
 			// Act: call the function to be tested
-			result := getIntelSocketPhysicalCores(socket)
+			result := getNumaSocketPhysicalCores(socket)
 
 			So(result, ShouldResemble, expectedCores)
 		})
 
-		mockey.PatchConvey("Exception scenario: panic should occur when IntelNumas maps to nil", func() {
+		mockey.PatchConvey("Boundary scenario: nil Numas returns an empty result", func() {
 			socket := &CPUSocket{
-				NumaIDs:    []int{0},
-				IntelNumas: nil, // IntelNumas map为nil
+				NumaIDs: []int{0},
+				Numas:   nil,
 			}
 
-			So(func() {
-				getIntelSocketPhysicalCores(socket)
-			}, ShouldPanic)
+			result := getNumaSocketPhysicalCores(socket)
+			So(result, ShouldBeEmpty)
 		})
 
-		mockey.PatchConvey("Exception scenario: panic should occur when NumaID does not exist in IntelNumas", func() {
+		mockey.PatchConvey("Boundary scenario: missing NumaID is skipped", func() {
 			socket := &CPUSocket{
 				NumaIDs: []int{0, 1},
-				IntelNumas: map[int]*LLCDomain{
+				Numas: map[int]*LLCDomain{
 					0: {
 						PhyCores: []PhyCore{{CPUs: []int64{0, 1}}},
 					},
 				},
 			}
 
-			So(func() {
-				getIntelSocketPhysicalCores(socket)
-			}, ShouldPanic)
+			result := getNumaSocketPhysicalCores(socket)
+			So(result, ShouldResemble, []PhyCore{{CPUs: []int64{0, 1}}})
 		})
 	})
 }
@@ -548,14 +608,14 @@ func Test_CPUInfo_GetSocketPhysicalCores(t *testing.T) {
 			So(cores, ShouldResemble, expectedCores)
 		})
 
-		mockey.PatchConvey("Scenario 4: When the CPU is Intel, getIntelSocketPhysicalCores should be called and its result should be returned.", func() {
+		mockey.PatchConvey("Scenario 4: NUMA physical cores are returned for Intel", func() {
 			// Arrange: prepare test data and mock
 			intelCPUInfo := &CPUInfo{
 				CPUVendor: cpuid.Intel,
 				Sockets: map[int]*CPUSocket{
 					0: {
 						NumaIDs: []int{0},
-						IntelNumas: map[int]*LLCDomain{
+						Numas: map[int]*LLCDomain{
 							0: {
 								PhyCores: []PhyCore{
 									{CPUs: []int64{0, 1}}, // Physical core 0, including logical core 0 and 1
@@ -566,13 +626,39 @@ func Test_CPUInfo_GetSocketPhysicalCores(t *testing.T) {
 				},
 			}
 			expectedCores := []PhyCore{{CPUs: []int64{0, 1}}}
-			mockey.Mock(getIntelSocketPhysicalCores).Return(expectedCores).Build()
+			mockey.Mock(getNumaSocketPhysicalCores).Return(expectedCores).Build()
 
 			cores := intelCPUInfo.GetSocketPhysicalCores(0)
 			So(cores, ShouldResemble, expectedCores)
 		})
 
-		mockey.PatchConvey("Scenario 5: When the CPU is another manufacturer, nil should be returned", func() {
+		mockey.PatchConvey("Scenario 5: NUMA topology does not depend on CPU vendor", func() {
+			numaCPUInfo := &CPUInfo{
+				CPUVendor: cpuid.Intel,
+				Sockets: map[int]*CPUSocket{
+					0: {
+						NumaIDs: []int{0},
+						Numas: map[int]*LLCDomain{
+							0: {
+								PhyCores: []PhyCore{
+									{CPUs: []int64{0}},
+									{CPUs: []int64{1}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			cores := numaCPUInfo.GetSocketPhysicalCores(0)
+
+			So(cores, ShouldResemble, []PhyCore{
+				{CPUs: []int64{0}},
+				{CPUs: []int64{1}},
+			})
+		})
+
+		mockey.PatchConvey("Scenario 6: When the CPU is another manufacturer without generic topology, nil should be returned", func() {
 			otherCPUInfo := &CPUInfo{
 				CPUVendor: cpuid.VendorUnknown,
 				Sockets: map[int]*CPUSocket{
@@ -600,7 +686,7 @@ func Test_CPUInfo_GetNodeCPUList(t *testing.T) {
 				Sockets: map[int]*CPUSocket{
 					0: {
 						NumaIDs: []int{0},
-						IntelNumas: map[int]*LLCDomain{
+						Numas: map[int]*LLCDomain{
 							0: {
 								PhyCores: []PhyCore{
 									{CPUs: []int64{1, 5}}, // CPU core1
@@ -611,7 +697,7 @@ func Test_CPUInfo_GetNodeCPUList(t *testing.T) {
 					},
 					1: {
 						NumaIDs: []int{1},
-						IntelNumas: map[int]*LLCDomain{
+						Numas: map[int]*LLCDomain{
 							1: {
 								PhyCores: []PhyCore{
 									{CPUs: []int64{2, 6}},
@@ -677,7 +763,7 @@ func Test_CPUInfo_GetNodeCPUList(t *testing.T) {
 				Sockets: map[int]*CPUSocket{
 					0: {
 						NumaIDs: []int{0},
-						IntelNumas: map[int]*LLCDomain{
+						Numas: map[int]*LLCDomain{
 							0: {
 								PhyCores: []PhyCore{
 									{CPUs: []int64{0, 4}},
@@ -712,13 +798,36 @@ func Test_CPUInfo_GetNodeCPUList(t *testing.T) {
 			So(cpuList, ShouldBeEmpty)
 		})
 
-		mockey.PatchConvey("Scenario 5: The node exists but does not have a CPU core", func() {
+		mockey.PatchConvey("Scenario 5: NUMA CPU list does not depend on CPU vendor", func() {
 			c := &CPUInfo{
 				CPUVendor: cpuid.Intel,
 				Sockets: map[int]*CPUSocket{
 					0: {
 						NumaIDs: []int{0},
-						IntelNumas: map[int]*LLCDomain{
+						Numas: map[int]*LLCDomain{
+							0: {
+								PhyCores: []PhyCore{
+									{CPUs: []int64{1}},
+									{CPUs: []int64{0}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			cpuList := c.GetNodeCPUList(0)
+
+			So(cpuList, ShouldResemble, []int64{0, 1})
+		})
+
+		mockey.PatchConvey("Scenario 6: The node exists but does not have a CPU core", func() {
+			c := &CPUInfo{
+				CPUVendor: cpuid.Intel,
+				Sockets: map[int]*CPUSocket{
+					0: {
+						NumaIDs: []int{0},
+						Numas: map[int]*LLCDomain{
 							0: {
 								PhyCores: []PhyCore{},
 							},


### PR DESCRIPTION
#### What type of PR is this?
<!--
Enhancement
-->

#### What this PR does / why we need it:
irq-tuning support ARM ach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## English

- Adds ARM64 support for `irqtuner` balance-fair tuning.
- Generalizes CPU topology handling to vendor-independent NUMA data.
- Adds Linux architecture detection and a non-Linux `runtime.GOARCH` fallback.
- Falls back unsupported IRQ tuning policies to `IrqTuningBalanceFair` and reports `UnsupportedIrqTuningPolicyFallback`.
- Updates agent controller balancing for AMD CCD and generic NUMA layouts.
- Runs topology discovery only on Linux.
- Adds tests for policy fallback, architecture handling, NUMA topology, and controller output.
- No dependency, scheduler, configuration, or release wiring changes are included.
- Rollout risk includes incorrect topology detection or policy fallback on unsupported hardware.

## 简体中文

- 为 `irqtuner` balance-fair tuning 增加 ARM64 支持。
- 将 CPU topology handling 扩展为 vendor-independent NUMA data。
- 增加 Linux architecture detection，并在非 Linux 平台使用 `runtime.GOARCH` fallback。
- 将不支持的 IRQ tuning policy 回退到 `IrqTuningBalanceFair`，并上报 `UnsupportedIrqTuningPolicyFallback`。
- 更新 agent controller balancing，以支持 AMD CCD 和 generic NUMA layouts。
- 仅在 Linux 平台执行 topology discovery。
- 增加 policy fallback、architecture handling、NUMA topology 和 controller output 的测试覆盖。
- 未包含 dependency、scheduler、configuration 或 release wiring changes。
- rollout risk 包括不支持硬件上的 topology detection 或 policy fallback 不正确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->